### PR TITLE
Auto-deploy to Spaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 - **API compatible** with `wandb.init`, `wandb.log`, and `wandb.finish` (drop-in replacement: just use `trackio` instead of `wandb`)
 - Store logs in a Hugging Face Datasets-compatible format (Parquet)
 - Visualize experiments with a Gradio dashboard
-- *Local-first* design: dashboard runs locally by default. You can also host it on Spaces by changing a single parameter.
+- *Local-first* design: dashboard runs locally by default. You can also host it on Spaces by specifying a `space_id` parameter in `init`.
 - Everything here, including hosting on Spaces, is **free**!
 
 Trackio is designed to be lightweight (<500 lines of code total), not fully-featured. It is designed in a modular way so that developers can easily fork the repository and add functionality that they care about.
@@ -99,6 +99,9 @@ trackio.show(project="my project")
 
 ![Screen Recording 2025-05-12 at 2 43 38 PM](https://github.com/user-attachments/assets/d627c9c3-7365-4250-839c-db67dde34a02)
 
+## Running in a Space
+
+When calling `trackio.init`, by default the service will run locally and collect data on the local machine. If instead you pass a `space_id` to `init`, like `org_name/space_name` or `user_name/space_name`, it will use an existing or automatically deploy a new Hugging Face Space as needed. The current version of trackio is deployed to the specified space if it does not yet exist.
 
 ## License
 

--- a/trackio/README.md
+++ b/trackio/README.md
@@ -1,0 +1,5 @@
+---
+sdk: gradio
+sdk_version: 5.30.0
+app_file: ui.py
+---

--- a/trackio/README.md
+++ b/trackio/README.md
@@ -1,5 +1,5 @@
 ---
 sdk: gradio
-sdk_version: GRADIO_VERSION
+sdk_version: {GRADIO_VERSION}
 app_file: ui.py
 ---

--- a/trackio/README.md
+++ b/trackio/README.md
@@ -1,5 +1,5 @@
 ---
 sdk: gradio
-sdk_version: 5.30.0
+sdk_version: GRADIO_VERSION
 app_file: ui.py
 ---

--- a/trackio/__init__.py
+++ b/trackio/__init__.py
@@ -3,9 +3,9 @@ import time
 import webbrowser
 from pathlib import Path
 
+import huggingface_hub
 from gradio_client import Client
 from httpx import ReadTimeout
-import huggingface_hub
 from huggingface_hub.errors import RepositoryNotFoundError
 
 from trackio.deploy import deploy_as_space

--- a/trackio/__init__.py
+++ b/trackio/__init__.py
@@ -29,6 +29,7 @@ current_server: contextvars.ContextVar[str | None] = contextvars.ContextVar(
 config = {}
 SPACE_URL = "https://huggingface.co/spaces/{space_id}"
 
+
 def init(
     project: str,
     name: str | None = None,
@@ -54,7 +55,7 @@ def init(
 
     if current_project.get() is None or current_project.get() != project:
         print(f"* Trackio project initialized: {project}")
-        
+
         if space_id is None:
             print(f"* Trackio metrics logged to: {TRACKIO_DIR}")
             print(
@@ -84,7 +85,9 @@ def create_space_if_not_exists(space_id: str) -> None:
         space_id: The ID of the Space to create.
     """
     if "/" not in space_id:
-        raise ValueError(f"Invalid space ID: {space_id}. Must be in the format: username/reponame.")
+        raise ValueError(
+            f"Invalid space ID: {space_id}. Must be in the format: username/reponame."
+        )
     try:
         huggingface_hub.repo_info(space_id, repo_type="space")
         print(f"* Found existing space: {SPACE_URL.format(space_id=space_id)}")
@@ -107,6 +110,7 @@ def create_space_if_not_exists(space_id: str) -> None:
         except ValueError as e:
             print(f"* Space gave error {e}. Trying again in 5 seconds...")
             time.sleep(5)
+
 
 def log(metrics: dict) -> None:
     """

--- a/trackio/__init__.py
+++ b/trackio/__init__.py
@@ -1,11 +1,11 @@
 import contextvars
+import time
 import webbrowser
 from pathlib import Path
-import time
 
 from gradio_client import Client
-from huggingface_hub.errors import RepositoryNotFoundError
 from httpx import ReadTimeout
+from huggingface_hub.errors import RepositoryNotFoundError
 
 from trackio.deploy import deploy_as_space
 from trackio.run import Run

--- a/trackio/__init__.py
+++ b/trackio/__init__.py
@@ -39,15 +39,7 @@ def init(project: str, name: str | None = None, space_id=None, config: dict | No
         current_server.set(url)
     else:
         url = current_server.get()
-    if current_project.get() is None or current_project.get() != project:
-        print(f"* Trackio project initialized: {project}")
-        print(f"* Trackio metrics logged to: {TRACKIO_DIR}")
-        print(
-            f'\n* View dashboard by running in your terminal: trackio show --project "{project}"'
-        )
-        print(f'* or by running in Python: trackio.show(project="{project}")')
 
-    current_project.set(project)
     client = None
     try:
         client = Client(url, verbose=False)
@@ -73,6 +65,19 @@ def init(project: str, name: str | None = None, space_id=None, config: dict | No
             attempts += 1
             if attempts >= max_attempts:
                 break
+
+    if current_project.get() is None or current_project.get() != project:
+        print(f"* Trackio project initialized: {project}")
+        if space_id is None:
+            print(f"* Trackio metrics logged to: {TRACKIO_DIR}")
+            print(
+                f'\n* View dashboard by running in your terminal: trackio show --project "{project}"'
+            )
+            print(f'* or by running in Python: trackio.show(project="{project}")')
+        else:
+            print(f"* Trackio metrics logged to: https://huggingface.co/spaces/{space_id}")
+    current_project.set(project)
+
     run = Run(project=project, client=client, name=name, config=config)
     current_run.set(run)
     globals()["config"] = run.config

--- a/trackio/__init__.py
+++ b/trackio/__init__.py
@@ -28,7 +28,9 @@ current_server: contextvars.ContextVar[str | None] = contextvars.ContextVar(
 config = {}
 
 
-def init(project: str, name: str | None = None, space_id=None, config: dict | None = None) -> Run:
+def init(
+    project: str, name: str | None = None, space_id=None, config: dict | None = None
+) -> Run:
     if not current_server.get():
         if space_id is None:
             _, url, _ = demo.launch(
@@ -75,7 +77,9 @@ def init(project: str, name: str | None = None, space_id=None, config: dict | No
             )
             print(f'* or by running in Python: trackio.show(project="{project}")')
         else:
-            print(f"* Trackio metrics logged to: https://huggingface.co/spaces/{space_id}")
+            print(
+                f"* Trackio metrics logged to: https://huggingface.co/spaces/{space_id}"
+            )
     current_project.set(project)
 
     run = Run(project=project, client=client, name=name, config=config)

--- a/trackio/__init__.py
+++ b/trackio/__init__.py
@@ -29,8 +29,20 @@ config = {}
 
 
 def init(
-    project: str, name: str | None = None, space_id=None, config: dict | None = None
+    project: str,
+    name: str | None = None,
+    space_id: str | None = None,
+    config: dict | None = None,
 ) -> Run:
+    """
+    Creates a new Trackio project and returns a Run object.
+
+    Args:
+        project: The name of the project (can be an existing project to continue tracking or a new project to start tracking from scratch).
+        name: The name of the run (if not provided, a default name will be generated).
+        space_id: If provided, the project will be logged to a Hugging Face Space instead of a local directory. Should be a complete Space name like "username/reponame". If the Space does not exist, it will be created. If the Space already exists, the project will be logged to it.
+        config: A dictionary of configuration options. Provided for compatibility with wandb.init()
+    """
     if not current_server.get():
         if space_id is None:
             _, url, _ = demo.launch(
@@ -89,18 +101,33 @@ def init(
 
 
 def log(metrics: dict) -> None:
+    """
+    Logs metrics to the current run.
+
+    Args:
+        metrics: A dictionary of metrics to log.
+    """
     if current_run.get() is None:
         raise RuntimeError("Call trackio.init() before log().")
     current_run.get().log(metrics)
 
 
 def finish():
+    """
+    Finishes the current run.
+    """
     if current_run.get() is None:
         raise RuntimeError("Call trackio.init() before finish().")
     current_run.get().finish()
 
 
 def show(project: str | None = None):
+    """
+    Launches the Trackio dashboard.
+
+    Args:
+        project: The name of the project whose runs to show. If not provided, all projects will be shown and the user can select one.
+    """
     _, url, share_url = demo.launch(
         show_api=False,
         quiet=True,

--- a/trackio/deploy.py
+++ b/trackio/deploy.py
@@ -1,5 +1,7 @@
 import os
 from importlib.resources import files
+import io
+import gradio
 
 import huggingface_hub
 
@@ -39,3 +41,14 @@ def deploy_as_space(title: str):
         repo_type="space",
         folder_path=trackio_path,
     )
+    
+    with open("README.md", "r") as f:
+        readme_content = f.read()
+        readme_content = readme_content.replace("{GRADIO_VERSION}", gradio.__version__)
+        readme_buffer = io.BytesIO(readme_content.encode("utf-8"))    
+        hf_api.upload_file(
+            path_or_fileobj=readme_buffer,
+            path_in_repo="README.md",
+            repo_id=space_id,
+            repo_type="space",
+        )

--- a/trackio/deploy.py
+++ b/trackio/deploy.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 from importlib.resources import files
 import io
 import gradio
@@ -36,13 +37,7 @@ def deploy_as_space(title: str):
     ).repo_id
     assert space_id == title  # not sure why these would differ
 
-    hf_api.upload_folder(
-        repo_id=space_id,
-        repo_type="space",
-        folder_path=trackio_path,
-    )
-    
-    with open("README.md", "r") as f:
+    with open(Path(trackio_path, "README.md"), "r") as f:
         readme_content = f.read()
         readme_content = readme_content.replace("{GRADIO_VERSION}", gradio.__version__)
         readme_buffer = io.BytesIO(readme_content.encode("utf-8"))    
@@ -52,3 +47,11 @@ def deploy_as_space(title: str):
             repo_id=space_id,
             repo_type="space",
         )
+
+    huggingface_hub.disable_progress_bars()
+    hf_api.upload_folder(
+        repo_id=space_id,
+        repo_type="space",
+        folder_path=trackio_path,
+        ignore_patterns=["README.md"],
+    )

--- a/trackio/deploy.py
+++ b/trackio/deploy.py
@@ -1,5 +1,5 @@
-from importlib.resources import files
 import os
+from importlib.resources import files
 
 import huggingface_hub
 

--- a/trackio/deploy.py
+++ b/trackio/deploy.py
@@ -1,9 +1,9 @@
-import os
-from pathlib import Path
-from importlib.resources import files
 import io
-import gradio
+import os
+from importlib.resources import files
+from pathlib import Path
 
+import gradio
 import huggingface_hub
 
 
@@ -40,7 +40,7 @@ def deploy_as_space(title: str):
     with open(Path(trackio_path, "README.md"), "r") as f:
         readme_content = f.read()
         readme_content = readme_content.replace("{GRADIO_VERSION}", gradio.__version__)
-        readme_buffer = io.BytesIO(readme_content.encode("utf-8"))    
+        readme_buffer = io.BytesIO(readme_content.encode("utf-8"))
         hf_api.upload_file(
             path_or_fileobj=readme_buffer,
             path_in_repo="README.md",
@@ -48,7 +48,7 @@ def deploy_as_space(title: str):
             repo_type="space",
         )
 
-    huggingface_hub.disable_progress_bars()
+    huggingface_hub.utils.disable_progress_bars()
     hf_api.upload_folder(
         repo_id=space_id,
         repo_type="space",

--- a/trackio/deploy.py
+++ b/trackio/deploy.py
@@ -32,7 +32,7 @@ def deploy_as_space(title: str):
         repo_type="space",
         exist_ok=True,
     ).repo_id
-    assert(space_id == title) # not sure why these would differ
+    assert space_id == title  # not sure why these would differ
 
     hf_api.upload_folder(
         repo_id=space_id,

--- a/trackio/deploy.py
+++ b/trackio/deploy.py
@@ -1,0 +1,41 @@
+from importlib.resources import files
+import os
+
+import huggingface_hub
+
+
+def deploy_as_space(title: str):
+    if (
+        os.getenv("SYSTEM") == "spaces"
+    ):  # in case a repo with this function is uploaded to spaces
+        return
+
+    trackio_path = files("trackio")
+
+    hf_api = huggingface_hub.HfApi()
+    whoami = None
+    login = False
+    try:
+        whoami = hf_api.whoami()
+        if whoami["auth"]["accessToken"]["role"] != "write":
+            login = True
+    except OSError:
+        login = True
+    if login:
+        print("Need 'write' access token to create a Spaces repo.")
+        huggingface_hub.login(add_to_git_credential=False)
+        whoami = hf_api.whoami()
+
+    space_id = huggingface_hub.create_repo(
+        title,
+        space_sdk="gradio",
+        repo_type="space",
+        exist_ok=True,
+    ).repo_id
+    assert(space_id == title) # not sure why these would differ
+
+    hf_api.upload_folder(
+        repo_id=space_id,
+        repo_type="space",
+        folder_path=trackio_path,
+    )

--- a/trackio/sqlite_storage.py
+++ b/trackio/sqlite_storage.py
@@ -4,7 +4,7 @@ import sqlite3
 
 try:
     from trackio.utils import RESERVED_KEYS, TRACKIO_DIR
-except:
+except:  # noqa: E722
     from utils import RESERVED_KEYS, TRACKIO_DIR
 
 

--- a/trackio/sqlite_storage.py
+++ b/trackio/sqlite_storage.py
@@ -2,8 +2,10 @@ import json
 import os
 import sqlite3
 
-from trackio.utils import RESERVED_KEYS, TRACKIO_DIR
-
+try:
+    from trackio.utils import RESERVED_KEYS, TRACKIO_DIR
+except:
+    from utils import RESERVED_KEYS, TRACKIO_DIR
 
 class SQLiteStorage:
     def __init__(self, project: str, name: str, config: dict):

--- a/trackio/sqlite_storage.py
+++ b/trackio/sqlite_storage.py
@@ -7,6 +7,7 @@ try:
 except:
     from utils import RESERVED_KEYS, TRACKIO_DIR
 
+
 class SQLiteStorage:
     def __init__(self, project: str, name: str, config: dict):
         self.project = project

--- a/trackio/ui.py
+++ b/trackio/ui.py
@@ -6,7 +6,7 @@ import pandas as pd
 try:
     from trackio.sqlite_storage import SQLiteStorage
     from trackio.utils import RESERVED_KEYS, TRACKIO_LOGO_PATH
-except:
+except:  # noqa: E722
     from sqlite_storage import SQLiteStorage
     from utils import RESERVED_KEYS, TRACKIO_LOGO_PATH
 

--- a/trackio/ui.py
+++ b/trackio/ui.py
@@ -179,5 +179,6 @@ with gr.Blocks(theme="citrus", title="Trackio Dashboard") as demo:
             plot.select(update_x_lim, outputs=x_lim)
             plot.double_click(lambda: None, outputs=x_lim)
 
+
 if __name__ == "__main__":
     demo.launch(allowed_paths=[TRACKIO_LOGO_PATH])

--- a/trackio/ui.py
+++ b/trackio/ui.py
@@ -3,8 +3,12 @@ from typing import Any
 import gradio as gr
 import pandas as pd
 
-from trackio.sqlite_storage import SQLiteStorage
-from trackio.utils import RESERVED_KEYS, TRACKIO_LOGO_PATH
+try:
+    from trackio.sqlite_storage import SQLiteStorage
+    from trackio.utils import RESERVED_KEYS, TRACKIO_LOGO_PATH
+except:
+    from sqlite_storage import SQLiteStorage
+    from utils import RESERVED_KEYS, TRACKIO_LOGO_PATH
 
 
 def get_projects(request: gr.Request):
@@ -174,7 +178,6 @@ with gr.Blocks(theme="citrus", title="Trackio Dashboard") as demo:
         for plot in plots:
             plot.select(update_x_lim, outputs=x_lim)
             plot.double_click(lambda: None, outputs=x_lim)
-
 
 if __name__ == "__main__":
     demo.launch(allowed_paths=[TRACKIO_LOGO_PATH])


### PR DESCRIPTION
* Add a space_id param to trackio.init, which will use an existing trackio space or deploy one on demand if it does not yet exist.
* Fix imports in ui.py and its relative dependencies to work both within and outside of a package/module. Gradio loads its app file outside of a module context.
* Add a README.md to trackio to default to the correct app file when uploading to a new Space.

TODO / not yet tested:

* Block metrics from non-authenticated clients (I think it is currently wide open and always deploys on a public space)
* Better UX for specifying HF_TOKEN when not specified