### PR TITLE
Check HF_TOKEN when logging

### DIFF
--- a/trackio/run.py
+++ b/trackio/run.py
@@ -1,3 +1,5 @@
+import os
+
 from gradio_client import Client
 
 from trackio.utils import generate_readable_name
@@ -25,6 +27,7 @@ class Run:
             run=self.name,
             metrics=metrics,
             dataset_id=self.dataset_id,
+            hf_token=os.getenv("HF_TOKEN", ""),
         )
 
     def finish(self):


### PR DESCRIPTION
To support the intended use case of a public Space that only the authorized users can write logs to (but anyone can view), pass in and check the ownership of the HF_TOKEN against the owner of the Space. Note: this only checks the ownership of the token against the ownership of the Space, and does not look at any specific permissions.