### PR TITLE
Bug fix: key param not recognized

### DIFF
--- a/trackio/ui.py
+++ b/trackio/ui.py
@@ -318,9 +318,7 @@ with gr.Blocks(theme="citrus", title="Trackio Dashboard", css=css) as demo:
                         min_width=400,
                     )
                 plot.select(update_x_lim, outputs=x_lim)
-                plot.double_click(
-                    lambda: None, outputs=x_lim
-                )
+                plot.double_click(lambda: None, outputs=x_lim)
 
 
 if __name__ == "__main__":

--- a/trackio/ui.py
+++ b/trackio/ui.py
@@ -317,9 +317,9 @@ with gr.Blocks(theme="citrus", title="Trackio Dashboard", css=css) as demo:
                         show_fullscreen_button=True,
                         min_width=400,
                     )
-                plot.select(update_x_lim, outputs=x_lim, key=f"select-{metric_idx}")
+                plot.select(update_x_lim, outputs=x_lim)
                 plot.double_click(
-                    lambda: None, outputs=x_lim, key=f"double-{metric_idx}"
+                    lambda: None, outputs=x_lim
                 )
 
 


### PR DESCRIPTION
The `select` call doesn't appear to take a `key` param and gives an error. This commit removes the param which appears to fix the error.