### PR TITLE
Queue up log items when Client is not ready

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 notebooks/
 trackio/__pycache__/
+tests/__pycache__/
 .trackio/
 trackio.db

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -10,7 +10,7 @@ class DummyClient:
 
 def test_run_log_calls_client():
     client = DummyClient()
-    run = Run(project="proj", client=client, name="run1")
+    run = Run(url="fake_url", project="proj", client=client, name="run1")
     metrics = {"x": 1}
     run.log(metrics)
     client.predict.assert_called_once_with(

--- a/trackio/__init__.py
+++ b/trackio/__init__.py
@@ -47,13 +47,15 @@ def init(
         dataset_id: If provided, a persistent Hugging Face Dataset will be created and the metrics will be synced to it every 5 minutes. Should be a complete Dataset name like "username/datasetname". If the Dataset does not exist, it will be created. If the Dataset already exists, the project will be appended to it.
         config: A dictionary of configuration options. Provided for compatibility with wandb.init()
     """
-    if not current_server.get() and space_id is None:
-        _, url, _ = demo.launch(
-            show_api=False, inline=False, quiet=True, prevent_thread_lock=True
-        )
+    url = current_server.get()
+    if url is None:
+        if space_id is None:
+            _, url, _ = demo.launch(
+                show_api=False, inline=False, quiet=True, prevent_thread_lock=True
+            )
+        else:
+            url = space_id
         current_server.set(url)
-    else:
-        url = current_server.get()
 
     if current_project.get() is None or current_project.get() != project:
         print(f"* Trackio project initialized: {project}")
@@ -71,9 +73,11 @@ def init(
             )
     current_project.set(project)
 
-    space_or_url = space_id if space_id else url
-    client = Client(space_or_url, verbose=False)
+    client = None
+    if not space_id:
+        client = Client(url, verbose=False)
     run = Run(
+        url=url,
         project=project, client=client, name=name, config=config, dataset_id=dataset_id
     )
     current_run.set(run)
@@ -109,19 +113,6 @@ def create_space_if_not_exists(
 
     print(f"* Creating new space: {SPACE_URL.format(space_id=space_id)}")
     deploy_as_space(space_id, dataset_id)
-
-    client = None
-    for _ in range(30):
-        try:
-            client = Client(space_id, verbose=False)
-            if client:
-                break
-        except ReadTimeout:
-            print("* Space is not yet ready. Waiting 5 seconds...")
-            time.sleep(5)
-        except ValueError as e:
-            print(f"* Space gave error {e}. Trying again in 5 seconds...")
-            time.sleep(5)
 
 
 def log(metrics: dict) -> None:

--- a/trackio/run.py
+++ b/trackio/run.py
@@ -1,3 +1,5 @@
+from collections import deque
+
 from gradio_client import Client
 
 from trackio.utils import generate_readable_name
@@ -6,26 +8,52 @@ from trackio.utils import generate_readable_name
 class Run:
     def __init__(
         self,
+        url: str,
         project: str,
         client: Client,
         name: str | None = None,
         config: dict | None = None,
         dataset_id: str | None = None,
     ):
+        self.url = url
         self.project = project
         self.client = client
         self.name = name or generate_readable_name()
         self.config = config or {}
         self.dataset_id = dataset_id
+        self.queued_logs = deque()
 
     def log(self, metrics: dict):
-        self.client.predict(
-            api_name="/log",
-            project=self.project,
-            run=self.name,
-            metrics=metrics,
-            dataset_id=self.dataset_id,
-        )
+        if self.client is None:
+            # lazily try to initialize the client
+            try:
+                self.client = Client(self.url, verbose=False)
+            except BaseException as e:
+                print(f"Unable to instantiate log client; error was {e}. Will queue log item and try again on next log() call.")
+        if self.client is None:
+            # client can still be None for a Space while the Space is still initializing.
+            # queue up log items for when the client is not None.
+            self.queued_logs.append(dict(
+                api_name="/log",
+                project=self.project,
+                run=self.name,
+                metrics=metrics,
+                dataset_id=self.dataset_id,
+            ))
+        else:
+            # flush the queued log items, if there are any
+            if len(self.queued_logs) > 0:
+                for queued_log in self.queued_logs:
+                    self.client.predict(**queued_log)
+                self.queued_logs.clear()
+            # write the current log item
+            self.client.predict(
+                api_name="/log",
+                project=self.project,
+                run=self.name,
+                metrics=metrics,
+                dataset_id=self.dataset_id,
+            )
 
     def finish(self):
         pass


### PR DESCRIPTION
Instead of blocking while waiting for a Space to initialize, keep the client as None and attempt to initialize it lazily on each log call. When a client is successfully initialized, the log call will flush the queue.

Fixes #28