### PR TITLE
create trackio folder if doesnt exist

### DIFF
--- a/trackio/sqlite_storage.py
+++ b/trackio/sqlite_storage.py
@@ -34,6 +34,7 @@ class SQLiteStorage:
         Returns the database path.
         """
         db_path = SQLiteStorage.get_project_db_path(project)
+        os.makedirs(os.path.dirname(db_path), exist_ok=True)
         with SQLiteStorage.get_scheduler().lock:
             with sqlite3.connect(db_path) as conn:
                 cursor = conn.cursor()


### PR DESCRIPTION
Fixes error
```
Traceback (most recent call last):
  File "/fsx/nouamane/projects/trackio/imp.py", line 8, in <module>
    trackio.import_csv(
  File "/fsx/nouamane/projects/trackio/trackio/imports.py", line 93, in import_csv
    SQLiteStorage.bulk_log(
  File "/fsx/nouamane/projects/trackio/trackio/sqlite_storage.py", line 142, in bulk_log
    db_path = SQLiteStorage.init_db(project)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/fsx/nouamane/projects/trackio/trackio/sqlite_storage.py", line 38, in init_db
    with sqlite3.connect(db_path) as conn:
         ^^^^^^^^^^^^^^^^^^^^^^^^
sqlite3.OperationalError: unable to open database file
```