### PR TITLE
Fix issues with persisting to datasets

### DIFF
--- a/examples/persist-dataset.py
+++ b/examples/persist-dataset.py
@@ -1,57 +1,87 @@
+import math
 import random
 import time
 
-from tqdm import tqdm
-
 import trackio as wandb
 
-wandb.init(
-    project="fake-training",
-    name="test-run",
-    config=dict(
-        epochs=5,
-        learning_rate=0.001,
-        batch_size=32,
-    ),
-    dataset_id="trackio-metrics",
-)
+EPOCHS = 20
+PROJECT_ID = random.randint(100000, 999999)
 
-EPOCHS = 5
-NUM_TRAIN_BATCHES = 100
-NUM_VAL_BATCHES = 20
 
-for epoch in range(EPOCHS):
-    train_loss = 0
-    train_accuracy = 0
-    val_loss = 0
-    val_accuracy = 0
+def generate_loss_curve(epoch, max_epochs, base_loss=2.5, min_loss=0.1):
+    """Generate a realistic loss curve that decreases over time with noise"""
+    progress = epoch / max_epochs
+    base_curve = base_loss * math.exp(-3 * progress) + min_loss
 
-    for _ in tqdm(range(NUM_TRAIN_BATCHES), desc=f"Epoch {epoch + 1} - Training"):
-        loss = random.uniform(0.2, 1.0)
-        accuracy = random.uniform(0.6, 0.95)
-        train_loss += loss
-        train_accuracy += accuracy
+    noise_scale = 0.3 * (1 - progress * 0.7)
+    noise = random.gauss(0, noise_scale)
 
-    for _ in tqdm(range(NUM_VAL_BATCHES), desc=f"Epoch {epoch + 1} - Validation"):
-        loss = random.uniform(0.2, 0.9)
-        accuracy = random.uniform(0.65, 0.98)
-        val_loss += loss
-        val_accuracy += accuracy
+    return max(min_loss * 0.5, base_curve + noise)
 
-    train_loss /= NUM_TRAIN_BATCHES
-    train_accuracy /= NUM_TRAIN_BATCHES
-    val_loss /= NUM_VAL_BATCHES
-    val_accuracy /= NUM_VAL_BATCHES
 
-    wandb.log(
-        {
-            "epoch": epoch + 1,
-            "train_loss": train_loss,
-            "train_accuracy": train_accuracy,
-            "val_loss": val_loss,
-            "val_accuracy": val_accuracy,
-        }
+def generate_accuracy_curve(epoch, max_epochs, max_acc=0.95, min_acc=0.1):
+    """Generate a realistic accuracy curve that increases over time with noise"""
+    progress = epoch / max_epochs
+    base_curve = max_acc / (1 + math.exp(-6 * (progress - 0.5))) + min_acc
+
+    noise_scale = 0.08 * (1 - progress * 0.5)
+    noise = random.gauss(0, noise_scale)
+
+    return max(0, min(max_acc, base_curve + noise))
+
+
+for run in range(3):
+    wandb.init(
+        project=f"fake-training-{PROJECT_ID}",
+        name=f"test-run-{run}",
+        config=dict(
+            epochs=EPOCHS,
+            learning_rate=0.001,
+            batch_size=32,
+        ),
+        dataset_id=f"trackio-test-dataset-{PROJECT_ID}",
     )
-    time.sleep(0.5)
 
-wandb.finish()
+    for epoch in range(EPOCHS):
+        train_loss = generate_loss_curve(
+            epoch,
+            EPOCHS,
+            base_loss=random.uniform(2.5, 3.5),
+            min_loss=random.uniform(0.05, 0.15),
+        )
+        val_loss = generate_loss_curve(
+            epoch,
+            EPOCHS,
+            base_loss=random.uniform(2.5, 3.5),
+            min_loss=random.uniform(0.05, 0.15),
+        )
+
+        train_accuracy = generate_accuracy_curve(
+            epoch,
+            EPOCHS,
+            max_acc=random.uniform(0.7, 0.9),
+            min_acc=random.uniform(0.1, 0.3),
+        )
+        val_accuracy = generate_accuracy_curve(
+            epoch,
+            EPOCHS,
+            max_acc=random.uniform(0.7, 0.9),
+            min_acc=random.uniform(0.1, 0.3),
+        )
+
+        if epoch > 2 and random.random() < 0.3:
+            val_loss *= 1.1
+            val_accuracy *= 0.95
+
+        wandb.log(
+            {
+                "train_loss": round(train_loss, 4),
+                "train_accuracy": round(train_accuracy, 4),
+                "val_loss": round(val_loss, 4),
+                "val_accuracy": round(val_accuracy, 4),
+            }
+        )
+
+        time.sleep(0.5)
+
+    wandb.finish()


### PR DESCRIPTION
Was looking at our logic for persisting to remote datasets and I think there's 3 issues that we need to fix:

* If you persist to a database, the trackio databases for all of your local projects will get synced to that dataset. Right now, it's not a big deal because the dataset is private but this is definitely unexpected (and a user might change the visibility of their dataset), so we should remedy
* Currently, we upload the trackio database for a project to a dataset but I think we don't ever read it back. So in the case your data is lost locally or Space restarts, the user wouldn't see their data recovered. (Unless CommitScheduler handles this internally?)
* Currently, it's not clear to me what happens if a user creates a 2 projects locally, each of which sync to different datasets. The dataset_id is stored and read as an environment variable so I think only a single dataset can be synced to from a single machine. We might need to modify this approach so that the TRACKIO_DATASET_ID env variable takes this format: project1_name:dataset1_name:project2_name:dataset2_name so that different projects can be synced to different datasets. I do think the env variable approach is a good one, as it allows us to use the same approach locally and on Spaces

this PR will fix these issues