### PR TITLE
Include the Manifest.ini file within pyproject.toml

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,0 @@
-include README.md
-include LICENSE 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,12 @@
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
+[tool.hatch.build]
+include = [
+  "README.md",
+  "LICENSE",
+]
+
 [project]
 name = "trackio"
 description = "A small Python library created to help developers protect their applications from Server Side Request Forgery (SSRF) attacks."


### PR DESCRIPTION
We can include the manifest.ini file into pyproject.toml without any breaking changes, leading to one less config file. I've tested the command with `hatch build` and confirmed its working.

Could you please review?

cc: @abidlabs