### PR TITLE
Fix multiple CommitSchedulers

### DIFF
--- a/trackio/context_vars.py
+++ b/trackio/context_vars.py
@@ -3,7 +3,6 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from trackio.run import Run
-    from trackio.sqlite_storage import CommitScheduler, DummyCommitScheduler
 
 current_run: contextvars.ContextVar["Run | None"] = contextvars.ContextVar(
     "current_run", default=None
@@ -14,6 +13,3 @@ current_project: contextvars.ContextVar[str | None] = contextvars.ContextVar(
 current_server: contextvars.ContextVar[str | None] = contextvars.ContextVar(
     "current_server", default=None
 )
-current_scheduler: contextvars.ContextVar[
-    "CommitScheduler | DummyCommitScheduler | None"
-] = contextvars.ContextVar("current_scheduler", default=None)

--- a/trackio/sqlite_storage.py
+++ b/trackio/sqlite_storage.py
@@ -3,20 +3,22 @@ import os
 import sqlite3
 from datetime import datetime
 from pathlib import Path
+from threading import Lock
 
 from huggingface_hub import CommitScheduler
 
 try:  # absolute imports when installed
-    from trackio.context_vars import current_scheduler
     from trackio.dummy_commit_scheduler import DummyCommitScheduler
     from trackio.utils import TRACKIO_DIR
 except Exception:  # relative imports for local execution on Spaces
-    from context_vars import current_scheduler
     from dummy_commit_scheduler import DummyCommitScheduler
     from utils import TRACKIO_DIR
 
 
 class SQLiteStorage:
+    _current_scheduler: CommitScheduler | DummyCommitScheduler | None = None
+    _scheduler_lock = Lock()
+
     @staticmethod
     def _get_connection(db_path: Path) -> sqlite3.Connection:
         conn = sqlite3.connect(str(db_path))
@@ -68,23 +70,24 @@ class SQLiteStorage:
         Get the scheduler for the database based on the environment variables.
         This applies to both local and Spaces.
         """
-        if current_scheduler.get() is not None:
-            return current_scheduler.get()
-        hf_token = os.environ.get("HF_TOKEN")
-        dataset_id = os.environ.get("TRACKIO_DATASET_ID")
-        if dataset_id is None:
-            scheduler = DummyCommitScheduler()
-        else:
-            scheduler = CommitScheduler(
-                repo_id=dataset_id,
-                repo_type="dataset",
-                folder_path=TRACKIO_DIR,
-                private=True,
-                squash_history=True,
-                token=hf_token,
-            )
-        current_scheduler.set(scheduler)
-        return scheduler
+        with SQLiteStorage._scheduler_lock:
+            if SQLiteStorage._current_scheduler is not None:
+                return SQLiteStorage._current_scheduler
+            hf_token = os.environ.get("HF_TOKEN")
+            dataset_id = os.environ.get("TRACKIO_DATASET_ID")
+            if dataset_id is None:
+                scheduler = DummyCommitScheduler()
+            else:
+                scheduler = CommitScheduler(
+                    repo_id=dataset_id,
+                    repo_type="dataset",
+                    folder_path=TRACKIO_DIR,
+                    private=True,
+                    squash_history=True,
+                    token=hf_token,
+                )
+            SQLiteStorage._current_scheduler = scheduler
+            return scheduler
 
     @staticmethod
     def log(project: str, run: str, metrics: dict):


### PR DESCRIPTION
The ContextVar is thread-local (one per thread), so using that as the source of what should be a single global CommitScheduler was the source of this bug. This commit moves the CommitScheduler to a class variable protected by a thread lock, and there is now a single global CommitScheduler.

This should fix any 429/500 errors from commits.