### PR TITLE
Fix dataset loading properly

### DIFF
--- a/trackio/sqlite_storage.py
+++ b/trackio/sqlite_storage.py
@@ -1,6 +1,5 @@
 import json
 import os
-import shutil
 import sqlite3
 from datetime import datetime
 from pathlib import Path
@@ -234,10 +233,9 @@ class SQLiteStorage:
                     for file in files:
                         if not file.endswith(".db"):
                             continue
-                        downloaded_path = hf.hf_hub_download(
-                            dataset_id, file, repo_type="dataset"
+                        hf.hf_hub_download(
+                            dataset_id, file, repo_type="dataset", local_dir=TRACKIO_DIR
                         )
-                        shutil.copy(downloaded_path, TRACKIO_DIR)
                 except hf.errors.EntryNotFoundError:
                     pass
                 except hf.errors.RepositoryNotFoundError:


### PR DESCRIPTION
The previous fix for #79 did not populate the projects list, and potentially had a race between whether the import would attempt first (w/o a projects list, meaning import would not succeed) and project list creation (from client init).

This change reads the project list from the dataset after importing, so the order of operations is always:

1. dataset import
2. populate projects list
3. first init & log call from client

This seems to fix #79 in a more robust way.