### PR TITLE
Flatten metrics column in parquet representation

### DIFF
--- a/trackio/utils.py
+++ b/trackio/utils.py
@@ -8,7 +8,7 @@ import numpy as np
 import pandas as pd
 from huggingface_hub.constants import HF_HOME
 
-RESERVED_KEYS = ["project", "run", "timestamp", "step", "time"]
+RESERVED_KEYS = ["project", "run", "timestamp", "step", "time", "metrics"]
 TRACKIO_DIR = Path(HF_HOME) / "trackio"
 
 TRACKIO_LOGO_DIR = Path(__file__).parent / "assets"


### PR DESCRIPTION
* When exporting to parquet, flatten the `metrics` column into multiple columns of Parquet.
* When importing, do the reverse (if the parquet file doesn't already have a `metrics` column).
* If the parquet file has a metrics column (legacy format), it will skip the unflattening on import, so it should continue to work.
* Adds "metrics" to the reserved metric names so that it's not possible to log a metric name that will get this logic confused.

Fixes #105