### PR TITLE
Don't use transformers container when building docs

### DIFF
--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -16,6 +16,5 @@ jobs:
       repo_owner: gradio-app
       package: trackio
       version_tag_suffix: ""
-      custom_container: huggingface/transformers-doc-builder
     secrets:
       hf_token: ${{ secrets.HF_DOC_BUILD }}

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -16,4 +16,3 @@ jobs:
       repo_owner: gradio-app
       package: trackio
       version_tag_suffix: ""
-      custom_container: huggingface/transformers-doc-builder


### PR DESCRIPTION
slack thread: https://huggingface.slack.com/archives/C04F8N7FQNL/p1756425040083309

cc @abidlabs @qgallouedec 

When building the docs you can chose to start from a pre-built container. This is useful for e.g. transformers as a lot of setup is required. However for most repos it is fine to just start "from scratch" which is much faster as we are not pulling a multi-GB image. See for instance [huggingface_hub's doc workflows](https://github.com/huggingface/huggingface_hub/blob/main/.github/workflows/build_pr_documentation.yaml).