### PR TITLE
🖨️ Print run name

### DIFF
--- a/trackio/__init__.py
+++ b/trackio/__init__.py
@@ -142,12 +142,18 @@ def init(
             raise ValueError("Must provide a run name when resume='must'")
         if name not in SQLiteStorage.get_runs(project):
             raise ValueError(f"Run '{name}' does not exist in project '{project}'")
+        resumed = True
     elif resume == "allow":
-        if name is not None and name in SQLiteStorage.get_runs(project):
-            print(f"* Resuming existing run: {name}")
+        resumed = name is not None and name in SQLiteStorage.get_runs(project)
     elif resume == "never":
         if name is not None and name in SQLiteStorage.get_runs(project):
+            warnings.warn(
+                f"* Warning: resume='never' but a run '{name}' already exists in "
+                f"project '{project}'. Generating a new name and instead. If you want "
+                "to resume this run, call init() with resume='must' or resume='allow'."
+            )
             name = None
+        resumed = False
     else:
         raise ValueError("resume must be one of: 'must', 'allow', or 'never'")
 
@@ -159,6 +165,12 @@ def init(
         config=config,
         space_id=space_id,
     )
+
+    if resumed:
+        print(f"* Resumed existing run: {run.name}")
+    else:
+        print(f"* Created new run: {run.name}")
+
     context_vars.current_run.set(run)
     globals()["config"] = run.config
     return run


### PR DESCRIPTION
```python
import random
import trackio

trackio.init(project="print-run-name")

for epoch in range(10):
    trackio.log({"loss": random.random()})

trackio.finish()
```

```
$ python demo.py
* Trackio project initialized: print-run-name
* Trackio metrics logged to: /fsx/qgallouedec/.cache/huggingface/trackio
* View dashboard by running in your terminal:
trackio show --project "print-run-name"
* or by running in Python: trackio.show(project="print-run-name")
* Created new run: dainty-sunset-0
* Run finished. Uploading logs to Trackio Space: http://127.0.0.1:7860/ (please wait...)
```


```diff
- trackio.init(project="print-run-name")
+ trackio.init(project="print-run-name", name="dainty-sunset-0")
```

```
$ python demo.py
* Trackio project initialized: print-run-name
* Trackio metrics logged to: /fsx/qgallouedec/.cache/huggingface/trackio
* View dashboard by running in your terminal:
trackio show --project "print-run-name"
* or by running in Python: trackio.show(project="print-run-name")
/fsx/qgallouedec/trackio/trackio/__init__.py:150: UserWarning: * Warning: resume='never' but a run 'dainty-sunset-0' already exists in project 'print-run-name'. Generating a new name and instead. If you want to resume this run, call init() with resume='must' or resume='allow'.
  warnings.warn(
* Created new run: brave-forest-1
* Run finished. Uploading logs to Trackio Space: http://127.0.0.1:7860/ (please wait...)
```

```diff
- trackio.init(project="print-run-name", name="dainty-sunset-0")
+ trackio.init(project="print-run-name", name="dainty-sunset-0", resume="allow")
```

```
$ python demo.py
* Trackio project initialized: print-run-name
* Trackio metrics logged to: /fsx/qgallouedec/.cache/huggingface/trackio
* View dashboard by running in your terminal:
trackio show --project "print-run-name"
* or by running in Python: trackio.show(project="print-run-name")
* Resumed existing run: dainty-sunset-0
* Run finished. Uploading logs to Trackio Space: http://127.0.0.1:7860/ (please wait...)
```