### PR TITLE
Fix plot legend ordering for smoothed metrics

### DIFF
--- a/trackio/ui.py
+++ b/trackio/ui.py
@@ -150,7 +150,7 @@ def load_run_data(
         numeric_cols = [c for c in numeric_cols if c not in utils.RESERVED_KEYS]
 
         df_original = df.copy()
-        df_original["run"] = f"{run}_original"
+        df_original["run"] = run
         df_original["data_type"] = "original"
 
         df_smoothed = df.copy()
@@ -623,8 +623,26 @@ with gr.Blocks(theme="citrus", title="Trackio Dashboard", css=css) as demo:
             if df is not None:
                 dfs.append(df)
                 images_by_run[run] = images_by_key
+
         if dfs:
-            master_df = pd.concat(dfs, ignore_index=True)
+            if smoothing_granularity > 0:
+                original_dfs = []
+                smoothed_dfs = []
+                for df in dfs:
+                    original_data = df[df["data_type"] == "original"]
+                    smoothed_data = df[df["data_type"] == "smoothed"]
+                    if not original_data.empty:
+                        original_dfs.append(original_data)
+                    if not smoothed_data.empty:
+                        smoothed_dfs.append(smoothed_data)
+
+                all_dfs = original_dfs + smoothed_dfs
+                master_df = (
+                    pd.concat(all_dfs, ignore_index=True) if all_dfs else pd.DataFrame()
+                )
+
+            else:
+                master_df = pd.concat(dfs, ignore_index=True)
         else:
             master_df = pd.DataFrame()
 

--- a/trackio/utils.py
+++ b/trackio/utils.py
@@ -431,7 +431,7 @@ def downsample(
 
     downsampled_df = df.loc[unique_indices].copy()
 
-    if color is not None and color in downsampled_df.columns:
+    if color is not None:
         downsampled_df = (
             downsampled_df.groupby(color, sort=False)
             .apply(lambda group: group.sort_values(x))

--- a/trackio/utils.py
+++ b/trackio/utils.py
@@ -341,8 +341,8 @@ def get_color_mapping(runs: list[str], smoothing: bool) -> dict[str, str]:
         base_color = COLOR_PALETTE[i % len(COLOR_PALETTE)]
 
         if smoothing:
+            color_map[run] = base_color + "4D"
             color_map[f"{run}_smoothed"] = base_color
-            color_map[f"{run}_original"] = base_color + "4D"
         else:
             color_map[run] = base_color
 
@@ -430,7 +430,16 @@ def downsample(
     unique_indices = list(set(downsampled_indices))
 
     downsampled_df = df.loc[unique_indices].copy()
-    downsampled_df = downsampled_df.sort_values(x).reset_index(drop=True)
+
+    if color is not None and color in downsampled_df.columns:
+        downsampled_df = (
+            downsampled_df.groupby(color, sort=False)
+            .apply(lambda group: group.sort_values(x))
+            .reset_index(drop=True)
+        )
+    else:
+        downsampled_df = downsampled_df.sort_values(x).reset_index(drop=True)
+
     downsampled_df = downsampled_df.drop(columns=["bin"], errors="ignore")
 
     return downsampled_df


### PR DESCRIPTION
Reorders plot legend entries so all non-smoothed runs appear first, followed by all smoothed runs. Removes the _original suffix from metric names while preserving the _smoothed suffix. Closes: #129, Closes: https://github.com/gradio-app/trackio/issues/156

Here's what it looks like now:

<img width="1320" height="524" alt="image" src="https://github.com/user-attachments/assets/f9690ac1-87d1-479b-be5f-341476d0cb84" />
