### PR TITLE
add temp_dir to tests where it's missing

### DIFF
--- a/tests/e2e/test_bulk_logging.py
+++ b/tests/e2e/test_bulk_logging.py
@@ -4,7 +4,7 @@ import trackio
 from trackio.sqlite_storage import SQLiteStorage
 
 
-def test_rapid_bulk_logging():
+def test_rapid_bulk_logging(temp_dir):
     """
     Test that logs sent rapidly across different runs are all successfully logged with correct run names.
     Also tests that trackio.log() is not too slow.

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -12,7 +12,7 @@ class DummyClient:
         self.predict = MagicMock()
 
 
-def test_run_log_calls_client():
+def test_run_log_calls_client(temp_dir):
     client = DummyClient()
     run = Run(url="fake_url", project="proj", client=client, name="run1", space_id=None)
     metrics = {"x": 1}
@@ -83,7 +83,7 @@ def test_init_resume_modes(temp_dir):
 
 @patch("huggingface_hub.whoami")
 @patch("time.time")
-def test_run_name_generation_with_space_id(mock_time, mock_whoami):
+def test_run_name_generation_with_space_id(mock_time, mock_whoami, temp_dir):
     mock_whoami.return_value = {"name": "testuser"}
     mock_time.return_value = 1234567890
 


### PR DESCRIPTION
Noticed some warnings which were resulting from tests which should have been using but were missing `temp_dir`.