### PR TITLE
Add a "Run detail" page

### DIFF
--- a/trackio/ui/main.py
+++ b/trackio/ui/main.py
@@ -21,6 +21,7 @@ try:
     from trackio.table import Table
     from trackio.typehints import LogEntry, UploadEntry
     from trackio.ui import fns
+    from trackio.ui.run_detail import run_detail_page
     from trackio.ui.runs import run_page
 except ImportError:
     import utils
@@ -30,6 +31,7 @@ except ImportError:
     from table import Table
     from typehints import LogEntry, UploadEntry
     from ui import fns
+    from ui.run_detail import run_detail_page
     from ui.runs import run_page
 
 
@@ -887,6 +889,8 @@ with gr.Blocks(title="Trackio Dashboard", css=css) as demo:
 
 with demo.route("Runs", show_in_navbar=False):
     run_page.render()
+with demo.route("Run", show_in_navbar=False):
+    run_detail_page.render()
 
 if __name__ == "__main__":
     demo.launch(allowed_paths=[utils.TRACKIO_LOGO_DIR], show_api=False, show_error=True)

--- a/trackio/ui/run_detail.py
+++ b/trackio/ui/run_detail.py
@@ -4,14 +4,16 @@ import gradio as gr
 
 try:
     import trackio.utils as utils
+    from trackio.sqlite_storage import SQLiteStorage
     from trackio.ui import fns
 except ImportError:
     import utils
+    from sqlite_storage import SQLiteStorage
     from ui import fns
 
 RUN_DETAILS_TEMPLATE = """
 ## Run Details
-* **Run Name:** {run_dd}
+* **Run Name:** `{run_dd}`
 * **Created:** {created}
 * **Username:** {username}
 """
@@ -41,10 +43,7 @@ with gr.Blocks() as run_detail_page:
         return project, run
 
     def update_run_details(project, run):
-        from trackio.sqlite_storage import SQLiteStorage
-
         config = SQLiteStorage.get_run_config(project, run)
-
         if not config:
             return gr.Markdown("No run details available"), {}
 

--- a/trackio/ui/run_detail.py
+++ b/trackio/ui/run_detail.py
@@ -14,8 +14,7 @@ except ImportError:
 RUN_DETAILS_TEMPLATE = """
 ## Run Details
 * **Run Name:** `{run_dd}`
-* **Created:** {created}
-* **Username:** {username}
+* **Created:** {created} by {username}
 """
 
 with gr.Blocks() as run_detail_page:
@@ -35,7 +34,7 @@ with gr.Blocks() as run_detail_page:
 
     run_details = gr.Markdown(RUN_DETAILS_TEMPLATE)
 
-    run_config = gr.JSON()
+    run_config = gr.JSON(label="Run Config")
 
     def configure(request: gr.Request):
         project = request.query_params.get("selected_project")

--- a/trackio/ui/run_detail.py
+++ b/trackio/ui/run_detail.py
@@ -1,0 +1,88 @@
+"""The Runs page for the Trackio UI."""
+
+import gradio as gr
+
+try:
+    import trackio.utils as utils
+    from trackio.ui import fns
+except ImportError:
+    import utils
+    from ui import fns
+
+RUN_DETAILS_TEMPLATE = """
+## Run Details
+* **Run Name:** {run_dd}
+* **Created:** {created}
+* **Username:** {username}
+"""
+
+with gr.Blocks() as run_detail_page:
+    with gr.Sidebar() as sidebar:
+        logo = gr.Markdown(
+            f"""
+                <img src='/gradio_api/file={utils.TRACKIO_LOGO_DIR}/trackio_logo_type_light_transparent.png' width='80%' class='logo-light'>
+                <img src='/gradio_api/file={utils.TRACKIO_LOGO_DIR}/trackio_logo_type_dark_transparent.png' width='80%' class='logo-dark'>            
+            """
+        )
+        project_dd = gr.Dropdown(
+            label="Project", allow_custom_value=True, interactive=False
+        )
+        run_dd = gr.Dropdown(label="Run", allow_custom_value=True, interactive=False)
+
+    navbar = gr.Navbar(value=[("Metrics", ""), ("Runs", "/runs")], main_page_name=False)
+
+    run_details = gr.Markdown(RUN_DETAILS_TEMPLATE)
+
+    run_config = gr.JSON()
+
+    def configure(request: gr.Request):
+        project = request.query_params.get("selected_project")
+        run = request.query_params.get("selected_run")
+        return project, run
+
+    def update_run_details(project, run):
+        from trackio.sqlite_storage import SQLiteStorage
+
+        config = SQLiteStorage.get_run_config(project, run)
+
+        if not config:
+            return gr.Markdown("No run details available"), {}
+
+        created = config.get("_Created", "Unknown")
+        if created != "Unknown":
+            created = utils.format_timestamp(created)
+
+        username = config.get("_Username", "Unknown")
+        if username and username != "None" and username != "Unknown":
+            username = f"[{username}](https://huggingface.co/{username})"
+
+        details_md = RUN_DETAILS_TEMPLATE.format(
+            run_dd=run, created=created, username=username
+        )
+
+        config_display = {k: v for k, v in config.items() if not k.startswith("_")}
+
+        return gr.Markdown(details_md), config_display
+
+    gr.on(
+        [run_detail_page.load],
+        fn=configure,
+        outputs=[project_dd, run_dd],
+        show_progress="hidden",
+        queue=False,
+        api_name=False,
+    ).then(
+        fns.update_navbar_value,
+        inputs=[project_dd],
+        outputs=[navbar],
+        show_progress="hidden",
+        api_name=False,
+        queue=False,
+    ).then(
+        update_run_details,
+        inputs=[project_dd, run_dd],
+        outputs=[run_details, run_config],
+        show_progress="hidden",
+        api_name=False,
+        queue=False,
+    )

--- a/trackio/ui/runs.py
+++ b/trackio/ui/runs.py
@@ -45,7 +45,14 @@ with gr.Blocks() as run_page:
 
         if "Username" in df.columns:
             df["Username"] = df["Username"].apply(
-                lambda x: f"[{x}](https://huggingface.co/{x})"
+                lambda x: f"<a href='https://huggingface.co/{x}' style='text-decoration-style: dotted;'>{x}</a>"
+                if x and x != "None"
+                else x
+            )
+
+        if "Name" in df.columns:
+            df["Name"] = df["Name"].apply(
+                lambda x: f"<a href='/run?selected_project={project}&selected_run={x}'>{x}</a>"
                 if x and x != "None"
                 else x
             )


### PR DESCRIPTION
When you click on a run name in the Runs table, you'll be taken to this page:

<img width="1367" height="695" alt="image" src="https://github.com/user-attachments/assets/f69d4126-3652-45c4-a4f8-36b0dbfab7a1" />

Particularly useful when the config is hard to visualize in the dataframe table.
