### PR TITLE
Allow deleting runs when running Trackio locally & implement Jupyter-style token authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
   - Visualize experiments with a Gradio dashboard locally (or, if you provide a `space_id`, on Hugging Face Spaces)
 - Everything here, including hosting on Hugging Face, is **free**!
 
-Trackio is designed to be lightweight (the core codebase is <4,000 lines of Python code), not fully-featured. It is designed in an extensible way and written entirely in Python so that developers can easily fork the repository and add functionality that they care about.
+Trackio is designed to be lightweight (the core codebase is <5,000 lines of Python code), not fully-featured. It is designed in an extensible way and written entirely in Python so that developers can easily fork the repository and add functionality that they care about.
 
 ## Installation
 

--- a/examples/fake-training.py
+++ b/examples/fake-training.py
@@ -45,7 +45,7 @@ def generate_grad_norm_curve(epoch, max_epochs):
         return max(0.1, base_value + noise)
 
 
-for run in range(3):
+for run in range(7):
     wandb.init(
         project=f"fake-training-{PROJECT_ID}",
         name=f"test-run-{run}",

--- a/examples/fake-training.py
+++ b/examples/fake-training.py
@@ -45,7 +45,7 @@ def generate_grad_norm_curve(epoch, max_epochs):
         return max(0.1, base_value + noise)
 
 
-for run in range(7):
+for run in range(3):
     wandb.init(
         project=f"fake-training-{PROJECT_ID}",
         name=f"test-run-{run}",

--- a/tests/test_sqlite_storage.py
+++ b/tests/test_sqlite_storage.py
@@ -35,6 +35,24 @@ def test_get_projects_and_runs(temp_dir):
     assert "run1" in runs
 
 
+def test_delete_run(temp_dir):
+    project = "test_project"
+    run_name = "test_run"
+
+    config = {"param1": "value1", "_Created": "2023-01-01T00:00:00"}
+    SQLiteStorage.store_config(project, run_name, config)
+
+    metrics = [{"accuracy": 0.95, "loss": 0.1}]
+    SQLiteStorage.bulk_log(project, run_name, metrics)
+
+    assert SQLiteStorage.get_run_config(project, run_name) is not None
+    assert len(SQLiteStorage.get_logs(project, run_name)) > 0
+
+    SQLiteStorage.delete_run(project, run_name)
+    assert SQLiteStorage.get_run_config(project, run_name) is None
+    assert len(SQLiteStorage.get_logs(project, run_name)) == 0
+
+
 def test_import_export(temp_dir):
     db_path_1 = SQLiteStorage.init_db("proj1")
     db_path_2 = SQLiteStorage.init_db("proj2")

--- a/tests/test_token_auth.py
+++ b/tests/test_token_auth.py
@@ -2,24 +2,24 @@
 
 from unittest.mock import Mock
 
-from trackio.ui.main import check_write_access, demo
+from trackio.ui.runs import check_write_access_runs
 
 
 def test_check_write_access():
-    demo.write_token = "test_token_123"
+    test_token = "test_token_123"
 
     mock_request = Mock()
     mock_request.headers = {"cookie": "trackio_write_token=test_token_123; other=value"}
     mock_request.query_params = {}
-    assert check_write_access(mock_request)
+    assert check_write_access_runs(mock_request, test_token)
 
     mock_request.headers = {"cookie": "trackio_write_token=wrong_token; other=value"}
-    assert not check_write_access(mock_request)
+    assert not check_write_access_runs(mock_request, test_token)
 
     mock_request.headers = {"cookie": ""}
     mock_request.query_params = {"write_token": "test_token_123"}
-    assert check_write_access(mock_request)
+    assert check_write_access_runs(mock_request, test_token)
 
     mock_request.headers = {"cookie": ""}
     mock_request.query_params = {}
-    assert not check_write_access(mock_request)
+    assert not check_write_access_runs(mock_request, test_token)

--- a/tests/test_token_auth.py
+++ b/tests/test_token_auth.py
@@ -76,24 +76,26 @@ def test_show_function_generates_token():
         assert "project=test" in called_url
 
 
-def test_write_access_indicator():
-    """Test the write access indicator function."""
-    from trackio.ui.main import demo, update_write_access_indicator
+def test_delete_button_access():
+    """Test the delete button access function."""
+    from trackio.ui.main import demo
+    from trackio.ui.runs import update_delete_button_access
 
-    demo.write_token = "test_indicator_token"
+    demo.write_token = "test_delete_token"
 
     # Test with valid access
     mock_request = Mock()
-    mock_request.headers = {"cookie": "trackio_write_token=test_indicator_token"}
+    mock_request.headers = {"cookie": "trackio_write_token=test_delete_token"}
     mock_request.query_params = {}
 
-    result = update_write_access_indicator(mock_request)
-    assert result.visible is True
-    assert "Write access enabled" in result.value
+    result = update_delete_button_access(mock_request)
+    assert "Select and delete run(s)" in result.value
+    assert result.variant == "stop"
 
     # Test without access
     mock_request.headers = {"cookie": ""}
     mock_request.query_params = {}
 
-    result = update_write_access_indicator(mock_request)
-    assert result.visible is False
+    result = update_delete_button_access(mock_request)
+    assert "Need write access to delete runs" in result.value
+    assert result.variant == "secondary"

--- a/tests/test_token_auth.py
+++ b/tests/test_token_auth.py
@@ -2,19 +2,15 @@
 
 from unittest.mock import Mock
 
-import pytest
+from trackio.ui.main import check_write_access, demo
 
 
 def test_check_write_access():
-    """Test the write access validation logic."""
-    from trackio.ui.main import check_write_access, demo
-
     demo.write_token = "test_token_123"
 
     mock_request = Mock()
     mock_request.headers = {"cookie": "trackio_write_token=test_token_123; other=value"}
     mock_request.query_params = {}
-
     assert check_write_access(mock_request)
 
     mock_request.headers = {"cookie": "trackio_write_token=wrong_token; other=value"}

--- a/tests/test_token_auth.py
+++ b/tests/test_token_auth.py
@@ -1,0 +1,99 @@
+"""Tests for token authentication functionality."""
+
+import secrets
+from unittest.mock import Mock, patch
+
+import pytest
+
+
+def test_token_generation():
+    """Test that tokens are generated with proper length and randomness."""
+    token1 = secrets.token_urlsafe(32)
+    token2 = secrets.token_urlsafe(32)
+
+    # Tokens should be different
+    assert token1 != token2
+
+    # Tokens should be reasonable length
+    assert len(token1) > 20
+    assert len(token2) > 20
+
+
+def test_check_write_access():
+    """Test the write access validation logic."""
+    from trackio.ui.main import check_write_access, demo
+
+    # Mock a demo with a token
+    demo.write_token = "test_token_123"
+
+    # Test with valid cookie
+    mock_request = Mock()
+    mock_request.headers = {"cookie": "trackio_write_token=test_token_123; other=value"}
+    mock_request.query_params = {}
+
+    assert check_write_access(mock_request) is True
+
+    # Test with invalid cookie
+    mock_request.headers = {"cookie": "trackio_write_token=wrong_token; other=value"}
+    assert check_write_access(mock_request) is False
+
+    # Test with valid query param
+    mock_request.headers = {"cookie": ""}
+    mock_request.query_params = {"write_token": "test_token_123"}
+    assert check_write_access(mock_request) is True
+
+    # Test with no token
+    mock_request.headers = {"cookie": ""}
+    mock_request.query_params = {}
+    assert check_write_access(mock_request) is False
+
+
+def test_show_function_generates_token():
+    """Test that the show function generates and uses a token."""
+    from trackio.ui.main import demo
+
+    with (
+        patch("trackio.ui.main.demo.launch") as mock_launch,
+        patch("webbrowser.open") as mock_browser,
+        patch("trackio.utils.is_in_notebook", return_value=False),
+    ):
+        mock_launch.return_value = (None, "http://localhost:7860", None)
+
+        # Import and call show
+        from trackio import show
+
+        show(project="test")
+
+        # Check that token was set on demo
+        assert hasattr(demo, "write_token")
+        assert len(demo.write_token) > 20
+
+        # Check that browser was opened with token in URL
+        mock_browser.assert_called_once()
+        called_url = mock_browser.call_args[0][0]
+        assert "write_token=" in called_url
+        assert demo.write_token in called_url
+        assert "project=test" in called_url
+
+
+def test_write_access_indicator():
+    """Test the write access indicator function."""
+    from trackio.ui.main import demo, update_write_access_indicator
+
+    demo.write_token = "test_indicator_token"
+
+    # Test with valid access
+    mock_request = Mock()
+    mock_request.headers = {"cookie": "trackio_write_token=test_indicator_token"}
+    mock_request.query_params = {}
+
+    result = update_write_access_indicator(mock_request)
+    assert result.visible is True
+    assert "Write access enabled" in result.value
+
+    # Test without access
+    mock_request.headers = {"cookie": ""}
+    mock_request.query_params = {}
+
+    result = update_write_access_indicator(mock_request)
+    assert result.visible is False

--- a/tests/test_token_auth.py
+++ b/tests/test_token_auth.py
@@ -1,101 +1,29 @@
 """Tests for token authentication functionality."""
 
-import secrets
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 
 import pytest
-
-
-def test_token_generation():
-    """Test that tokens are generated with proper length and randomness."""
-    token1 = secrets.token_urlsafe(32)
-    token2 = secrets.token_urlsafe(32)
-
-    # Tokens should be different
-    assert token1 != token2
-
-    # Tokens should be reasonable length
-    assert len(token1) > 20
-    assert len(token2) > 20
 
 
 def test_check_write_access():
     """Test the write access validation logic."""
     from trackio.ui.main import check_write_access, demo
 
-    # Mock a demo with a token
     demo.write_token = "test_token_123"
 
-    # Test with valid cookie
     mock_request = Mock()
     mock_request.headers = {"cookie": "trackio_write_token=test_token_123; other=value"}
     mock_request.query_params = {}
 
-    assert check_write_access(mock_request) is True
+    assert check_write_access(mock_request)
 
-    # Test with invalid cookie
     mock_request.headers = {"cookie": "trackio_write_token=wrong_token; other=value"}
-    assert check_write_access(mock_request) is False
+    assert not check_write_access(mock_request)
 
-    # Test with valid query param
     mock_request.headers = {"cookie": ""}
     mock_request.query_params = {"write_token": "test_token_123"}
-    assert check_write_access(mock_request) is True
+    assert check_write_access(mock_request)
 
-    # Test with no token
     mock_request.headers = {"cookie": ""}
     mock_request.query_params = {}
-    assert check_write_access(mock_request) is False
-
-
-def test_show_function_generates_token():
-    """Test that the show function generates and uses a token."""
-    from trackio.ui.main import demo
-
-    with (
-        patch("trackio.ui.main.demo.launch") as mock_launch,
-        patch("webbrowser.open") as mock_browser,
-        patch("trackio.utils.is_in_notebook", return_value=False),
-    ):
-        mock_launch.return_value = (None, "http://localhost:7860", None)
-
-        # Import and call show
-        from trackio import show
-
-        show(project="test")
-
-        # Check that token was set on demo
-        assert hasattr(demo, "write_token")
-        assert len(demo.write_token) > 20
-
-        # Check that browser was opened with token in URL
-        mock_browser.assert_called_once()
-        called_url = mock_browser.call_args[0][0]
-        assert "write_token=" in called_url
-        assert demo.write_token in called_url
-        assert "project=test" in called_url
-
-
-def test_delete_button_access():
-    """Test the delete button access function."""
-    from trackio.ui.main import demo
-    from trackio.ui.runs import update_delete_button_access
-
-    demo.write_token = "test_delete_token"
-
-    # Test with valid access
-    mock_request = Mock()
-    mock_request.headers = {"cookie": "trackio_write_token=test_delete_token"}
-    mock_request.query_params = {}
-
-    result = update_delete_button_access(mock_request)
-    assert "Select and delete run(s)" in result.value
-    assert result.variant == "stop"
-
-    # Test without access
-    mock_request.headers = {"cookie": ""}
-    mock_request.query_params = {}
-
-    result = update_delete_button_access(mock_request)
-    assert "Need write access to delete runs" in result.value
-    assert result.variant == "secondary"
+    assert not check_write_access(mock_request)

--- a/trackio/__init__.py
+++ b/trackio/__init__.py
@@ -277,8 +277,7 @@ def show(project: str | None = None, theme: str | ThemeClass = DEFAULT_THEME):
     params.append(f"write_token={write_token}")
     if project:
         params.append(f"project={project}")
-
-    dashboard_url = base_url + "?" + "&".join(params) if params else base_url
+    dashboard_url = base_url + "?" + "&".join(params)
 
     if not utils.is_in_notebook():
         print(f"* Trackio UI launched at: {dashboard_url}")

--- a/trackio/__init__.py
+++ b/trackio/__init__.py
@@ -19,6 +19,7 @@ from trackio.run import Run
 from trackio.sqlite_storage import SQLiteStorage
 from trackio.table import Table
 from trackio.ui.main import demo
+from trackio.ui.runs import run_page
 from trackio.utils import TRACKIO_DIR, TRACKIO_LOGO_DIR
 
 __version__ = Path(__file__).parent.joinpath("version.txt").read_text().strip()
@@ -231,6 +232,7 @@ def show(project: str | None = None, theme: str | ThemeClass = DEFAULT_THEME):
 
     # Store the token on the demo object
     demo.write_token = write_token
+    run_page.write_token = write_token
 
     if theme != DEFAULT_THEME:
         # TODO: It's a little hacky to reproduce this theme-setting logic from Gradio Blocks,

--- a/trackio/__init__.py
+++ b/trackio/__init__.py
@@ -273,8 +273,7 @@ def show(project: str | None = None, theme: str | ThemeClass = DEFAULT_THEME):
 
     base_url = share_url + "/" if share_url else url
 
-    params = []
-    params.append(f"write_token={write_token}")
+    params = [f"write_token={write_token}"]
     if project:
         params.append(f"project={project}")
     dashboard_url = base_url + "?" + "&".join(params)

--- a/trackio/__init__.py
+++ b/trackio/__init__.py
@@ -227,10 +227,8 @@ def show(project: str | None = None, theme: str | ThemeClass = DEFAULT_THEME):
             can be a built-in theme (e.g. `'soft'`, `'default'`), a theme from the Hub
             (e.g. `"gstaff/xkcd"`), or a custom Theme class.
     """
-    # Generate a secure write token
     write_token = secrets.token_urlsafe(32)
 
-    # Store the token on the demo object
     demo.write_token = write_token
     run_page.write_token = write_token
 
@@ -268,7 +266,6 @@ def show(project: str | None = None, theme: str | ThemeClass = DEFAULT_THEME):
 
     base_url = share_url + "/" if share_url else url
 
-    # Build the URL with the write token
     params = []
     params.append(f"write_token={write_token}")
     if project:

--- a/trackio/__init__.py
+++ b/trackio/__init__.py
@@ -273,12 +273,14 @@ def show(project: str | None = None, theme: str | ThemeClass = DEFAULT_THEME):
 
     base_url = share_url + "/" if share_url else url
 
-    params = [f"write_token={write_token}"]
+    params = []
     if project:
         params.append(f"project={project}")
+    safe_url = base_url + ("?" + "&".join(params) if params else "")
+    params.append(f"write_token={write_token}")
     dashboard_url = base_url + "?" + "&".join(params)
 
     if not utils.is_in_notebook():
-        print(f"* Trackio UI launched at: {dashboard_url}")
+        print(f"* Trackio UI launched at: {safe_url}")
         webbrowser.open(dashboard_url)
         utils.block_except_in_notebook()

--- a/trackio/__init__.py
+++ b/trackio/__init__.py
@@ -1,5 +1,6 @@
 import hashlib
 import os
+import secrets
 import warnings
 import webbrowser
 from pathlib import Path
@@ -225,6 +226,12 @@ def show(project: str | None = None, theme: str | ThemeClass = DEFAULT_THEME):
             can be a built-in theme (e.g. `'soft'`, `'default'`), a theme from the Hub
             (e.g. `"gstaff/xkcd"`), or a custom Theme class.
     """
+    # Generate a secure write token
+    write_token = secrets.token_urlsafe(32)
+
+    # Store the token on the demo object
+    demo.write_token = write_token
+
     if theme != DEFAULT_THEME:
         # TODO: It's a little hacky to reproduce this theme-setting logic from Gradio Blocks,
         # but in Gradio 6.0, the theme will be set in `launch()` instead, which means that we
@@ -258,7 +265,14 @@ def show(project: str | None = None, theme: str | ThemeClass = DEFAULT_THEME):
     )
 
     base_url = share_url + "/" if share_url else url
-    dashboard_url = base_url + f"?project={project}" if project else base_url
+
+    # Build the URL with the write token
+    params = []
+    params.append(f"write_token={write_token}")
+    if project:
+        params.append(f"project={project}")
+
+    dashboard_url = base_url + "?" + "&".join(params) if params else base_url
 
     if not utils.is_in_notebook():
         print(f"* Trackio UI launched at: {dashboard_url}")

--- a/trackio/__init__.py
+++ b/trackio/__init__.py
@@ -273,14 +273,12 @@ def show(project: str | None = None, theme: str | ThemeClass = DEFAULT_THEME):
 
     base_url = share_url + "/" if share_url else url
 
-    params = []
+    params = [f"write_token={write_token}"]
     if project:
         params.append(f"project={project}")
-    safe_url = base_url + ("?" + "&".join(params) if params else "")
-    params.append(f"write_token={write_token}")
     dashboard_url = base_url + "?" + "&".join(params)
 
     if not utils.is_in_notebook():
-        print(f"* Trackio UI launched at: {safe_url}")
+        print(f"* Trackio UI launched at: {dashboard_url}")
         webbrowser.open(dashboard_url)
         utils.block_except_in_notebook()

--- a/trackio/sqlite_storage.py
+++ b/trackio/sqlite_storage.py
@@ -511,6 +511,24 @@ class SQLiteStorage:
                 raise
 
     @staticmethod
+    def delete_run(project: str, run: str) -> bool:
+        """Delete a run from the database (both metrics and config)."""
+        db_path = SQLiteStorage.get_project_db_path(project)
+        if not db_path.exists():
+            return False
+
+        with SQLiteStorage._get_process_lock(project):
+            with SQLiteStorage._get_connection(db_path) as conn:
+                cursor = conn.cursor()
+                try:
+                    cursor.execute("DELETE FROM metrics WHERE run_name = ?", (run,))
+                    cursor.execute("DELETE FROM configs WHERE run_name = ?", (run,))
+                    conn.commit()
+                    return True
+                except sqlite3.Error:
+                    return False
+
+    @staticmethod
     def get_all_run_configs(project: str) -> dict[str, dict]:
         """Get configurations for all runs in a project."""
         db_path = SQLiteStorage.get_project_db_path(project)

--- a/trackio/ui/main.py
+++ b/trackio/ui/main.py
@@ -428,7 +428,6 @@ css = """
 
 javascript = """
 <script>
-// Cookie management functions
 function setCookie(name, value, days) {
     var expires = "";
     if (days) {
@@ -450,16 +449,13 @@ function getCookie(name) {
     return null;
 }
 
-// Handle write token on page load
 (function() {
     const urlParams = new URLSearchParams(window.location.search);
     const writeToken = urlParams.get('write_token');
     
     if (writeToken) {
-        // Save token to cookie (7 days expiry)
         setCookie('trackio_write_token', writeToken, 7);
         
-        // Remove token from URL for security
         urlParams.delete('write_token');
         const newUrl = window.location.pathname + 
             (urlParams.toString() ? '?' + urlParams.toString() : '') + 

--- a/trackio/ui/main.py
+++ b/trackio/ui/main.py
@@ -469,29 +469,6 @@ function getCookie(name) {
 """
 
 
-def check_write_access(request: gr.Request):
-    """Check if the user has write access based on token validation."""
-    if not hasattr(demo, "write_token"):
-        return False
-
-    # Check cookie first
-    cookies = request.headers.get("cookie", "")
-    if cookies:
-        for cookie in cookies.split(";"):
-            parts = cookie.strip().split("=")
-            if len(parts) == 2 and parts[0] == "trackio_write_token":
-                if parts[1] == demo.write_token:
-                    return True
-
-    # Check query parameter as fallback
-    if hasattr(request, "query_params") and request.query_params:
-        token = request.query_params.get("write_token")
-        if token == demo.write_token:
-            return True
-
-    return False
-
-
 gr.set_static_paths(paths=[utils.MEDIA_DIR])
 
 with gr.Blocks(title="Trackio Dashboard", css=css, head=javascript) as demo:

--- a/trackio/ui/main.py
+++ b/trackio/ui/main.py
@@ -390,16 +390,6 @@ css = """
 .dark .logo-light { display: none; }
 .dark .logo-dark { display: block; }
 .dark .caption-label { color: white; }
-.write-access-badge {
-    background-color: #10b981;
-    color: white;
-    padding: 2px 8px;
-    border-radius: 4px;
-    font-size: 12px;
-    font-weight: 500;
-    margin-bottom: 10px;
-    display: inline-block;
-}
 
 .info-container {
     position: relative;
@@ -502,17 +492,6 @@ def check_write_access(request: gr.Request):
     return False
 
 
-def update_write_access_indicator(request: gr.Request):
-    """Update the write access indicator based on token validation."""
-    has_access = check_write_access(request)
-    if has_access:
-        return gr.HTML(
-            '<div class="write-access-badge">✅ Write access enabled</div>',
-            visible=True,
-        )
-    return gr.HTML(visible=False)
-
-
 gr.set_static_paths(paths=[utils.MEDIA_DIR])
 
 with gr.Blocks(title="Trackio Dashboard", css=css, head=javascript) as demo:
@@ -523,7 +502,6 @@ with gr.Blocks(title="Trackio Dashboard", css=css, head=javascript) as demo:
                 <img src='/gradio_api/file={utils.TRACKIO_LOGO_DIR}/trackio_logo_type_dark_transparent.png' width='80%' class='logo-dark'>            
             """
         )
-        write_access_indicator = gr.HTML(visible=False)
         project_dd = gr.Dropdown(label="Project", allow_custom_value=True)
 
         embed_code = gr.Code(
@@ -587,14 +565,6 @@ with gr.Blocks(title="Trackio Dashboard", css=css, head=javascript) as demo:
         [demo.load],
         fn=fns.get_projects,
         outputs=project_dd,
-        show_progress="hidden",
-        queue=False,
-        api_name=False,
-    )
-    gr.on(
-        [demo.load],
-        fn=update_write_access_indicator,
-        outputs=write_access_indicator,
         show_progress="hidden",
         queue=False,
         api_name=False,

--- a/trackio/ui/runs.py
+++ b/trackio/ui/runs.py
@@ -72,7 +72,7 @@ def get_runs_table(project):
         pinned_columns=2,
         datatype=datatype,
         wrap=True,
-        column_widths=["40px", "100px"],
+        column_widths=["40px", "150px"],
         interactive=True,
         static_columns=list(range(1, len(df.columns))),
         row_count=(len(df), "fixed"),

--- a/trackio/ui/runs.py
+++ b/trackio/ui/runs.py
@@ -1,5 +1,7 @@
 """The Runs page for the Trackio UI."""
 
+import re
+
 import gradio as gr
 import pandas as pd
 
@@ -11,22 +13,6 @@ except ImportError:
     import utils
     from sqlite_storage import SQLiteStorage
     from ui import fns
-
-
-def update_delete_button_access(request: gr.Request):
-    """Update the delete button text based on write access."""
-    has_access = check_write_access_runs(request)
-    if has_access:
-        return gr.Button(
-            "Select and delete run(s)", interactive=False, variant="stop", size="sm"
-        )
-    else:
-        return gr.Button(
-            "⚠️ Need write access to delete runs",
-            interactive=False,
-            variant="secondary",
-            size="sm",
-        )
 
 
 def update_delete_button_interactivity(runs_data, request: gr.Request):
@@ -68,8 +54,6 @@ def delete_selected_runs(runs_data, project, request: gr.Request):
         run_name_raw = runs_data.iloc[idx, 1]
 
         if isinstance(run_name_raw, str) and run_name_raw.startswith("<a href="):
-            import re
-
             match = re.search(r">([^<]+)<", run_name_raw)
             run_name = match.group(1) if match else run_name_raw
         else:

--- a/trackio/ui/runs.py
+++ b/trackio/ui/runs.py
@@ -97,7 +97,7 @@ def check_write_access_runs(request: gr.Request, write_token: str) -> bool:
 def update_delete_button(runs_data, request: gr.Request):
     """Update the delete button value and interactivity based on the runs data and user write access."""
     if not check_write_access_runs(request, run_page.write_token):
-        return
+        return gr.Button("⚠️ Need write access to delete runs", interactive=False)
 
     has_selection = False
     if runs_data is not None and len(runs_data) > 0:

--- a/trackio/ui/runs.py
+++ b/trackio/ui/runs.py
@@ -80,9 +80,23 @@ def get_runs_table(project):
     )
 
 
+def check_write_access_runs(request: gr.Request, write_token: str) -> bool:
+    """Check if the user has write access based on token validation."""
+    cookies = request.headers.get("cookie", "")
+    if cookies:
+        for cookie in cookies.split(";"):
+            parts = cookie.strip().split("=")
+            if len(parts) == 2 and parts[0] == "trackio_write_token":
+                return parts[1] == write_token
+    if hasattr(request, "query_params") and request.query_params:
+        token = request.query_params.get("write_token")
+        return token == write_token
+    return False
+
+
 def update_delete_button(runs_data, request: gr.Request):
     """Update the delete button value and interactivity based on the runs data and user write access."""
-    if not check_write_access_runs(request):
+    if not check_write_access_runs(request, run_page.write_token):
         return
 
     has_selection = False
@@ -111,21 +125,6 @@ def delete_selected_runs(runs_data, project, request: gr.Request):
 
 
 with gr.Blocks() as run_page:
-
-    def check_write_access_runs(request: gr.Request):
-        """Check if the user has write access based on token validation."""
-        write_token = run_page.write_token
-        cookies = request.headers.get("cookie", "")
-        if cookies:
-            for cookie in cookies.split(";"):
-                parts = cookie.strip().split("=")
-                if len(parts) == 2 and parts[0] == "trackio_write_token":
-                    return parts[1] == write_token
-        if hasattr(request, "query_params") and request.query_params:
-            token = request.query_params.get("write_token")
-            return token == write_token
-        return False
-
     with gr.Sidebar() as sidebar:
         logo = gr.Markdown(
             f"""

--- a/trackio/ui/runs.py
+++ b/trackio/ui/runs.py
@@ -147,6 +147,11 @@ with gr.Blocks() as run_page:
             variant="stop",
             size="sm",
         )
+        confirm_btn = gr.Button(
+            "Confirm delete", variant="stop", size="sm", visible=False
+        )
+        cancel_btn = gr.Button("Cancel", size="sm", visible=False)
+
     runs_table = gr.DataFrame()
 
     gr.on(
@@ -193,6 +198,32 @@ with gr.Blocks() as run_page:
 
     gr.on(
         [delete_run_btn.click],
+        fn=lambda: [
+            gr.update(visible=False),
+            gr.update(visible=True),
+            gr.update(visible=True),
+        ],
+        inputs=None,
+        outputs=[delete_run_btn, confirm_btn, cancel_btn],
+        show_progress="hidden",
+        api_name=False,
+        queue=False,
+    )
+    gr.on(
+        [confirm_btn.click, cancel_btn.click],
+        fn=lambda: [
+            gr.update(visible=True),
+            gr.update(visible=False),
+            gr.update(visible=False),
+        ],
+        inputs=None,
+        outputs=[delete_run_btn, confirm_btn, cancel_btn],
+        show_progress="hidden",
+        api_name=False,
+        queue=False,
+    )
+    gr.on(
+        [confirm_btn.click],
         fn=delete_selected_runs,
         inputs=[runs_table, project_dd],
         outputs=[runs_table],

--- a/trackio/ui/runs.py
+++ b/trackio/ui/runs.py
@@ -13,32 +13,6 @@ except ImportError:
     from ui import fns
 
 
-def check_write_access_runs(request: gr.Request):
-    """Check if the user has write access based on token validation."""
-    # Import demo from main to access write_token
-    from trackio.ui.main import demo
-
-    if not hasattr(demo, "write_token"):
-        return False
-
-    # Check cookie first
-    cookies = request.headers.get("cookie", "")
-    if cookies:
-        for cookie in cookies.split(";"):
-            parts = cookie.strip().split("=")
-            if len(parts) == 2 and parts[0] == "trackio_write_token":
-                if parts[1] == demo.write_token:
-                    return True
-
-    # Check query parameter as fallback
-    if hasattr(request, "query_params") and request.query_params:
-        token = request.query_params.get("write_token")
-        if token == demo.write_token:
-            return True
-
-    return False
-
-
 def update_delete_button_access(request: gr.Request):
     """Update the delete button text based on write access."""
     has_access = check_write_access_runs(request)
@@ -48,14 +22,55 @@ def update_delete_button_access(request: gr.Request):
         )
     else:
         return gr.Button(
-            "Need write access to delete runs",
+            "⚠️ Need write access to delete runs",
             interactive=False,
             variant="secondary",
             size="sm",
         )
 
 
+def update_delete_button_interactivity(runs_data, request: gr.Request):
+    if not check_write_access_runs(request):
+        return
+
+    has_selection = False
+    print("runs_data", runs_data)
+    if runs_data is not None and len(runs_data) > 0:
+        first_column = [row[0] if len(row) > 0 else False for row in runs_data]
+        print("first_column", first_column)
+        has_selection = any(first_column)
+
+    if has_selection:
+        return gr.Button("Delete selected run(s)", interactive=True)
+    else:
+        return gr.Button("Select runs to delete", interactive=False)
+
+
 with gr.Blocks() as run_page:
+
+    def check_write_access_runs(request: gr.Request):
+        """Check if the user has write access based on token validation."""
+
+        if not hasattr(run_page, "write_token"):
+            return False
+
+        # Check cookie first
+        cookies = request.headers.get("cookie", "")
+        if cookies:
+            for cookie in cookies.split(";"):
+                parts = cookie.strip().split("=")
+                if len(parts) == 2 and parts[0] == "trackio_write_token":
+                    if parts[1] == run_page.write_token:
+                        return True
+
+        # Check query parameter as fallback
+        if hasattr(request, "query_params") and request.query_params:
+            token = request.query_params.get("write_token")
+            if token == run_page.write_token:
+                return True
+
+        return False
+
     with gr.Sidebar() as sidebar:
         logo = gr.Markdown(
             f"""
@@ -70,7 +85,10 @@ with gr.Blocks() as run_page:
     with gr.Row():
         gr.Markdown("")
         delete_run_btn = gr.Button(
-            "Select and delete run(s)", interactive=False, variant="stop", size="sm"
+            "⚠️ Need write access to delete runs",
+            interactive=False,
+            variant="stop",
+            size="sm",
         )
     runs_table = gr.DataFrame()
 
@@ -97,30 +115,37 @@ with gr.Blocks() as run_page:
                 else x
             )
 
+        # Add a column of False values as the first column
+        df.insert(0, " ", False)
+
         columns = list(df.columns)
         if "Username" in columns and "Created" in columns:
             columns.remove("Username")
             columns.remove("Created")
-            columns.insert(1, "Username")
-            columns.insert(2, "Created")
+            columns.insert(2, "Username")  # Shift right due to new Select column
+            columns.insert(3, "Created")  # Shift right due to new Select column
             df = df[columns]
 
+        # Create datatype list: first column is bool, rest are markdown
+        datatype = ["bool"] + ["markdown"] * (len(df.columns) - 1)
+
         return gr.DataFrame(
-            df, visible=True, pinned_columns=1, datatype="markdown", wrap=True
+            df,
+            visible=True,
+            pinned_columns=2,
+            datatype=datatype,
+            wrap=True,
+            column_widths=["40px", "100px"],
+            interactive=True,
+            static_columns=list(range(1, len(df.columns))),
+            row_count=(len(df), "fixed"),
+            col_count=(len(df.columns), "fixed"),
         )
 
     gr.on(
         [run_page.load],
         fn=fns.get_projects,
         outputs=project_dd,
-        show_progress="hidden",
-        queue=False,
-        api_name=False,
-    )
-    gr.on(
-        [run_page.load],
-        fn=update_delete_button_access,
-        outputs=delete_run_btn,
         show_progress="hidden",
         queue=False,
         api_name=False,
@@ -144,6 +169,16 @@ with gr.Blocks() as run_page:
         fns.update_navbar_value,
         inputs=[project_dd],
         outputs=[navbar],
+        show_progress="hidden",
+        api_name=False,
+        queue=False,
+    )
+
+    gr.on(
+        [runs_table.change],
+        fn=update_delete_button_interactivity,
+        inputs=[runs_table],
+        outputs=[delete_run_btn],
         show_progress="hidden",
         api_name=False,
         queue=False,

--- a/trackio/ui/runs.py
+++ b/trackio/ui/runs.py
@@ -39,15 +39,20 @@ def check_write_access_runs(request: gr.Request):
     return False
 
 
-def update_write_access_indicator_runs(request: gr.Request):
-    """Update the write access indicator based on token validation."""
+def update_delete_button_access(request: gr.Request):
+    """Update the delete button text based on write access."""
     has_access = check_write_access_runs(request)
     if has_access:
-        return gr.HTML(
-            '<div style="background-color: #10b981; color: white; padding: 2px 8px; border-radius: 4px; font-size: 12px; font-weight: 500; margin-bottom: 10px; display: inline-block;">✅ Write access enabled</div>',
-            visible=True,
+        return gr.Button(
+            "Select and delete run(s)", interactive=False, variant="stop", size="sm"
         )
-    return gr.HTML(visible=False)
+    else:
+        return gr.Button(
+            "Need write access to delete runs",
+            interactive=False,
+            variant="secondary",
+            size="sm",
+        )
 
 
 with gr.Blocks() as run_page:
@@ -58,11 +63,15 @@ with gr.Blocks() as run_page:
                 <img src='/gradio_api/file={utils.TRACKIO_LOGO_DIR}/trackio_logo_type_dark_transparent.png' width='80%' class='logo-dark'>            
             """
         )
-        write_access_indicator = gr.HTML(visible=False)
         project_dd = gr.Dropdown(label="Project", allow_custom_value=True)
 
     navbar = gr.Navbar(value=[("Metrics", ""), ("Runs", "/runs")], main_page_name=False)
     timer = gr.Timer(value=1)
+    with gr.Row():
+        gr.Markdown("")
+        delete_run_btn = gr.Button(
+            "Select and delete run(s)", interactive=False, variant="stop", size="sm"
+        )
     runs_table = gr.DataFrame()
 
     def get_runs_table(project):
@@ -110,8 +119,8 @@ with gr.Blocks() as run_page:
     )
     gr.on(
         [run_page.load],
-        fn=update_write_access_indicator_runs,
-        outputs=write_access_indicator,
+        fn=update_delete_button_access,
+        outputs=delete_run_btn,
         show_progress="hidden",
         queue=False,
         api_name=False,

--- a/trackio/ui/runs.py
+++ b/trackio/ui/runs.py
@@ -99,13 +99,13 @@ def update_delete_button(runs_data, request: gr.Request):
     if not check_write_access_runs(request, run_page.write_token):
         return gr.Button("⚠️ Need write access to delete runs", interactive=False)
 
-    has_selection = False
+    num_selected = 0
     if runs_data is not None and len(runs_data) > 0:
         first_column_values = runs_data.iloc[:, 0].tolist()
-        has_selection = any(first_column_values)
+        num_selected = sum(1 for x in first_column_values if x)
 
-    if has_selection:
-        return gr.Button("Delete selected run(s)", interactive=True)
+    if num_selected:
+        return gr.Button(f"Delete {num_selected} selected run(s)", interactive=True)
     else:
         return gr.Button("Select runs to delete", interactive=False)
 
@@ -140,17 +140,20 @@ with gr.Blocks() as run_page:
     navbar = gr.Navbar(value=[("Metrics", ""), ("Runs", "/runs")], main_page_name=False)
     timer = gr.Timer(value=1)
     with gr.Row():
-        gr.Markdown("")  # Just here to push the delete button to the right
-        delete_run_btn = gr.Button(
-            "⚠️ Need write access to delete runs",
-            interactive=False,
-            variant="stop",
-            size="sm",
-        )
-        confirm_btn = gr.Button(
-            "Confirm delete", variant="stop", size="sm", visible=False
-        )
-        cancel_btn = gr.Button("Cancel", size="sm", visible=False)
+        with gr.Column():
+            pass
+        with gr.Column():
+            with gr.Row():
+                delete_run_btn = gr.Button(
+                    "⚠️ Need write access to delete runs",
+                    interactive=False,
+                    variant="stop",
+                    size="sm",
+                )
+                confirm_btn = gr.Button(
+                    "Confirm delete", variant="stop", size="sm", visible=False
+                )
+                cancel_btn = gr.Button("Cancel", size="sm", visible=False)
 
     runs_table = gr.DataFrame()
 
@@ -199,9 +202,9 @@ with gr.Blocks() as run_page:
     gr.on(
         [delete_run_btn.click],
         fn=lambda: [
-            gr.update(visible=False),
-            gr.update(visible=True),
-            gr.update(visible=True),
+            gr.Button(visible=False),
+            gr.Button(visible=True),
+            gr.Button(visible=True),
         ],
         inputs=None,
         outputs=[delete_run_btn, confirm_btn, cancel_btn],
@@ -212,9 +215,9 @@ with gr.Blocks() as run_page:
     gr.on(
         [confirm_btn.click, cancel_btn.click],
         fn=lambda: [
-            gr.update(visible=True),
-            gr.update(visible=False),
-            gr.update(visible=False),
+            gr.Button(visible=True),
+            gr.Button(visible=False),
+            gr.Button(visible=False),
         ],
         inputs=None,
         outputs=[delete_run_btn, confirm_btn, cancel_btn],

--- a/trackio/ui/runs.py
+++ b/trackio/ui/runs.py
@@ -112,6 +112,9 @@ def update_delete_button(runs_data, request: gr.Request):
 
 def delete_selected_runs(runs_data, project, request: gr.Request):
     """Delete the selected runs and refresh the table."""
+    if not check_write_access_runs(request, run_page.write_token):
+        return runs_data
+
     first_column_values = runs_data.iloc[:, 0].tolist()
     for i, selected in enumerate(first_column_values):
         if selected:

--- a/trackio/ui/runs.py
+++ b/trackio/ui/runs.py
@@ -76,7 +76,7 @@ with gr.Blocks() as run_page:
     navbar = gr.Navbar(value=[("Metrics", ""), ("Runs", "/runs")], main_page_name=False)
     timer = gr.Timer(value=1)
     with gr.Row():
-        gr.Markdown("")
+        gr.Markdown("")  # Just here to push the delete button to the right
         delete_run_btn = gr.Button(
             "⚠️ Need write access to delete runs",
             interactive=False,


### PR DESCRIPTION
* Adds support for deleting runs through the Trackio UI, as requested in #157
* Note that this introduces a security risk: what if a different user accesses the Trackio dashboard (via SSH tunneling or gradio's share links), that user should NOT be able to delete runs. To address this, I've added a token-based authentication system similar to Jupyter notebooks. So now, `trackio show` generates a token on server startup and saves it through cookies and URL parameters. 
* This auth mechanism will provides write access control for future features as well.
* Note that this auth mechanism will not work on Spaces. Instead, if running on Spaces, I will replace this with a `gr.LoginButton` that can be used to oauth via Hugging Face. In that case, any user with write access to the namespace will be able to delete runs (in the same way that they can currently log runs).

Partially addresses https://github.com/gradio-app/trackio/issues/157, will close that issue once we have deleting runs supported on Spaces as well.

If you have write access, the flow looks like this (note that I'm deleting runs while other runs are being logged, so the number of runs doesn't seem to change in the first step):


https://github.com/user-attachments/assets/9c9e3e75-6c66-49f0-97aa-a8338317c0b0



If you don't, you can't click on the delete button:

https://github.com/user-attachments/assets/2c59c5fd-dedd-473f-ad68-ea35cd3776f7




I am aware that there are some UI hiccups (like the column of "true"s showing up in the dataframe). Those are bugs in Gradio that will need to be fixed upstream.

cc @lewtun for visibility