### PR TITLE
Add index on metrics(run_name, timestamp) for improved query performance

### DIFF
--- a/trackio/sqlite_storage.py
+++ b/trackio/sqlite_storage.py
@@ -141,6 +141,12 @@ class SQLiteStorage:
                     ON configs(run_name)
                     """
                 )
+                cursor.execute(
+                    """
+                    CREATE INDEX IF NOT EXISTS idx_metrics_run_timestamp
+                    ON metrics(run_name, timestamp)
+                    """
+                )
                 conn.commit()
         return db_path
 


### PR DESCRIPTION
Since query is ordered by timestamp.
https://github.com/gradio-app/trackio/blob/9daeadf7d1b7c89903a34b965c5c3f4b37c6f8e8/trackio/sqlite_storage.py#L374-L378