### PR TITLE
Suppress httpx INFO logs by default

### DIFF
--- a/trackio/__init__.py
+++ b/trackio/__init__.py
@@ -12,8 +12,6 @@ from gradio.themes import ThemeClass
 from gradio_client import Client
 from huggingface_hub import SpaceStorage
 
-logging.getLogger("httpx").setLevel(logging.WARNING)
-
 from trackio import context_vars, deploy, utils
 from trackio.imports import import_csv, import_tf_events
 from trackio.media import TrackioImage, TrackioVideo
@@ -22,6 +20,8 @@ from trackio.sqlite_storage import SQLiteStorage
 from trackio.table import Table
 from trackio.ui.main import demo
 from trackio.utils import TRACKIO_DIR, TRACKIO_LOGO_DIR
+
+logging.getLogger("httpx").setLevel(logging.WARNING)
 
 __version__ = Path(__file__).parent.joinpath("version.txt").read_text().strip()
 


### PR DESCRIPTION
Adds logging configuration to suppress httpx INFO level logs by setting the httpx logger to WARNING level. Prevents HTTP request logs from cluttering training output while still allowing warnings and errors to appear. Test with a script like this:

```py
import logging
import sys

logging.basicConfig(
    level=logging.INFO, format="%(levelname)-8s %(name)-15s %(message)s"
)

import trackio

try:
    from gradio_client import Client

    # This will make HTTP requests that normally produce httpx INFO logs
    print("\nAttempting connection to a Hugging Face Space...\n")
    try:
        client = Client("abidlabs/en2fr", verbose=False)
        print("\n✓ Connection attempt completed")
    except Exception as e:
        print(
            f"\n✓ Connection failed (expected): {e[:100] if len(str(e)) > 100 else e}"
        )

except ImportError:
    print("gradio_client not available")
```

Closes: https://github.com/gradio-app/trackio/issues/258