### PR TITLE
fix: #280 NotADirectoryError message and fixed test_import_export test.

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,7 +11,7 @@ from trackio.video_writer import write_video
 @pytest.fixture
 def temp_dir(monkeypatch):
     """Fixture that creates a temporary TRACKIO_DIR."""
-    with tempfile.TemporaryDirectory() as tmpdir:
+    with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
         for name in ["trackio.sqlite_storage"]:
             monkeypatch.setattr(f"{name}.TRACKIO_DIR", Path(tmpdir))
         for name in ["trackio.media", "trackio.file_storage"]:

--- a/tests/test_sqlite_storage.py
+++ b/tests/test_sqlite_storage.py
@@ -1,3 +1,4 @@
+import gc
 import multiprocessing
 import os
 import platform
@@ -65,16 +66,20 @@ def test_import_export(temp_dir):
     SQLiteStorage.log(project="proj1", run="run1", metrics={"a": 1})
     SQLiteStorage.log(project="proj2", run="run2", metrics={"b": 2})
     SQLiteStorage.export_to_parquet()
+
     metrics_before = {}
     for proj in SQLiteStorage.get_projects():
         if proj not in metrics_before:
             metrics_before[proj] = {}
         for run in SQLiteStorage.get_runs(proj):
             metrics_before[proj][run] = SQLiteStorage.get_logs(proj, run)
-
+    
+    ## there might be open connections from previous test, hence closing them
+    gc.collect()
+    [conn.close() for conn in gc.get_objects() if isinstance(conn, sqlite3.Connection)]
     # clear existing SQLite data
-    os.unlink(db_path_1)
-    os.unlink(db_path_2)
+    os.remove(db_path_1)
+    os.remove(db_path_2)
 
     # import from parquet, compare copies
     SQLiteStorage.import_from_parquet()

--- a/tests/test_sqlite_storage.py
+++ b/tests/test_sqlite_storage.py
@@ -73,7 +73,7 @@ def test_import_export(temp_dir):
             metrics_before[proj] = {}
         for run in SQLiteStorage.get_runs(proj):
             metrics_before[proj][run] = SQLiteStorage.get_logs(proj, run)
-    
+
     ## there might be open connections from previous test, hence closing them
     gc.collect()
     [conn.close() for conn in gc.get_objects() if isinstance(conn, sqlite3.Connection)]

--- a/tests/test_sqlite_storage.py
+++ b/tests/test_sqlite_storage.py
@@ -78,8 +78,8 @@ def test_import_export(temp_dir):
     gc.collect()
     [conn.close() for conn in gc.get_objects() if isinstance(conn, sqlite3.Connection)]
     # clear existing SQLite data
-    os.remove(db_path_1)
-    os.remove(db_path_2)
+    os.unlink(db_path_1)
+    os.unlink(db_path_2)
 
     # import from parquet, compare copies
     SQLiteStorage.import_from_parquet()


### PR DESCRIPTION
Thank you for your contribution! All PRs should include the following sections. PRs missing these sections may be closed immediately.


This PR resolves fixes: #280 and also fixed the issue with test_import_export, where in windows, we were not able to close the database connection, I have used garbage collection to previous connections. 

## AI Disclosure

We encourage the use of AI tooling in creating PRs, but the any non-trivial use of AI needs be disclosed. E.g. if you used Claude to write a first draft, you should mention that. Trivial tab-completion doesn't need to be disclosed. **You should self-review all PRs, especially if they were generated with AI**. 

-----

- I did not use AI to fix this, it was a simple fix. 

----

## Type of Change

- [ x] Bug fix
- [ ] New feature (non-breaking)
- [ ] New feature (breaking change)
- [ ] Documentation update
- [ x] Test improvements

## Related Issues

If this PR closes an issue, please link it below: 

Closes: #280 

## Testing and linting

Please run tests before submitting changes:
   ```bash
   python -m pytest
   ```

and format your code using Ruff:

   ```bash
   ruff check --fix --select I && ruff format
   ```
