### PR TITLE
feat: add first-class audio logging

### DIFF
--- a/tests/test_audio_logging.py
+++ b/tests/test_audio_logging.py
@@ -1,0 +1,25 @@
+# tests/test_audio_smoke.py
+import numpy as np
+
+from trackio.media import TrackioAudio as Audio
+from trackio.sqlite_storage import SQLiteStorage
+
+
+def test_audio_array(tmp_path, monkeypatch):
+    monkeypatch.setenv("TRACKIO_HOME", str(tmp_path))
+    project, run = "audio-proj", "audio-run"
+    SQLiteStorage.init_db(project)
+
+    y = np.zeros(16000, dtype=float)  # 1 sec silence @ 16k
+    SQLiteStorage.bulk_log(
+        project=project,
+        run=run,
+        metrics_list=[{"clip": Audio(y, sample_rate=16000)}],
+        steps=[0],
+        timestamps=[""],
+    )
+
+    logs = SQLiteStorage.get_logs(project, run)
+    payload = logs[0]["clip"]
+    assert payload["_type"] == "trackio.audio"
+    assert payload["file_path"].endswith(".wav")

--- a/trackio/__init__.py
+++ b/trackio/__init__.py
@@ -14,7 +14,7 @@ from huggingface_hub import SpaceStorage
 
 from trackio import context_vars, deploy, utils
 from trackio.imports import import_csv, import_tf_events
-from trackio.media import TrackioImage, TrackioVideo
+from trackio.media import TrackioAudio, TrackioImage, TrackioVideo
 from trackio.run import Run
 from trackio.sqlite_storage import SQLiteStorage
 from trackio.table import Table
@@ -42,10 +42,12 @@ __all__ = [
     "Image",
     "Video",
     "Table",
+    "Audio",
 ]
 
 Image = TrackioImage
 Video = TrackioVideo
+Audio = TrackioAudio
 
 
 config = {}


### PR DESCRIPTION

## Short description

This PR adds first-class support for logging audio clips in Trackio.
It introduces a new trackio.Audio media type that allows users to log and visualize audio alongside scalar metrics, similar to existing Image and Video media.
Audio can be logged either from NumPy arrays (with a sample rate) or directly from file paths. Files are persisted as .wav under the project’s media directory and stored as lightweight JSON references in SQLite.

This feature fulfills Issue #251 and enables richer experiment tracking for speech, sound, and audio ML workflows.

## AI Disclosure


-----

- [x] I used AI to assist with summarization and writing this PR description.
- [ ] I did not use AI

----

## Type of Change

- [ ] Bug fix
- [x] New feature (non-breaking)
- [ ] New feature (breaking change)
- [ ] Documentation update
- [ ] Test improvements

## Related Issues

Closes:  https://github.com/gradio-app/trackio/issues/251

## Testing and linting

Please run tests before submitting changes:
   ```bash
   python -m pytest                                    
================================================== test session starts ==================================================
platform darwin -- Python 3.11.9, pytest-8.4.2, pluggy-1.6.0
rootdir: /Users/vaibhavpandey/Projects/trackio
configfile: pyproject.toml
plugins: anyio-4.11.0
collected 49 items                                                                                                      

tests/e2e/test_basic_logging.py ....                                                                              [  8%]
tests/e2e/test_bulk_logging.py .                                                                                  [ 10%]
tests/e2e/test_image_logging.py .                                                                                 [ 12%]
tests/e2e/test_import_from_csv.py .                                                                               [ 14%]
tests/e2e/test_import_from_tf.py .                                                                                [ 16%]
tests/test_audio_logging.py .                                                                                     [ 18%]
tests/test_media.py ........                                                                                      [ 34%]
tests/test_run.py ......                                                                                          [ 46%]
tests/test_sqlite_storage.py ........                                                                             [ 63%]
tests/test_token_auth.py .                                                                                        [ 65%]
tests/test_utils.py .................                                                                             [100%]

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=========================================== 49 passed, 131 warnings in 14.52s ===========================================

   ```

and format your code using Ruff:

   ```bash
   ruff check --fix --select I && ruff format
All checks passed!
44 files left unchanged
   ```
