### PR TITLE
Bump huggingface_hub to allow 0.x and 1.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
     "pandas<3.0.0",
-    "huggingface-hub<1.0.0",
+    "huggingface-hub<2.0.0",
     "gradio>=5.44.0,<6.0.0",
     "numpy<3.0.0",
     "pillow<12.0.0",


### PR DESCRIPTION
Wondering if there is any hard limit on not supporting huggingface_hub v1.x ? This PR does allow both 0.x and 1.x which is the expected behavior for libraries for the HF ecosystem (at the notable exception of `transformers` which support 0.x in its 4.x version, and 1.x in its upcoming 5.x version).