### PR TITLE
Enable moving a run between multiple projects

### DIFF
--- a/debug_move_run.py
+++ b/debug_move_run.py
@@ -1,7 +1,6 @@
-
 import os
-import sys
 import shutil
+import sys
 from pathlib import Path
 
 # Add current dir to path so we can import trackio
@@ -13,6 +12,7 @@ except ImportError:
     print("Could not import trackio.sqlite_storage")
     sys.exit(1)
 
+
 def test_move_run():
     print("Setting up test...")
     # Setup temp dir
@@ -20,41 +20,43 @@ def test_move_run():
     if test_dir.exists():
         shutil.rmtree(test_dir)
     test_dir.mkdir()
-    
+
     # Mock TRACKIO_DIR
     import trackio.sqlite_storage
+
     trackio.sqlite_storage.TRACKIO_DIR = test_dir
-    
+
     src_proj = "src_proj"
     dst_proj = "dst_proj"
     run_name = "test_run"
-    
+
     print("Creating run in source...")
     SQLiteStorage.log(src_proj, run_name, {"accuracy": 0.8}, step=1)
     SQLiteStorage.store_config(src_proj, run_name, {"param": "value"})
-    
+
     logs = SQLiteStorage.get_logs(src_proj, run_name)
     with open("debug_result.txt", "w") as f:
         f.write(f"Source logs: {len(logs)}\n")
-        
+
         print("Moving run...")
         success = SQLiteStorage.move_run(src_proj, dst_proj, run_name)
         f.write(f"Move result: {success}\n")
-        
+
         print("Verifying destination...")
         dst_logs = SQLiteStorage.get_logs(dst_proj, run_name)
         f.write(f"Dest logs: {len(dst_logs)}\n")
         dst_config = SQLiteStorage.get_run_config(dst_proj, run_name)
         f.write(f"Dest config: {dst_config}\n")
-        
+
         print("Verifying source...")
         src_logs = SQLiteStorage.get_logs(src_proj, run_name)
         f.write(f"Source logs: {len(src_logs)}\n")
-        
+
         if success and len(dst_logs) == 1 and len(src_logs) == 0:
             f.write("SUCCESS: Run moved correctly.\n")
         else:
             f.write("FAILURE: Run move failed.\n")
+
 
 if __name__ == "__main__":
     test_move_run()

--- a/examples/transformers-integration.py
+++ b/examples/transformers-integration.py
@@ -8,9 +8,15 @@
 # ///
 
 import os
-from datasets import Dataset
-from transformers import AutoModelForSequenceClassification, AutoTokenizer, Trainer, TrainingArguments
+
 import huggingface_hub
+from datasets import Dataset
+from transformers import (
+    AutoModelForSequenceClassification,
+    AutoTokenizer,
+    Trainer,
+    TrainingArguments,
+)
 
 model_name = "distilbert-base-uncased"
 tokenizer = AutoTokenizer.from_pretrained(model_name)
@@ -38,7 +44,6 @@ trainer = Trainer(
         report_to="trackio",
         push_to_hub=bool(hub_model_id),
         hub_model_id=hub_model_id,
-
     ),
     train_dataset=dataset,
 )
@@ -47,4 +52,3 @@ trainer.train()
 trainer.push_to_hub()
 
 print(f"Model pushed to Hub, available at: https://huggingface.co/{hub_model_id}")
-

--- a/tests/unit/test_move_run.py
+++ b/tests/unit/test_move_run.py
@@ -1,29 +1,26 @@
-
-import os
-import sqlite3
-import pytest
 from trackio.sqlite_storage import SQLiteStorage
+
 
 def test_move_run_success(temp_dir):
     # Setup
     src_proj = "src_proj"
     dst_proj = "dst_proj"
     run_name = "test_run"
-    
+
     # 1. Create run in source
     SQLiteStorage.log(src_proj, run_name, {"accuracy": 0.8}, step=1)
     SQLiteStorage.store_config(src_proj, run_name, {"param": "value"})
     SQLiteStorage.bulk_log_system(src_proj, run_name, [{"cpu": 10}])
-    
+
     # Verify creation
     assert len(SQLiteStorage.get_logs(src_proj, run_name)) == 1
     assert SQLiteStorage.get_run_config(src_proj, run_name) is not None
     assert len(SQLiteStorage.get_system_logs(src_proj, run_name)) == 1
-    
+
     # 2. Move run
     success = SQLiteStorage.move_run(src_proj, dst_proj, run_name)
     assert success is True
-    
+
     # 3. Verify destination
     assert len(SQLiteStorage.get_logs(dst_proj, run_name)) == 1
     assert SQLiteStorage.get_logs(dst_proj, run_name)[0]["step"] == 1
@@ -31,39 +28,42 @@ def test_move_run_success(temp_dir):
     assert config is not None
     assert config["param"] == "value"
     assert len(SQLiteStorage.get_system_logs(dst_proj, run_name)) == 1
-    
+
     # 4. Verify source (should be empty)
     assert len(SQLiteStorage.get_logs(src_proj, run_name)) == 0
     assert SQLiteStorage.get_run_config(src_proj, run_name) is None
+
 
 def test_move_run_target_exists(temp_dir):
     src_proj = "src_proj"
     dst_proj = "dst_proj"
     run_name = "conflict_run"
-    
+
     # Create in both
     SQLiteStorage.log(src_proj, run_name, {"a": 1})
     SQLiteStorage.log(dst_proj, run_name, {"b": 2})
-    
+
     # Attempt move
     success = SQLiteStorage.move_run(src_proj, dst_proj, run_name)
     assert success is False
-    
+
     # Verify no changes
     logs_src = SQLiteStorage.get_logs(src_proj, run_name)
     assert logs_src[0]["a"] == 1
-    
+
     logs_dst = SQLiteStorage.get_logs(dst_proj, run_name)
     assert logs_dst[0]["b"] == 2
+
 
 def test_move_run_source_not_found(temp_dir):
     success = SQLiteStorage.move_run("non_existent", "dst", "run")
     assert success is False
-    
+
     # Create empty source project
     SQLiteStorage.init_db("empty_src")
     success = SQLiteStorage.move_run("empty_src", "dst", "missing_run")
     assert success is False
+
 
 def test_move_run_same_project(temp_dir):
     success = SQLiteStorage.move_run("p1", "p1", "r1")


### PR DESCRIPTION
##summary
Implements support for moving a run between multiple projects.

## Changes
- Added move run debug script
- Added unit tests for move run functionality
- updated SQLite storage to support moving runs

## Tests 
- All unit tests pass locally using Pytest

Closes #120 
