### PR TITLE
fix metric layout

### DIFF
--- a/trackio/ui/system_page.py
+++ b/trackio/ui/system_page.py
@@ -187,7 +187,6 @@ trackio.log_gpu()
         all_runs = selection.choices if selection else original_runs
         color_map = utils.get_color_mapping(all_runs, False)
 
-        metric_idx = 0
         for group_name in ordered_groups:
             group_data = nested_metric_groups[group_name]
 
@@ -213,7 +212,9 @@ trackio.log_gpu()
             ):
                 if group_data["direct_metrics"]:
                     with gr.Draggable(
-                        key=f"sys-row-{group_name}-direct", orientation="row"
+                        key=f"sys-row-{group_name}-direct",
+                        orientation="row",
+                        preserved_by_key=["children"],
                     ):
                         for metric_name in group_data["direct_metrics"]:
                             metric_df = master_df.dropna(subset=[metric_name])
@@ -226,6 +227,8 @@ trackio.log_gpu()
                                 x_lim_value,
                             )
                             if not metric_df.empty:
+                                # Use stable key based on metric name, not loop index
+                                safe_metric_key = metric_name.replace("/", "-").replace(" ", "_")
                                 plot = gr.LinePlot(
                                     downsampled_df,
                                     x=x_column,
@@ -236,8 +239,8 @@ trackio.log_gpu()
                                     color_map=color_map,
                                     colors_in_legend=original_runs,
                                     title=metric_name,
-                                    key=f"sys-plot-{metric_idx}",
-                                    preserved_by_key=None,
+                                    key=f"sys-plot-{group_name}-{safe_metric_key}",
+                                    preserved_by_key=["value"],
                                     buttons=["fullscreen", "export"],
                                     x_lim=updated_x_lim,
                                     min_width=400,
@@ -245,14 +248,13 @@ trackio.log_gpu()
                                 plot.select(
                                     update_x_lim,
                                     outputs=x_lim,
-                                    key=f"sys-select-{metric_idx}",
+                                    key=f"sys-select-{group_name}-{safe_metric_key}",
                                 )
                                 plot.double_click(
                                     lambda: None,
                                     outputs=x_lim,
-                                    key=f"sys-double-{metric_idx}",
+                                    key=f"sys-double-{group_name}-{safe_metric_key}",
                                 )
-                            metric_idx += 1
 
                 if group_data["subgroups"]:
                     for subgroup_name in sorted(group_data["subgroups"].keys()):
@@ -278,6 +280,7 @@ trackio.log_gpu()
                             with gr.Draggable(
                                 key=f"sys-row-{group_name}-{subgroup_name}",
                                 orientation="row",
+                                preserved_by_key=["children"],
                             ):
                                 for metric_name in subgroup_metrics:
                                     metric_df = master_df.dropna(subset=[metric_name])
@@ -292,6 +295,8 @@ trackio.log_gpu()
                                         x_lim_value,
                                     )
                                     if not metric_df.empty:
+                                        # Use stable key based on metric name, not loop index
+                                        safe_metric_key = metric_name.replace("/", "-").replace(" ", "_")
                                         plot = gr.LinePlot(
                                             downsampled_df,
                                             x=x_column,
@@ -302,8 +307,8 @@ trackio.log_gpu()
                                             color_map=color_map,
                                             colors_in_legend=original_runs,
                                             title=metric_name,
-                                            key=f"sys-plot-{metric_idx}",
-                                            preserved_by_key=None,
+                                            key=f"sys-plot-{group_name}-{subgroup_name}-{safe_metric_key}",
+                                            preserved_by_key=["value"],
                                             buttons=["fullscreen", "export"],
                                             x_lim=updated_x_lim,
                                             min_width=400,
@@ -311,14 +316,13 @@ trackio.log_gpu()
                                         plot.select(
                                             update_x_lim,
                                             outputs=x_lim,
-                                            key=f"sys-select-{metric_idx}",
+                                            key=f"sys-select-{group_name}-{subgroup_name}-{safe_metric_key}",
                                         )
                                         plot.double_click(
                                             lambda: None,
                                             outputs=x_lim,
-                                            key=f"sys-double-{metric_idx}",
+                                            key=f"sys-double-{group_name}-{subgroup_name}-{safe_metric_key}",
                                         )
-                                    metric_idx += 1
 
     gr.on(
         [timer.tick],


### PR DESCRIPTION
Closes : #260 

Thank you for your contribution! All PRs should include the following sections. PRs missing these sections may be closed immediately.

## Short description

This PR ensures that the metric layout is preserved across axis changes and run modifications. Previously, the layout would reset when switching the X-axis counter (e.g., from step to epoch) or when removing a run from the display list. With this update, the layout remains intact until the user explicitly refreshes the screen, improving usability and consistency in metric visualization.

## AI Disclosure

We encourage the use of AI tooling in creating PRs, but the any non-trivial use of AI needs be disclosed. E.g. if you used Claude to write a first draft, you should mention that. Trivial tab-completion doesn't need to be disclosed. **You should self-review all PRs, especially if they were generated with AI**. 

-----

- [x] I used AI to write docs.
- [ ] I did not use AI

----

## Type of Change

- [x] Bug fix
- [ ] New feature (non-breaking)
- [ ] New feature (breaking change)
- [ ] Documentation update
- [ ] Test improvements

## Related Issues

If this PR closes an issue, please link it below:

Closes: #260 

## Testing and linting

Please run tests before submitting changes:
   ```bash
   python -m pytest
   ```

and format your code using Ruff:

   ```bash
   ruff check --fix --select I && ruff format
   ```
