### PR TITLE
fix URL of images in media gallery

### DIFF
--- a/trackio/ui/media_page.py
+++ b/trackio/ui/media_page.py
@@ -1,5 +1,6 @@
 """The Media and Tables page for the Trackio UI."""
 
+import os
 import re
 from dataclasses import dataclass
 
@@ -112,7 +113,11 @@ with gr.Blocks() as media_page:
         show_progress="hidden",
         queue=False,
     )
-    def display_media_and_tables(project: str | None, selected_run: str | None):
+    def display_media_and_tables(
+        project: str | None,
+        selected_run: str | None,
+        request: gr.Request,
+    ):
         if not project or not selected_run:
             gr.Markdown("*Select a project and run to view media and tables*")
             return
@@ -153,8 +158,20 @@ with gr.Blocks() as media_page:
                 ]
                 audio = [item for item in media_items if item.type == TrackioAudio.TYPE]
                 if image_and_video:
+                    if os.environ.get("GRADIO_ROOT_PATH"):
+                        gallery_items = [
+                            (item.file_path, item.caption) for item in image_and_video
+                        ]
+                    else:
+                        gallery_items = [
+                            (
+                                f"{request.base_url}gradio_api/file={item.file_path}",
+                                item.caption,
+                            )
+                            for item in image_and_video
+                        ]
                     gr.Gallery(
-                        [(item.file_path, item.caption) for item in image_and_video],
+                        value=gallery_items,
                         label=key,
                         columns=6,
                         elem_classes=("media-gallery"),


### PR DESCRIPTION
## Short description

This PR fixes a bug where in some cases, in particular when using a SSH tunnel, URLs of images are incorrect and include `gradio_api` twice, e.g. `http://127.0.0.1:7861/gradio_api/run/predict/gradio_api/file=...`. A workaround is setting `GRADIO_ROOT_PATH` but it must be set e.g. to `http://127.0.0.1:7861/` (the empty string does not work, `/` works for this component but breaks the rest of the app).

To avoid this we construct the HTTP URL instead of passing the file path when `GRADIO_ROOT_PATH` is unset.

## AI Disclosure

I used AI (Claude Code and Gemini) to investigate the problem, but I wrote the patch without assistance.

----

## Type of Change

- [x] Bug fix
- [ ] New feature (non-breaking)
- [ ] New feature (breaking change)
- [ ] Documentation update
- [ ] Test improvements

## Related Issues

None I know about.

## Testing and linting

Code is linted / formatted.

I could not run all the tests because of dependency problems but those I could run pass.

