### PR TITLE
Remove manual changeset approval requirement

### DIFF
--- a/.github/workflows/generate-changeset.yml
+++ b/.github/workflows/generate-changeset.yml
@@ -83,7 +83,7 @@ jobs:
           token: ${{ secrets.COMMIT_STATUS }}
           name: "Changeset Results"
           pr: ${{ needs.get-pr.outputs.pr_number }}
-          result: ${{ needs.version.outputs.approved == 'true' && 'success' || 'failure' }}
+          result: 'success'
           type: all
   comment-changes-skipped:
     uses: "./.github/workflows/comment-queue.yml"


### PR DESCRIPTION
This PR removes the requirement for maintainers to manually check a box to approve the changeset. The changeset workflow will now automatically pass when the changeset is successfully generated, without requiring manual confirmation.

Previously, the commit status was set based on an 'approved' output that required manual checkbox confirmation. Now it simply succeeds when the version job completes successfully.