### PR TITLE
fix: use GitHub-hosted image URL in RapidFire AI integration docs

### DIFF
--- a/docs/source/rapidfireai_integration.md
+++ b/docs/source/rapidfireai_integration.md
@@ -147,7 +147,7 @@ trackio.show(project="my-sft-experiment")
 
 The dashboard displays real-time training curves for all your runs, making it easy to compare configurations side-by-side:
 
-![Trackio dashboard showing RapidFire AI fine-tuning metrics](./trackio-screenshot-sft.png)
+![Trackio dashboard showing RapidFire AI fine-tuning metrics](https://github.com/user-attachments/assets/3c239fb9-3f07-4297-a3f3-1c51d9181eac)
 
 *Trackio dashboard comparing 4 fine-tuning runs with different hyperparameters. The plots show training loss, validation loss, learning rate schedules, and ROUGE-L scores—making it easy to identify which configuration (Run 4, in orange) achieves the lowest loss and best generation quality.*
 


### PR DESCRIPTION
## Summary

Fixes broken image rendering in the RapidFire AI integration documentation.

**Problem:**
The local relative path `./trackio-screenshot-sft.png` does not render on the HuggingFace docs site at https://huggingface.co/docs/trackio/rapidfireai_integration

**Fix:**
Replace with the GitHub user-attachments URL:
`https://github.com/user-attachments/assets/3c239fb9-3f07-4297-a3f3-1c51d9181eac`

This follows the same pattern used by other docs in the repo (e.g., `index.md`, `deploy_embed.md`).

**Note:** This is a clean re-submission of #417, rebased directly on the current `main` with no conflicts — only the single-line image URL change.