### PR TITLE
Fix duplicate columns in parquet export

### DIFF
--- a/.changeset/funny-files-burn.md
+++ b/.changeset/funny-files-burn.md
@@ -1,0 +1,5 @@
+---
+"trackio": minor
+---
+
+feat:Fix duplicate columns in parquet export

--- a/.changeset/funny-files-burn.md
+++ b/.changeset/funny-files-burn.md
@@ -1,5 +1,5 @@
 ---
-"trackio": minor
+"trackio": patch
 ---
 
 feat:Fix duplicate columns in parquet export

--- a/trackio/sqlite_storage.py
+++ b/trackio/sqlite_storage.py
@@ -294,9 +294,8 @@ class SQLiteStorage:
             index=df.index,
         )
         df = df.drop(columns=[col])
-        for c in expanded.columns:
-            df[c] = expanded[c]
-        return df
+        expanded = expanded.loc[:, ~expanded.columns.isin(df.columns)]
+        return pd.concat([df, expanded], axis=1)
 
     @staticmethod
     def _read_table(db_path: Path, table: str) -> pd.DataFrame:


### PR DESCRIPTION
 use `pd.concat(..., axis=1)` to avoid DataFrame fragmentation in the flattening path, avoids this warning in the terminal:

```
pandas PerformanceWarning: the DataFrame was highly fragmented...
```