### PR TITLE
Relax `PIL` dependency and remove `plotly` as it's no longer used

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,10 +17,9 @@ dependencies = [
     "huggingface-hub>=1.10.0,<2",
     "gradio[oauth]>=6.10.0,<7.0.0",
     "numpy<3.0.0",
-    "pillow<12.0.0",
+    "pillow<13.0.0",
     "orjson>=3.0,<4.0.0",
     "pydub<1.0.0",
-    "plotly>=6.0.0,<7.0.0",
     "tomli>=2.0.0; python_version < '3.11'",
 ]
 classifiers = [


### PR DESCRIPTION
cc @ehcalabres for visibility