### PR TITLE
Remove `gradio` dependency in `trackio` -- only `gradio_client` is needed locally anymore. Also lazily import `pandas` and remove it as a dependency

### DIFF
--- a/.changeset/great-trams-double.md
+++ b/.changeset/great-trams-double.md
@@ -2,4 +2,4 @@
 "trackio": minor
 ---
 
-feat:Remove `gradio` dependency in `trackio` -- only `gradio_client` is needed locally anymore
+feat:Remove `gradio` dependency in `trackio` -- only `gradio_client` is needed locally anymore. Also lazily import `pandas` and `PIL`

--- a/.changeset/great-trams-double.md
+++ b/.changeset/great-trams-double.md
@@ -1,0 +1,5 @@
+---
+"trackio": minor
+---
+
+feat:Remove `gradio` dependency in `trackio` -- only `gradio_client` is needed locally anymore

--- a/.changeset/great-trams-double.md
+++ b/.changeset/great-trams-double.md
@@ -2,4 +2,4 @@
 "trackio": minor
 ---
 
-feat:Remove `gradio` dependency in `trackio` -- only `gradio_client` is needed locally anymore. Also lazily import `pandas` and `PIL`
+feat:Remove `gradio` dependency in `trackio` -- only `gradio_client` is needed locally anymore. Also lazily import `pandas` and remove it as a dependency

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ dist/
 build/
 tf_test_run/
 test.py
+screenshots/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "pandas<3.0.0",
     "huggingface-hub>=1.10.0,<2",
     "gradio-client>=2.0.0,<3.0.0",
-    "starlette>=0.40.0,<1.0.0",
+    "starlette>=1.0.0,<2",
     "uvicorn[standard]>=0.30.0,<1.0.0",
     "numpy<3.0.0",
     "pillow<13.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "huggingface-hub>=1.10.0,<2",
     "gradio-client>=2.0.0,<3.0.0",
     "starlette>=1.0.0,<2",
+    "python-multipart>=0.0.9,<1.0.0",
     "uvicorn[standard]>=0.30.0,<1.0.0",
     "numpy<3.0.0",
     "pillow<13.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,9 @@ apple-gpu = [
 spaces = [
     "pyarrow>=21.0",
 ]
+mcp = [
+    "mcp>=1.0.0,<2.0.0",
+]
 
 [project.scripts]
 trackio = "trackio.cli:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,9 @@ requires-python = ">=3.10"
 dependencies = [
     "pandas<3.0.0",
     "huggingface-hub>=1.10.0,<2",
-    "gradio[oauth]>=6.10.0,<7.0.0",
+    "gradio-client>=2.0.0,<3.0.0",
+    "starlette>=0.40.0,<1.0.0",
+    "uvicorn[standard]>=0.30.0,<1.0.0",
     "numpy<3.0.0",
     "pillow<13.0.0",
     "orjson>=3.0,<4.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,6 @@ authors = [
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    "pandas<3.0.0",
     "huggingface-hub>=1.10.0,<2",
     "gradio-client>=2.0.0,<3.0.0",
     "starlette>=1.0.0,<2",

--- a/tests/e2e-local/test_api.py
+++ b/tests/e2e-local/test_api.py
@@ -1,8 +1,10 @@
 import asyncio
 
+import httpx
 import pytest
 
 import trackio
+import trackio.utils as trackio_utils
 from trackio import Api
 from trackio.remote_client import RemoteClient as Client
 from trackio.sqlite_storage import SQLiteStorage
@@ -189,6 +191,57 @@ def test_local_dashboard_supports_remote_client(temp_dir):
         assert project in projects
         assert runs == [run_name]
         assert "logo_urls" in settings
+    finally:
+        trackio.delete_project(project, force=True)
+        app.close()
+
+
+def test_local_dashboard_returns_400_for_missing_required_parameter(temp_dir):
+    app, url, _, _ = trackio.show(block_thread=False, open_browser=False)
+
+    try:
+        resp = httpx.post(
+            f"{url.rstrip('/')}/api/get_runs_for_project",
+            json={},
+            timeout=5,
+        )
+
+        assert resp.status_code == 400
+        assert resp.json() == {"error": "Missing required parameter: project"}
+    finally:
+        app.close()
+
+
+def test_local_dashboard_file_endpoint_only_serves_trackio_paths(
+    temp_dir, image_ndarray
+):
+    project = "test_local_file_endpoint"
+    run_name = "file-run"
+
+    trackio.init(project=project, name=run_name)
+    trackio.log(metrics={"image": trackio.Image(image_ndarray, caption="allowed")})
+    trackio.finish()
+
+    logs = SQLiteStorage.get_logs(project=project, run=run_name)
+    rel_path = logs[0]["image"]["file_path"]
+    allowed_path = trackio_utils.MEDIA_DIR / rel_path
+
+    app, url, _, _ = trackio.show(block_thread=False, open_browser=False)
+
+    try:
+        allowed_resp = httpx.get(
+            f"{url.rstrip('/')}/file",
+            params={"path": str(allowed_path)},
+            timeout=5,
+        )
+        blocked_resp = httpx.get(
+            f"{url.rstrip('/')}/file",
+            params={"path": "/etc/hosts"},
+            timeout=5,
+        )
+
+        assert allowed_resp.status_code == 200
+        assert blocked_resp.status_code == 404
     finally:
         trackio.delete_project(project, force=True)
         app.close()

--- a/tests/e2e-local/test_api.py
+++ b/tests/e2e-local/test_api.py
@@ -1,4 +1,6 @@
 import asyncio
+import tempfile
+from pathlib import Path
 
 import httpx
 import pytest
@@ -243,6 +245,80 @@ def test_local_dashboard_file_endpoint_only_serves_trackio_paths(
         assert allowed_resp.status_code == 200
         assert blocked_resp.status_code == 404
     finally:
+        trackio.delete_project(project, force=True)
+        app.close()
+
+
+def test_local_dashboard_upload_api_accepts_only_server_uploaded_paths(temp_dir):
+    project = "test_local_upload_guard"
+    source_path = Path(tempfile.gettempdir()) / "trackio-upload-source.txt"
+    source_text = "uploaded through server"
+    source_path.write_text(source_text)
+    blocked_target = trackio_utils.MEDIA_DIR / project / "files" / "blocked.txt"
+    allowed_target = None
+
+    app, url, _, _ = trackio.show(block_thread=False, open_browser=False)
+
+    try:
+        with source_path.open("rb") as handle:
+            upload_resp = httpx.post(
+                f"{url.rstrip('/')}/api/upload",
+                files={"files": (source_path.name, handle)},
+                timeout=5,
+            )
+        upload_resp.raise_for_status()
+        uploaded_path = upload_resp.json()["paths"][0]
+        allowed_target = (
+            trackio_utils.MEDIA_DIR
+            / project
+            / "files"
+            / "allowed.txt"
+            / Path(uploaded_path).name
+        )
+
+        allowed_resp = httpx.post(
+            f"{url.rstrip('/')}/api/bulk_upload_media",
+            json={
+                "uploads": [
+                    {
+                        "project": project,
+                        "run": None,
+                        "step": None,
+                        "relative_path": "allowed.txt",
+                        "uploaded_file": {"path": uploaded_path},
+                    }
+                ],
+                "hf_token": None,
+            },
+            timeout=5,
+        )
+        blocked_resp = httpx.post(
+            f"{url.rstrip('/')}/api/bulk_upload_media",
+            json={
+                "uploads": [
+                    {
+                        "project": project,
+                        "run": None,
+                        "step": None,
+                        "relative_path": "blocked.txt",
+                        "uploaded_file": {"path": "/etc/hosts"},
+                    }
+                ],
+                "hf_token": None,
+            },
+            timeout=5,
+        )
+
+        assert allowed_resp.status_code == 200
+        assert allowed_target is not None
+        assert allowed_target.read_text() == source_text
+        assert blocked_resp.status_code == 400
+        assert blocked_resp.json() == {
+            "error": "Uploaded file was not created by this Trackio server."
+        }
+        assert not blocked_target.exists()
+    finally:
+        source_path.unlink(missing_ok=True)
         trackio.delete_project(project, force=True)
         app.close()
 

--- a/tests/e2e-local/test_api.py
+++ b/tests/e2e-local/test_api.py
@@ -1,5 +1,10 @@
+import asyncio
+
+import pytest
+
 import trackio
 from trackio import Api
+from trackio.remote_client import RemoteClient as Client
 from trackio.sqlite_storage import SQLiteStorage
 
 
@@ -163,3 +168,82 @@ def test_rename_run(temp_dir, image_ndarray):
 
     new_config = SQLiteStorage.get_run_config(project=project, run=new_name)
     assert new_config is not None
+
+
+def test_local_dashboard_supports_remote_client(temp_dir):
+    project = "test_local_client"
+    run_name = "client-run"
+
+    trackio.init(project=project, name=run_name)
+    trackio.log(metrics={"loss": 0.1})
+    trackio.finish()
+
+    app, url, _, _ = trackio.show(block_thread=False, open_browser=False)
+
+    try:
+        client = Client(url, verbose=False)
+        projects = client.predict(api_name="/get_all_projects")
+        runs = client.predict(project, api_name="/get_runs_for_project")
+        settings = client.predict(api_name="/get_settings")
+
+        assert project in projects
+        assert runs == [run_name]
+        assert "logo_urls" in settings
+    finally:
+        trackio.delete_project(project, force=True)
+        app.close()
+
+
+def test_local_dashboard_supports_mcp(temp_dir):
+    pytest.importorskip("mcp")
+
+    project = "test_local_mcp"
+    run_name = "mcp-run"
+
+    trackio.init(project=project, name=run_name)
+    trackio.log(metrics={"loss": 0.1})
+    trackio.finish()
+
+    app, url, _, _ = trackio.show(
+        block_thread=False,
+        open_browser=False,
+        mcp_server=True,
+    )
+
+    async def check_mcp() -> None:
+        from mcp import ClientSession
+        from mcp.client.streamable_http import streamable_http_client
+
+        async with streamable_http_client(f"{url.rstrip('/')}/mcp") as (
+            read_stream,
+            write_stream,
+            _,
+        ):
+            async with ClientSession(read_stream, write_stream) as session:
+                await session.initialize()
+                tools = await session.list_tools()
+                tool_names = {tool.name for tool in tools.tools}
+                assert "get_all_projects" in tool_names
+                assert "get_run_summary" in tool_names
+
+                projects = await session.call_tool("get_all_projects")
+                assert project in projects.structuredContent["result"]
+
+                runs = await session.call_tool(
+                    "get_runs_for_project",
+                    {"project": project},
+                )
+                assert runs.structuredContent["result"] == [run_name]
+
+                run_summary = await session.call_tool(
+                    "get_run_summary",
+                    {"project": project, "run": run_name},
+                )
+                assert run_summary.structuredContent["run"] == run_name
+                assert run_summary.structuredContent["num_logs"] == 1
+
+    try:
+        asyncio.run(check_mcp())
+    finally:
+        trackio.delete_project(project, force=True)
+        app.close()

--- a/tests/e2e-local/test_table_with_images.py
+++ b/tests/e2e-local/test_table_with_images.py
@@ -1,7 +1,5 @@
 """End-to-end test for Table with TrackioImage functionality."""
 
-import pandas as pd
-
 import trackio
 from trackio.media import TrackioImage
 from trackio.sqlite_storage import SQLiteStorage
@@ -16,15 +14,14 @@ def test_table_mixed_images_and_regular_data(image_ndarray, temp_dir):
 
     img = TrackioImage(image_ndarray, caption="Only Image")
 
-    df = pd.DataFrame(
-        {
-            "experiment": ["exp1", "exp2", "exp3"],
-            "result_image": [img, None, img],
-            "score": [0.75, 0.80, 0.85],
-        }
+    table = Table(
+        columns=["experiment", "result_image", "score"],
+        data=[
+            ["exp1", img, 0.75],
+            ["exp2", None, 0.80],
+            ["exp3", img, 0.85],
+        ],
     )
-
-    table = Table(dataframe=df)
     trackio.log({"mixed_results": table})
     trackio.finish()
 

--- a/tests/e2e-spaces/conftest.py
+++ b/tests/e2e-spaces/conftest.py
@@ -2,9 +2,9 @@ import os
 import time
 
 import pytest
-from gradio_client import Client
 
 from trackio import deploy, utils
+from trackio.remote_client import RemoteClient as Client
 
 
 @pytest.fixture(scope="session")

--- a/tests/e2e-spaces/test_data_robustness.py
+++ b/tests/e2e-spaces/test_data_robustness.py
@@ -1,9 +1,8 @@
 import secrets
 import time
 
-from gradio_client import Client
-
 import trackio
+from trackio.remote_client import RemoteClient as Client
 from trackio.sqlite_storage import SQLiteStorage
 
 

--- a/tests/e2e-spaces/test_metrics_on_spaces.py
+++ b/tests/e2e-spaces/test_metrics_on_spaces.py
@@ -3,9 +3,8 @@ import time
 
 import huggingface_hub
 import pytest
-from gradio_client import Client
-
 import trackio
+from trackio.remote_client import RemoteClient as Client
 from trackio import utils
 
 

--- a/tests/e2e-spaces/test_metrics_on_spaces.py
+++ b/tests/e2e-spaces/test_metrics_on_spaces.py
@@ -3,9 +3,10 @@ import time
 
 import huggingface_hub
 import pytest
+
 import trackio
-from trackio.remote_client import RemoteClient as Client
 from trackio import utils
+from trackio.remote_client import RemoteClient as Client
 
 
 def test_basic_logging(test_space_id):

--- a/tests/e2e-spaces/test_spaces_features.py
+++ b/tests/e2e-spaces/test_spaces_features.py
@@ -3,6 +3,7 @@ import time
 
 import numpy as np
 import pytest
+
 import trackio
 from trackio.remote_client import RemoteClient as Client
 

--- a/tests/e2e-spaces/test_spaces_features.py
+++ b/tests/e2e-spaces/test_spaces_features.py
@@ -3,9 +3,8 @@ import time
 
 import numpy as np
 import pytest
-from gradio_client import Client
-
 import trackio
+from trackio.remote_client import RemoteClient as Client
 
 
 def _predict_run_summary(

--- a/tests/e2e-spaces/test_sync_and_freeze.py
+++ b/tests/e2e-spaces/test_sync_and_freeze.py
@@ -4,7 +4,7 @@ import time
 from pathlib import Path
 
 import huggingface_hub
-import pandas as pd
+import pyarrow.parquet as pq
 
 import trackio
 from trackio import deploy, utils
@@ -28,7 +28,7 @@ def _download_parquet_from_bucket(bucket_id, remote_name="metrics.parquet"):
         huggingface_hub.download_bucket_files(
             bucket_id, files=[(remote_name, str(local_path))]
         )
-        return pd.read_parquet(local_path)
+        return pq.read_table(local_path).to_pylist()
 
 
 def _cleanup_space(space_id):
@@ -93,7 +93,7 @@ def test_sync_to_static_space_incremental(temp_dir):
 
         df1 = _download_parquet_from_bucket(bucket_id)
         assert len(df1) == 2
-        assert "loss" in df1.columns
+        assert "loss" in df1[0]
 
         trackio.init(project=project_name, name=run_name)
         trackio.log({"loss": 0.1})
@@ -104,7 +104,7 @@ def test_sync_to_static_space_incremental(temp_dir):
 
         df2 = _download_parquet_from_bucket(bucket_id)
         assert len(df2) == 4
-        assert sorted(df2["loss"].tolist()) == [0.05, 0.1, 0.3, 0.5]
+        assert sorted(row["loss"] for row in df2) == [0.05, 0.1, 0.3, 0.5]
     finally:
         _cleanup_space(space_id)
         _cleanup_bucket(bucket_id)

--- a/tests/e2e-spaces/test_sync_and_freeze.py
+++ b/tests/e2e-spaces/test_sync_and_freeze.py
@@ -154,9 +154,9 @@ def test_sync_gradio_then_freeze_to_static(test_space_id, temp_dir):
 
         df = _download_parquet_from_bucket(frozen_bucket_id)
         assert len(df) == 3
-        assert "loss" in df.columns
-        assert "acc" in df.columns
-        assert sorted(df["loss"].tolist()) == [0.1, 0.3, 0.5]
+        assert "loss" in df[0]
+        assert "acc" in df[0]
+        assert sorted(row["loss"] for row in df) == [0.1, 0.3, 0.5]
     finally:
         _cleanup_space(frozen_space_id)
         _cleanup_bucket(frozen_bucket_id)

--- a/tests/e2e-spaces/test_sync_and_freeze.py
+++ b/tests/e2e-spaces/test_sync_and_freeze.py
@@ -5,10 +5,10 @@ from pathlib import Path
 
 import huggingface_hub
 import pandas as pd
-from gradio_client import Client
 
 import trackio
 from trackio import deploy, utils
+from trackio.remote_client import RemoteClient as Client
 
 
 def _wait_for_space_ready(space_id, timeout=300):

--- a/tests/e2e-spaces/test_throughput.py
+++ b/tests/e2e-spaces/test_throughput.py
@@ -2,9 +2,8 @@ import secrets
 import threading
 import time
 
-from gradio_client import Client
-
 import trackio
+from trackio.remote_client import RemoteClient as Client
 
 
 def test_burst_2000_logs_single_process(test_space_id, wait_for_client):

--- a/tests/ui/test_settings_theme.py
+++ b/tests/ui/test_settings_theme.py
@@ -8,14 +8,16 @@ def test_settings_theme_switching_and_persistence(temp_dir):
     trackio.log(metrics={"loss": 0.5})
     trackio.finish()
 
-    app, url, _, _ = trackio.show(block_thread=False, open_browser=False)
+    app, _, _, full_url = trackio.show(
+        project="test_theme", block_thread=False, open_browser=False
+    )
 
     try:
         with sync_playwright() as p:
             browser = p.chromium.launch()
             page = browser.new_page()
             page.set_default_timeout(5000)
-            base_url = url if url.endswith("/") else url + "/"
+            base_url = full_url
             page.goto(base_url)
             page.wait_for_load_state("networkidle")
 

--- a/tests/ui/test_ui_display.py
+++ b/tests/ui/test_ui_display.py
@@ -16,14 +16,16 @@ def test_runs_plots_images_are_displayed(temp_dir):
 
     trackio.finish()
 
-    app, url, _, _ = trackio.show(block_thread=False, open_browser=False)
+    app, _, _, full_url = trackio.show(
+        project="test_project", block_thread=False, open_browser=False
+    )
 
     try:
         with sync_playwright() as p:
             browser = p.chromium.launch()
             page = browser.new_page()
             page.set_default_timeout(5000)
-            page.goto(url if url.endswith("/") else url + "/")
+            page.goto(full_url)
             page.wait_for_load_state("networkidle")
             nav_links = page.locator(".nav-link")
             expect(nav_links).to_have_count(7)
@@ -63,14 +65,16 @@ def test_latest_only_selects_last_run(temp_dir):
         trackio.log(metrics={"loss": 0.1 * (i + 1)})
         trackio.finish()
 
-    app, url, _, _ = trackio.show(block_thread=False, open_browser=False)
+    app, _, _, full_url = trackio.show(
+        project="test_latest", block_thread=False, open_browser=False
+    )
 
     try:
         with sync_playwright() as p:
             browser = p.chromium.launch()
             page = browser.new_page()
             page.set_default_timeout(5000)
-            page.goto(url if url.endswith("/") else url + "/")
+            page.goto(full_url)
             page.wait_for_load_state("networkidle")
 
             checkboxes = page.locator(".checkbox-item input[type='checkbox']")
@@ -96,14 +100,16 @@ def test_navbar_page_navigation(temp_dir):
     trackio.log(metrics={"loss": 0.5})
     trackio.finish()
 
-    app, url, _, _ = trackio.show(block_thread=False, open_browser=False)
+    app, _, _, full_url = trackio.show(
+        project="test_nav", block_thread=False, open_browser=False
+    )
 
     try:
         with sync_playwright() as p:
             browser = p.chromium.launch()
             page = browser.new_page()
             page.set_default_timeout(5000)
-            page.goto(url if url.endswith("/") else url + "/")
+            page.goto(full_url)
             page.wait_for_load_state("networkidle")
             nav_links = page.locator(".nav-link")
             expect(nav_links).to_have_count(7)
@@ -134,14 +140,16 @@ def test_runs_table_shows_run_data(temp_dir):
         trackio.log(metrics={"loss": 1.0 / (i + 1)})
     trackio.finish()
 
-    app, url, _, _ = trackio.show(block_thread=False, open_browser=False)
+    app, _, _, full_url = trackio.show(
+        project="test_runs_table", block_thread=False, open_browser=False
+    )
 
     try:
         with sync_playwright() as p:
             browser = p.chromium.launch()
             page = browser.new_page()
             page.set_default_timeout(5000)
-            page.goto(url if url.endswith("/") else url + "/")
+            page.goto(full_url)
             page.wait_for_load_state("networkidle")
 
             nav_links = page.locator(".nav-link")
@@ -170,14 +178,16 @@ def test_multiple_runs_display_multiple_plots(temp_dir):
         trackio.log(metrics={"val_loss": 0.05 * (i + 1)})
         trackio.finish()
 
-    app, url, _, _ = trackio.show(block_thread=False, open_browser=False)
+    app, _, _, full_url = trackio.show(
+        project="test_multi", block_thread=False, open_browser=False
+    )
 
     try:
         with sync_playwright() as p:
             browser = p.chromium.launch()
             page = browser.new_page()
             page.set_default_timeout(5000)
-            page.goto(url if url.endswith("/") else url + "/")
+            page.goto(full_url)
             page.wait_for_load_state("networkidle")
 
             run_items = page.locator(".checkbox-item")

--- a/tests/unit/test_deploy.py
+++ b/tests/unit/test_deploy.py
@@ -7,6 +7,19 @@ from trackio import deploy
 from trackio.bucket_storage import _list_bucket_file_paths
 
 
+def test_get_source_install_dependencies_includes_mcp():
+    dependencies = deploy._get_source_install_dependencies().splitlines()
+
+    assert any(dep.startswith("pyarrow>=") for dep in dependencies)
+    assert any(dep.startswith("mcp>=") for dep in dependencies)
+
+
+def test_get_space_install_requirement_includes_mcp_extra():
+    requirement = deploy._get_space_install_requirement()
+
+    assert requirement == f"trackio[spaces,mcp]=={deploy.trackio.__version__}"
+
+
 @patch("trackio.deploy.huggingface_hub.HfApi")
 def test_get_source_bucket_falls_back_to_space_info_runtime(mock_hf_api):
     api = mock_hf_api.return_value

--- a/tests/unit/test_table.py
+++ b/tests/unit/test_table.py
@@ -73,7 +73,7 @@ def test_table_to_display_format_with_images():
     assert row1["step"] == 1
     assert row1["value"] == 42
     assert row1["text"] == "regular text"
-    assert '<img src="/gradio_api/file=' in row1["image"]
+    assert '<img src="/file?path=' in row1["image"]
     assert 'image.png"' in row1["image"]
     assert 'alt="Test Caption"' in row1["image"]
 
@@ -121,7 +121,7 @@ def test_table_to_display_format_with_multiple_images():
     row1 = processed_data[0]
     assert row1["step"] == 1
     assert row1["value"] == 42
-    assert '<img src="/gradio_api/file=' in row1["images"]
+    assert '<img src="/file?path=' in row1["images"]
     assert 'alt="First Image"' in row1["images"]
     assert 'image1.png"' in row1["images"]
     assert 'alt="Second Image"' in row1["images"]

--- a/tests/unit/test_table.py
+++ b/tests/unit/test_table.py
@@ -1,4 +1,4 @@
-import pandas as pd
+import pytest
 
 from trackio.media import TrackioImage
 from trackio.table import Table
@@ -9,16 +9,14 @@ RUN_NAME = "test_run"
 
 def test_table_to_dict_with_images(image_ndarray, temp_dir):
     img = TrackioImage(image_ndarray, caption="Mixed Test")
-    df = pd.DataFrame(
-        {
-            "step": [1, 2, 3],
-            "image": [img, None, img],
-            "text": ["hello", "world", "test"],
-            "number": [1.5, 2.5, 3.5],
-        }
+    table = Table(
+        columns=["step", "image", "text", "number"],
+        data=[
+            [1, img, "hello", 1.5],
+            [2, None, "world", 2.5],
+            [3, img, "test", 3.5],
+        ],
     )
-
-    table = Table(dataframe=df)
     result = table._to_dict(project=PROJECT_NAME, run=RUN_NAME, step=5)
 
     assert result["_type"] == Table.TYPE
@@ -43,6 +41,17 @@ def test_table_to_dict_with_images(image_ndarray, temp_dir):
     assert row3["number"] == 3.5
     assert isinstance(row3["image"], dict)
     assert row3["image"]["_type"] == TrackioImage.TYPE
+
+
+def test_table_accepts_pandas_dataframe_if_installed():
+    pd = pytest.importorskip("pandas")
+
+    df = pd.DataFrame({"step": [1], "text": ["hello"]})
+    table = Table(dataframe=df)
+
+    assert table._to_dict(project=PROJECT_NAME, run=RUN_NAME)["_value"] == [
+        {"step": 1, "text": "hello"}
+    ]
 
 
 def test_table_to_display_format_with_images():

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -238,31 +238,37 @@ def test_plot_ordering():
 
 def test_downsample_with_none_x_lim():
     """Test downsample function handles None values in x_lim correctly."""
-    import pandas as pd
+    rows = [
+        {"x": 0, "y": 1},
+        {"x": 1, "y": 2},
+        {"x": 2, "y": 3},
+        {"x": 3, "y": 4},
+        {"x": 4, "y": 5},
+        {"x": 5, "y": 6},
+        {"x": 6, "y": 7},
+        {"x": 7, "y": 8},
+        {"x": 8, "y": 9},
+        {"x": 9, "y": 10},
+        {"x": 10, "y": 11},
+    ]
 
-    data = {
-        "x": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
-        "y": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
-    }
-    df = pd.DataFrame(data)
-
-    result_df, result_x_lim = utils.downsample(df, "x", "y", None, None)
+    result_df, result_x_lim = utils.downsample(rows, "x", "y", None, None)
     assert result_x_lim is None
-    assert len(result_df) <= len(df)
+    assert len(result_df) <= len(rows)
 
-    result_df, result_x_lim = utils.downsample(df, "x", "y", None, (None, 5))
+    result_df, result_x_lim = utils.downsample(rows, "x", "y", None, (None, 5))
     assert result_x_lim == (0, 5)
-    assert len(result_df) <= len(df)
+    assert len(result_df) <= len(rows)
 
-    result_df, result_x_lim = utils.downsample(df, "x", "y", None, (2, None))
+    result_df, result_x_lim = utils.downsample(rows, "x", "y", None, (2, None))
     assert result_x_lim == (2, 10)
-    assert len(result_df) <= len(df)
+    assert len(result_df) <= len(rows)
 
-    result_df, result_x_lim = utils.downsample(df, "x", "y", None, (None, None))
+    result_df, result_x_lim = utils.downsample(rows, "x", "y", None, (None, None))
     assert result_x_lim == (0, 10)
-    assert len(result_df) <= len(df)
+    assert len(result_df) <= len(rows)
 
-    empty_df = pd.DataFrame({"x": [], "y": []})
+    empty_df = []
     result_df, result_x_lim = utils.downsample(empty_df, "x", "y", None, (2, None))
     assert result_x_lim == (2, 0)
     assert len(result_df) == 0

--- a/trackio/__init__.py
+++ b/trackio/__init__.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from typing import Any
 
 import huggingface_hub
-from gradio_client import Client, handle_file
+from gradio_client import handle_file
 from huggingface_hub import SpaceStorage
 from huggingface_hub.errors import LocalTokenNotFoundError
 
@@ -32,6 +32,7 @@ from trackio.media import (
     TrackioVideo,
     get_project_media_path,
 )
+from trackio.remote_client import RemoteClient
 from trackio.run import Run
 from trackio.server import TrackioDashboardApp, build_starlette_app_only
 from trackio.sqlite_storage import SQLiteStorage
@@ -166,9 +167,9 @@ def init(
         embed (`bool`, *optional*, defaults to `True`):
             If running inside a Jupyter/Colab notebook, whether the dashboard should
             automatically be embedded in the cell when trackio.init() is called. For
-            local runs, this launches a local Gradio app and embeds it. For Space runs,
+            local runs, this launches a local Trackio dashboard and embeds it. For Space runs,
             this embeds the Space URL. In Colab, the local dashboard will be accessible
-            via a public share URL (default Gradio behavior).
+            via a public share URL when `share=True`.
         auto_log_gpu (`bool` or `None`, *optional*, defaults to `None`):
             Controls automatic GPU metrics logging. If `None` (default), GPU logging
             is automatically enabled when `nvidia-ml-py` is installed and an NVIDIA
@@ -626,7 +627,11 @@ def save(
                 )
 
             try:
-                client = Client(url, verbose=False, httpx_kwargs={"timeout": 90})
+                client = RemoteClient(
+                    url,
+                    hf_token=huggingface_hub.utils.get_token(),
+                    httpx_kwargs={"timeout": 90},
+                )
                 client.predict(
                     api_name="/bulk_upload_media",
                     uploads=upload_entries,
@@ -664,8 +669,9 @@ def show(
         theme (`Any`, *optional*):
             Ignored. Kept for backward compatibility; Trackio no longer uses Gradio themes.
         mcp_server (`bool`, *optional*):
-            If `True`, the dashboard enables MCP lifespan hooks when available. If `None`
-            (default), the `GRADIO_MCP_SERVER` environment variable is used (e.g. on Spaces).
+            If `True`, the dashboard exposes an MCP server at `/mcp` when the optional
+            `trackio[mcp]` dependency is installed. If `None` (default), the
+            `GRADIO_MCP_SERVER` environment variable is used (e.g. on Spaces).
         footer (`bool`, *optional*, defaults to `True`):
             Whether to include `footer=false` in the write-token URL when `False`.
             This can also be controlled via the `footer` query parameter in the URL.
@@ -696,7 +702,7 @@ def show(
             `share_url`: The public share URL, if any.
             `full_url`: The full URL including the write token (share URL when sharing, else local).
     """
-    if theme is not None:
+    if theme is not None and theme != "default":
         warnings.warn(
             "The theme argument is ignored; Trackio no longer depends on Gradio themes.",
             UserWarning,
@@ -737,7 +743,6 @@ def show(
 
     if not utils.is_in_notebook():
         print(f"* Trackio UI launched at: {dashboard_url}")
-        print(f"* API (gradio_client-compatible) at: {base_url}gradio_api/")
         if open_browser:
             webbrowser.open(dashboard_url)
         block_thread = block_thread if block_thread is not None else True

--- a/trackio/__init__.py
+++ b/trackio/__init__.py
@@ -74,6 +74,7 @@ __all__ = [
     "Histogram",
     "Markdown",
     "Api",
+    "TRACKIO_LOGO_DIR",
 ]
 
 Audio = TrackioAudio

--- a/trackio/__init__.py
+++ b/trackio/__init__.py
@@ -10,8 +10,6 @@ from pathlib import Path
 from typing import Any
 
 import huggingface_hub
-from gradio.themes import ThemeClass
-from gradio.utils import TupleNoPrint
 from gradio_client import Client, handle_file
 from huggingface_hub import SpaceStorage
 from huggingface_hub.errors import LocalTokenNotFoundError
@@ -22,11 +20,11 @@ from trackio.api import Api
 from trackio.apple_gpu import apple_gpu_available
 from trackio.apple_gpu import log_apple_gpu as _log_apple_gpu
 from trackio.deploy import freeze, sync
-from trackio.frontend_server import mount_frontend
 from trackio.gpu import gpu_available
 from trackio.gpu import log_gpu as _log_nvidia_gpu
 from trackio.histogram import Histogram
 from trackio.imports import import_csv, import_tf_events
+from trackio.launch import launch_trackio_dashboard
 from trackio.markdown import Markdown
 from trackio.media import (
     TrackioAudio,
@@ -35,24 +33,23 @@ from trackio.media import (
     get_project_media_path,
 )
 from trackio.run import Run
-from trackio.server import make_trackio_server
+from trackio.server import TrackioDashboardApp, build_starlette_app_only
 from trackio.sqlite_storage import SQLiteStorage
 from trackio.table import Table
 from trackio.typehints import UploadEntry
-from trackio.utils import TRACKIO_DIR, TRACKIO_LOGO_DIR
+from trackio.utils import TRACKIO_DIR
 
 logging.getLogger("httpx").setLevel(logging.WARNING)
-
-warnings.filterwarnings(
-    "ignore",
-    message="Empty session being created. Install gradio\\[oauth\\]",
-    category=UserWarning,
-    module="gradio.helpers",
-)
 
 __version__ = json.loads(Path(__file__).parent.joinpath("package.json").read_text())[
     "version"
 ]
+
+
+class _TupleNoPrint(tuple):
+    def __repr__(self) -> str:
+        return ""
+
 
 __all__ = [
     "init",
@@ -647,13 +644,15 @@ def save(
 def show(
     project: str | None = None,
     *,
-    theme: str | ThemeClass | None = None,
+    theme: Any = None,
     mcp_server: bool | None = None,
     footer: bool = True,
     color_palette: list[str] | None = None,
     open_browser: bool = True,
     block_thread: bool | None = None,
     host: str | None = None,
+    share: bool | None = None,
+    server_port: int | None = None,
 ):
     """
     Launches the Trackio dashboard.
@@ -662,19 +661,13 @@ def show(
         project (`str`, *optional*):
             The name of the project whose runs to show. If not provided, all projects
             will be shown and the user can select one.
-        theme (`str` or `ThemeClass`, *optional*):
-            A Gradio Theme to use for the dashboard instead of the default Gradio theme,
-            can be a built-in theme (e.g. `'soft'`, `'citrus'`), a theme from the Hub
-            (e.g. `"gstaff/xkcd"`), or a custom Theme class. If not provided, the
-            `TRACKIO_THEME` environment variable will be used, or if that is not set,
-            the default Gradio theme will be used.
+        theme (`Any`, *optional*):
+            Ignored. Kept for backward compatibility; Trackio no longer uses Gradio themes.
         mcp_server (`bool`, *optional*):
-            If `True`, the Trackio dashboard will be set up as an MCP server and certain
-            functions will be added as MCP tools. If `None` (default behavior), then the
-            `GRADIO_MCP_SERVER` environment variable will be used to determine if the
-            MCP server should be enabled (which is `"True"` on Hugging Face Spaces).
+            If `True`, the dashboard enables MCP lifespan hooks when available. If `None`
+            (default), the `GRADIO_MCP_SERVER` environment variable is used (e.g. on Spaces).
         footer (`bool`, *optional*, defaults to `True`):
-            Whether to show the Gradio footer. When `False`, the footer will be hidden.
+            Whether to include `footer=false` in the write-token URL when `False`.
             This can also be controlled via the `footer` query parameter in the URL.
         color_palette (`list[str]`, *optional*):
             A list of hex color codes to use for plot lines. If not provided, the
@@ -691,17 +684,27 @@ def show(
         host (`str`, *optional*):
             The host to bind the server to. If not provided, defaults to `'127.0.0.1'`
             (localhost only). Set to `'0.0.0.0'` to allow remote access.
+        share (`bool`, *optional*):
+            If `True`, creates a temporary public URL (Gradio-compatible tunnel). On Colab
+            or hosted notebooks, defaults to `True` unless overridden.
+        server_port (`int`, *optional*):
+            Port to bind. If not set, scans from `GRADIO_SERVER_PORT` (default 7860).
 
         Returns:
-            `app`: The Gradio app object corresponding to the dashboard launched by Trackio.
+            `app`: The dashboard handle (`.close()` stops the server).
             `url`: The local URL of the dashboard.
-            `share_url`: The public share URL of the dashboard.
-            `full_url`: The full URL of the dashboard including the write token (will use the public share URL if launched publicly, otherwise the local URL).
+            `share_url`: The public share URL, if any.
+            `full_url`: The full URL including the write token (share URL when sharing, else local).
     """
+    if theme is not None:
+        warnings.warn(
+            "The theme argument is ignored; Trackio no longer depends on Gradio themes.",
+            UserWarning,
+            stacklevel=2,
+        )
+
     if color_palette is not None:
         os.environ["TRACKIO_COLOR_PALETTE"] = ",".join(color_palette)
-
-    theme = theme or os.environ.get("TRACKIO_THEME")
 
     _mcp_server = (
         mcp_server
@@ -709,34 +712,32 @@ def show(
         else os.environ.get("GRADIO_MCP_SERVER", "False") == "True"
     )
 
-    server = make_trackio_server()
-    mount_frontend(server)
-
-    _, url, share_url = server.launch(
-        quiet=True,
-        inline=False,
-        prevent_thread_lock=True,
-        favicon_path=TRACKIO_LOGO_DIR / "trackio_logo_light.png",
-        allowed_paths=[TRACKIO_LOGO_DIR, TRACKIO_DIR],
-        mcp_server=_mcp_server,
-        theme=theme,
+    starlette_app, wt = build_starlette_app_only(mcp_server=_mcp_server)
+    local_url, share_url, _local_api_url, uv_server = launch_trackio_dashboard(
+        starlette_app,
         server_name=host,
+        server_port=server_port,
+        share=share,
+        mcp_server=_mcp_server,
+        quiet=True,
     )
+    server = TrackioDashboardApp(starlette_app, uv_server, wt)
 
-    base_url = share_url + "/" if share_url else url
-    dashboard_url = base_url.rstrip("/") + "/"
+    base_root = (share_url or local_url).rstrip("/")
+    base_url = base_root + "/"
+    dashboard_url = base_url
     if project:
         dashboard_url += f"?project={project}"
     full_url = utils.get_full_url(
-        base_url.rstrip("/"),
+        base_root,
         project=project,
-        write_token=server.write_token,
+        write_token=wt,
         footer=footer,
     )
 
     if not utils.is_in_notebook():
         print(f"* Trackio UI launched at: {dashboard_url}")
-        print(f"* Gradio API available at: {base_url}")
+        print(f"* API (gradio_client-compatible) at: {base_url}gradio_api/")
         if open_browser:
             webbrowser.open(dashboard_url)
         block_thread = block_thread if block_thread is not None else True
@@ -746,4 +747,4 @@ def show(
 
     if block_thread:
         utils.block_main_thread_until_keyboard_interrupt()
-    return TupleNoPrint((server, url, share_url, full_url))
+    return _TupleNoPrint((server, local_url, share_url, full_url))

--- a/trackio/_vendor/gradio_exceptions.py
+++ b/trackio/_vendor/gradio_exceptions.py
@@ -1,0 +1,6 @@
+class ChecksumMismatchError(Exception):
+    pass
+
+
+class ShareCertificateWriteError(Exception):
+    pass

--- a/trackio/_vendor/networking.py
+++ b/trackio/_vendor/networking.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import os
+import time
+import warnings
+from pathlib import Path
+from urllib.parse import urlparse, urlunparse
+
+import httpx
+
+from trackio._vendor.gradio_exceptions import ShareCertificateWriteError
+from trackio._vendor.tunneling import CERTIFICATE_PATH, Tunnel
+
+GRADIO_API_SERVER = "https://api.gradio.app/v3/tunnel-request"
+GRADIO_SHARE_SERVER_ADDRESS = os.getenv("GRADIO_SHARE_SERVER_ADDRESS")
+
+
+def setup_tunnel(
+    local_host: str,
+    local_port: int,
+    share_token: str,
+    share_server_address: str | None,
+    share_server_tls_certificate: str | None,
+) -> str:
+    share_server_address = (
+        GRADIO_SHARE_SERVER_ADDRESS
+        if share_server_address is None
+        else share_server_address
+    )
+    if share_server_address is None:
+        try:
+            response = httpx.get(GRADIO_API_SERVER, timeout=30)
+            payload = response.json()[0]
+            remote_host, remote_port = payload["host"], int(payload["port"])
+            certificate = payload["root_ca"]
+        except Exception as e:
+            raise RuntimeError(
+                "Could not get share link from Gradio API Server."
+            ) from e
+        try:
+            Path(CERTIFICATE_PATH).parent.mkdir(parents=True, exist_ok=True)
+            with open(CERTIFICATE_PATH, "w") as f:
+                f.write(certificate)
+        except Exception as e:
+            raise ShareCertificateWriteError(
+                f"{e}. This can happen if the current working directory is read-only."
+            ) from e
+        share_server_tls_certificate = CERTIFICATE_PATH
+
+    else:
+        remote_host, remote_port = share_server_address.split(":")
+        remote_port = int(remote_port)
+    tunnel = Tunnel(
+        remote_host,
+        remote_port,
+        local_host,
+        local_port,
+        share_token,
+        share_server_tls_certificate,
+    )
+    address = tunnel.start_tunnel()
+    return address
+
+
+def url_ok(url: str) -> bool:
+    try:
+        for _ in range(5):
+            with warnings.catch_warnings():
+                warnings.filterwarnings("ignore")
+                r = httpx.head(url, timeout=3, verify=False)
+            if r.status_code in (200, 401, 302, 303, 307):
+                return True
+            time.sleep(0.500)
+    except (ConnectionError, httpx.ConnectError, httpx.TimeoutException):
+        return False
+    return False
+
+
+def normalize_share_url(share_url: str, share_server_protocol: str) -> str:
+    parsed_url = urlparse(share_url)
+    return urlunparse((share_server_protocol,) + parsed_url[1:])

--- a/trackio/_vendor/tunneling.py
+++ b/trackio/_vendor/tunneling.py
@@ -1,0 +1,191 @@
+import atexit
+import hashlib
+import os
+import platform
+import re
+import stat
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import httpx
+from huggingface_hub.constants import HF_HOME
+
+from trackio._vendor.gradio_exceptions import ChecksumMismatchError
+
+VERSION = "0.3"
+CURRENT_TUNNELS: list["Tunnel"] = []
+
+machine = platform.machine()
+if machine == "x86_64":
+    machine = "amd64"
+elif machine == "aarch64":
+    machine = "arm64"
+
+BINARY_REMOTE_NAME = f"frpc_{platform.system().lower()}_{machine.lower()}"
+EXTENSION = ".exe" if os.name == "nt" else ""
+BINARY_URL = f"https://cdn-media.huggingface.co/frpc-gradio-{VERSION}/{BINARY_REMOTE_NAME}{EXTENSION}"
+
+CHECKSUMS = {
+    "https://cdn-media.huggingface.co/frpc-gradio-0.3/frpc_windows_amd64.exe": "14bc0ea470be5d67d79a07412bd21de8a0a179c6ac1116d7764f68e942dc9ceb",
+    "https://cdn-media.huggingface.co/frpc-gradio-0.3/frpc_linux_amd64": "c791d1f047b41ff5885772fc4bf20b797c6059bbd82abb9e31de15e55d6a57c4",
+    "https://cdn-media.huggingface.co/frpc-gradio-0.3/frpc_linux_arm64": "823ced25104de6dc3c9f4798dbb43f20e681207279e6ab89c40e2176ccbf70cd",
+    "https://cdn-media.huggingface.co/frpc-gradio-0.3/frpc_darwin_amd64": "930f8face3365810ce16689da81b7d1941fda4466225a7bbcbced9a2916a6e15",
+    "https://cdn-media.huggingface.co/frpc-gradio-0.3/frpc_darwin_arm64": "dfac50c690aca459ed5158fad8bfbe99f9282baf4166cf7c410a6673fbc1f327",
+    "https://cdn-media.huggingface.co/frpc-gradio-0.3/frpc_linux_arm": "4b563beb2e36c448cc688174e20b53af38dc1ff2b5e362d4ddd1401f2affbfb7",
+    "https://cdn-media.huggingface.co/frpc-gradio-0.3/frpc_freebsd_386": "cb0a56c764ecf96dd54ed601d240c564f060ee4e58202d65ffca17c1a51ce19c",
+    "https://cdn-media.huggingface.co/frpc-gradio-0.3/frpc_freebsd_amd64": "516d9e6903513869a011ddcd1ec206167ad1eb5dd6640d21057acc258edecbbb",
+    "https://cdn-media.huggingface.co/frpc-gradio-0.3/frpc_linux_386": "4c2f2a48cd71571498c0ac8a4d42a055f22cb7f14b4b5a2b0d584220fd60a283",
+    "https://cdn-media.huggingface.co/frpc-gradio-0.3/frpc_linux_mips": "b309ecd594d4f0f7f33e556a80d4b67aef9319c00a8334648a618e56b23cb9e0",
+    "https://cdn-media.huggingface.co/frpc-gradio-0.3/frpc_linux_mips64": "0372ef5505baa6f3b64c6295a86541b24b7b0dbe4ef28b344992e21f47624b7b",
+    "https://cdn-media.huggingface.co/frpc-gradio-0.3/frpc_linux_riscv64": "1658eed7e8c14ea76e1d95749d58441ce24147c3d559381832c725c29cfc3df3",
+    "https://cdn-media.huggingface.co/frpc-gradio-0.3/frpc_linux_mipsle": "a2aaba16961d3372b79bd7a28976fcd0f0bbaebc2b50d5a7a71af2240747960f",
+    "https://cdn-media.huggingface.co/frpc-gradio-0.3/frpc_windows_386.exe": "721b90550195a83e15f2176d8f85a48d5a25822757cb872e9723d4bccc4e5bb6",
+    "https://cdn-media.huggingface.co/frpc-gradio-0.3/frpc_linux_mips64le": "796481edd609f31962b45cc0ab4c9798d040205ae3bf354ed1b72fb432d796b8",
+}
+
+CHUNK_SIZE = 128
+
+BINARY_FILENAME = f"{BINARY_REMOTE_NAME}_v{VERSION}"
+BINARY_FOLDER = Path(HF_HOME) / "trackio" / "frpc"
+BINARY_PATH = str(BINARY_FOLDER / BINARY_FILENAME)
+
+TUNNEL_TIMEOUT_SECONDS = 30
+TUNNEL_ERROR_MESSAGE = (
+    "Could not create share URL. "
+    "Please check the appended log from frpc for more information:"
+)
+
+CERTIFICATE_PATH = ".trackio/certificate.pem"
+
+
+class Tunnel:
+    def __init__(
+        self,
+        remote_host: str,
+        remote_port: int,
+        local_host: str,
+        local_port: int,
+        share_token: str,
+        share_server_tls_certificate: str | None,
+    ):
+        self.proc = None
+        self.url = None
+        self.remote_host = remote_host
+        self.remote_port = remote_port
+        self.local_host = local_host
+        self.local_port = local_port
+        self.share_token = share_token
+        self.share_server_tls_certificate = share_server_tls_certificate
+
+    @staticmethod
+    def download_binary():
+        if not Path(BINARY_PATH).exists():
+            Path(BINARY_FOLDER).mkdir(parents=True, exist_ok=True)
+            resp = httpx.get(BINARY_URL, timeout=30)
+
+            if resp.status_code == 403:
+                raise OSError(
+                    f"Cannot set up a share link as this platform is incompatible. Please "
+                    f"create a GitHub issue with information about your platform: {platform.uname()}"
+                )
+
+            resp.raise_for_status()
+
+            with open(BINARY_PATH, "wb") as file:
+                file.write(resp.content)
+            st = os.stat(BINARY_PATH)
+            os.chmod(BINARY_PATH, st.st_mode | stat.S_IEXEC)
+
+            if BINARY_URL in CHECKSUMS:
+                sha = hashlib.sha256()
+                with open(BINARY_PATH, "rb") as f:
+                    for chunk in iter(lambda: f.read(CHUNK_SIZE * sha.block_size), b""):
+                        sha.update(chunk)
+                calculated_hash = sha.hexdigest()
+
+                if calculated_hash != CHECKSUMS[BINARY_URL]:
+                    raise ChecksumMismatchError()
+
+    def start_tunnel(self) -> str:
+        self.download_binary()
+        self.url = self._start_tunnel(BINARY_PATH)
+        return self.url
+
+    def kill(self):
+        if self.proc is not None:
+            print(f"Killing tunnel {self.local_host}:{self.local_port} <> {self.url}")
+            self.proc.terminate()
+            self.proc = None
+
+    def _start_tunnel(self, binary: str) -> str:
+        CURRENT_TUNNELS.append(self)
+        command = [
+            binary,
+            "http",
+            "-n",
+            self.share_token,
+            "-l",
+            str(self.local_port),
+            "-i",
+            self.local_host,
+            "--uc",
+            "--sd",
+            "random",
+            "--ue",
+            "--server_addr",
+            f"{self.remote_host}:{self.remote_port}",
+            "--disable_log_color",
+        ]
+        if self.share_server_tls_certificate is not None:
+            command.extend(
+                [
+                    "--tls_enable",
+                    "--tls_trusted_ca_file",
+                    self.share_server_tls_certificate,
+                ]
+            )
+        self.proc = subprocess.Popen(
+            command, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+        )
+        atexit.register(self.kill)
+        return self._read_url_from_tunnel_stream()
+
+    def _read_url_from_tunnel_stream(self) -> str:
+        start_timestamp = time.time()
+
+        log = []
+        url = ""
+
+        def _raise_tunnel_error():
+            log_text = "\n".join(log)
+            print(log_text, file=sys.stderr)
+            raise ValueError(f"{TUNNEL_ERROR_MESSAGE}\n{log_text}")
+
+        while url == "":
+            if time.time() - start_timestamp >= TUNNEL_TIMEOUT_SECONDS:
+                _raise_tunnel_error()
+
+            assert self.proc is not None  # noqa: S101
+            if self.proc.stdout is None:
+                continue
+
+            line = self.proc.stdout.readline()
+            line = line.decode("utf-8")
+
+            if line == "":
+                continue
+
+            log.append(line.strip())
+
+            if "start proxy success" in line:
+                result = re.search("start proxy success: (.+)\n", line)
+                if result is None:
+                    _raise_tunnel_error()
+                else:
+                    url = result.group(1)
+            elif "login to server failed" in line:
+                _raise_tunnel_error()
+
+        return url

--- a/trackio/asgi_app.py
+++ b/trackio/asgi_app.py
@@ -1,175 +1,167 @@
 from __future__ import annotations
 
-import asyncio
 import inspect
 import json
-import secrets
-import traceback
-from collections.abc import Callable
+import math
+import tempfile
+from pathlib import Path
 from typing import Any
+from urllib.parse import unquote
 
 from starlette.applications import Starlette
 from starlette.requests import Request
-from starlette.responses import FileResponse, JSONResponse, Response, StreamingResponse
+from starlette.responses import FileResponse, JSONResponse, Response
 from starlette.routing import Route
 
 from trackio.exceptions import TrackioAPIError
+from trackio.remote_client import HTTP_API_VERSION
 
-API_PREFIX = "/gradio_api"
 
-
-def _serialize_result(data: Any) -> str:
-    def default(o: Any):
-        if isinstance(o, (dict, list, str, int, float, bool)) or o is None:
-            return o
-        if hasattr(o, "item"):
-            try:
-                return o.item()
-            except Exception:
-                pass
-        return str(o)
-
-    return json.dumps(data, default=default)
+def _json_safe(data: Any) -> Any:
+    if data is None or isinstance(data, (str, bool, int)):
+        return data
+    if isinstance(data, float):
+        return data if math.isfinite(data) else None
+    if isinstance(data, dict):
+        return {k: _json_safe(v) for k, v in data.items()}
+    if isinstance(data, (list, tuple)):
+        return [_json_safe(v) for v in data]
+    if hasattr(data, "item"):
+        try:
+            return _json_safe(data.item())
+        except Exception:
+            pass
+    return str(data)
 
 
 def _invoke_handler(
-    fn: Callable,
+    fn: Any,
     request: Request,
-    data: list[Any],
+    args: list[Any] | None = None,
+    kwargs: dict[str, Any] | None = None,
 ) -> Any:
     sig = inspect.signature(fn)
     params = list(sig.parameters.values())
-    pos_args: list[Any] = []
-    di = 0
-    for p in params:
-        if p.name == "request":
-            pos_args.append(request)
+    positional_args: list[Any] = []
+    keyword_args: dict[str, Any] = {}
+    args = list(args or [])
+    kwargs = dict(kwargs or {})
+    data_index = 0
+
+    for param in params:
+        if param.name == "request":
+            keyword_args["request"] = request
+        elif param.name in kwargs:
+            keyword_args[param.name] = kwargs.pop(param.name)
+        elif data_index < len(args):
+            positional_args.append(args[data_index])
+            data_index += 1
+        elif param.default is inspect.Signature.empty:
+            positional_args.append(None)
+
+    return fn(*positional_args, **keyword_args)
+
+
+async def version_handler(request: Request) -> Response:
+    package_json = Path(__file__).parent / "package.json"
+    version = json.loads(package_json.read_text())["version"]
+    mcp_enabled = bool(getattr(request.app.state, "mcp_enabled", False))
+    return JSONResponse(
+        {
+            "version": version,
+            "api_version": HTTP_API_VERSION,
+            "api_transport": "http",
+            "mcp_enabled": mcp_enabled,
+            "mcp_path": "/mcp" if mcp_enabled else None,
+        }
+    )
+
+
+async def api_handler(request: Request) -> Response:
+    api_registry = request.app.state.api_registry
+    api_name = request.path_params["api_name"]
+    fn = api_registry.get(api_name)
+    if fn is None:
+        return JSONResponse({"error": f"Unknown API: {api_name}"}, status_code=404)
+
+    try:
+        body = await request.json()
+    except Exception:
+        body = {}
+
+    args: list[Any] = []
+    kwargs: dict[str, Any] = {}
+    if isinstance(body, dict):
+        if "args" in body or "kwargs" in body:
+            args = body.get("args") or []
+            kwargs = body.get("kwargs") or {}
+        elif "data" in body and isinstance(body["data"], list):
+            args = body["data"]
         else:
-            if di < len(data):
-                pos_args.append(data[di])
-            else:
-                pos_args.append(None)
-            di += 1
-    return fn(*pos_args)
+            kwargs = body
+    elif isinstance(body, list):
+        args = body
+    elif body is not None:
+        args = [body]
+
+    if not isinstance(args, list):
+        args = [args]
+    if not isinstance(kwargs, dict):
+        kwargs = {}
+
+    try:
+        result = _invoke_handler(fn, request, args=args, kwargs=kwargs)
+        return JSONResponse({"data": _json_safe(result)})
+    except TrackioAPIError as e:
+        return JSONResponse({"error": str(e)}, status_code=400)
+    except Exception as e:
+        return JSONResponse({"error": str(e)}, status_code=500)
 
 
-class _EventStore:
-    def __init__(self) -> None:
-        self._results: dict[str, tuple[Any, bool, str | None]] = {}
-
-    def store_result(
-        self, event_id: str, result: Any, is_error: bool, err_msg: str | None
-    ) -> None:
-        self._results[event_id] = (result, is_error, err_msg)
-
-    def pop(self, event_id: str) -> tuple[Any, bool, str | None] | None:
-        return self._results.pop(event_id, None)
-
-
-_event_store = _EventStore()
-
-
-def build_gradio_compat_handlers(
-    api_registry: dict[str, Callable[..., Any]],
-) -> tuple[Callable, Callable]:
-    async def call_post(request: Request) -> Response:
-        api_name = request.path_params["api_name"].lstrip("/")
-        fn = api_registry.get(api_name)
-        if fn is None:
-            return JSONResponse({"detail": f"Unknown API: {api_name}"}, status_code=404)
-        try:
-            body = await request.json()
-        except Exception:
-            body = {}
-        data = body.get("data") or []
-        if not isinstance(data, list):
-            data = [data]
-        event_id = secrets.token_urlsafe(16)
-        try:
-            out = await asyncio.to_thread(_invoke_handler, fn, request, data)
-            _event_store.store_result(event_id, out, False, None)
-        except TrackioAPIError as e:
-            _event_store.store_result(event_id, None, True, str(e))
-        except Exception:
-            tb = traceback.format_exc()
-            print(tb)
-            _event_store.store_result(event_id, None, True, tb)
-        return JSONResponse({"event_id": event_id})
-
-    async def call_get(request: Request) -> Response:
-        event_id = request.path_params["event_id"]
-
-        async def sse_gen():
-            for _ in range(500):
-                await asyncio.sleep(0.005)
-                got = _event_store.pop(event_id)
-                if got is not None:
-                    result, is_err, err_msg = got
-                    if is_err:
-                        payload = json.dumps(err_msg)
-                        yield f"event: error\ndata: {payload}\n\n"
-                    else:
-                        wrapped = [result] if not isinstance(result, list) else result
-                        payload = _serialize_result(wrapped)
-                        yield f"event: complete\ndata: {payload}\n\n"
-                    return
-            err = json.dumps("timeout waiting for result")
-            yield f"event: error\ndata: {err}\n\n"
-
-        return StreamingResponse(sse_gen(), media_type="text/event-stream")
-
-    return call_post, call_get
+async def upload_handler(request: Request) -> Response:
+    form = await request.form()
+    uploads = form.getlist("files")
+    saved_paths = []
+    for upload in uploads:
+        suffix = Path(getattr(upload, "filename", "") or "").suffix
+        with tempfile.NamedTemporaryFile(
+            delete=False,
+            prefix="trackio-upload-",
+            suffix=suffix,
+        ) as tmp:
+            tmp.write(await upload.read())
+            saved_paths.append(tmp.name)
+    return JSONResponse({"paths": saved_paths})
 
 
-async def gradio_file_handler(request: Request) -> Response:
-    from pathlib import Path
-    from urllib.parse import unquote
-
-    rest = request.path_params.get("rest", "")
-    if not rest.startswith("file="):
-        return Response("Not found", status_code=404)
-    fs_path = unquote(rest[5:])
-    fp = Path(fs_path)
+async def file_handler(request: Request) -> Response:
+    fs_path = request.query_params.get("path")
+    if fs_path is None:
+        return Response("Missing path", status_code=400)
+    fp = Path(unquote(fs_path))
     if fp.is_file():
         return FileResponse(str(fp))
     return Response("Not found", status_code=404)
 
 
-async def startup_events_handler(request: Request) -> Response:
-    return JSONResponse({"status": "ok"})
-
-
 def create_trackio_starlette_app(
     oauth_routes: list[Route],
-    api_registry: dict[str, Callable[..., Any]],
+    api_registry: dict[str, Any],
+    extra_routes: list[Any] | None = None,
     mcp_lifespan: Any = None,
+    mcp_enabled: bool = False,
 ) -> Starlette:
-    call_post, call_get = build_gradio_compat_handlers(api_registry)
     routes: list[Any] = list(oauth_routes)
-    routes.append(
-        Route(
-            API_PREFIX + "/call/{api_name:path}",
-            endpoint=call_post,
-            methods=["POST"],
-        )
+    routes.extend(
+        [
+            Route("/version", endpoint=version_handler, methods=["GET"]),
+            Route("/api/upload", endpoint=upload_handler, methods=["POST"]),
+            Route("/api/{api_name:str}", endpoint=api_handler, methods=["POST"]),
+            Route("/file", endpoint=file_handler, methods=["GET"]),
+        ]
     )
-    routes.append(
-        Route(
-            API_PREFIX + "/call/{api_name:path}/{event_id}",
-            endpoint=call_get,
-            methods=["GET"],
-        )
-    )
-    routes.append(
-        Route(
-            API_PREFIX + "/startup-events",
-            endpoint=startup_events_handler,
-            methods=["GET"],
-        )
-    )
-    routes.append(
-        Route(
-            API_PREFIX + "/{rest:path}", endpoint=gradio_file_handler, methods=["GET"]
-        )
-    )
-    return Starlette(routes=routes, lifespan=mcp_lifespan)
+    routes.extend(extra_routes or [])
+    app = Starlette(routes=routes, lifespan=mcp_lifespan)
+    app.state.api_registry = api_registry
+    app.state.mcp_enabled = mcp_enabled
+    return app

--- a/trackio/asgi_app.py
+++ b/trackio/asgi_app.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+import asyncio
+import inspect
+import json
+import secrets
+import traceback
+from collections.abc import Callable
+from typing import Any
+
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import FileResponse, JSONResponse, Response, StreamingResponse
+from starlette.routing import Route
+
+from trackio.exceptions import TrackioAPIError
+
+API_PREFIX = "/gradio_api"
+
+
+def _serialize_result(data: Any) -> str:
+    def default(o: Any):
+        if isinstance(o, (dict, list, str, int, float, bool)) or o is None:
+            return o
+        if hasattr(o, "item"):
+            try:
+                return o.item()
+            except Exception:
+                pass
+        return str(o)
+
+    return json.dumps(data, default=default)
+
+
+def _invoke_handler(
+    fn: Callable,
+    request: Request,
+    data: list[Any],
+) -> Any:
+    sig = inspect.signature(fn)
+    params = list(sig.parameters.values())
+    pos_args: list[Any] = []
+    di = 0
+    for p in params:
+        if p.name == "request":
+            pos_args.append(request)
+        else:
+            if di < len(data):
+                pos_args.append(data[di])
+            else:
+                pos_args.append(None)
+            di += 1
+    return fn(*pos_args)
+
+
+class _EventStore:
+    def __init__(self) -> None:
+        self._results: dict[str, tuple[Any, bool, str | None]] = {}
+
+    def store_result(
+        self, event_id: str, result: Any, is_error: bool, err_msg: str | None
+    ) -> None:
+        self._results[event_id] = (result, is_error, err_msg)
+
+    def pop(self, event_id: str) -> tuple[Any, bool, str | None] | None:
+        return self._results.pop(event_id, None)
+
+
+_event_store = _EventStore()
+
+
+def build_gradio_compat_handlers(
+    api_registry: dict[str, Callable[..., Any]],
+) -> tuple[Callable, Callable]:
+    async def call_post(request: Request) -> Response:
+        api_name = request.path_params["api_name"].lstrip("/")
+        fn = api_registry.get(api_name)
+        if fn is None:
+            return JSONResponse({"detail": f"Unknown API: {api_name}"}, status_code=404)
+        try:
+            body = await request.json()
+        except Exception:
+            body = {}
+        data = body.get("data") or []
+        if not isinstance(data, list):
+            data = [data]
+        event_id = secrets.token_urlsafe(16)
+        try:
+            out = await asyncio.to_thread(_invoke_handler, fn, request, data)
+            _event_store.store_result(event_id, out, False, None)
+        except TrackioAPIError as e:
+            _event_store.store_result(event_id, None, True, str(e))
+        except Exception:
+            tb = traceback.format_exc()
+            print(tb)
+            _event_store.store_result(event_id, None, True, tb)
+        return JSONResponse({"event_id": event_id})
+
+    async def call_get(request: Request) -> Response:
+        event_id = request.path_params["event_id"]
+
+        async def sse_gen():
+            for _ in range(500):
+                await asyncio.sleep(0.005)
+                got = _event_store.pop(event_id)
+                if got is not None:
+                    result, is_err, err_msg = got
+                    if is_err:
+                        payload = json.dumps(err_msg)
+                        yield f"event: error\ndata: {payload}\n\n"
+                    else:
+                        wrapped = [result] if not isinstance(result, list) else result
+                        payload = _serialize_result(wrapped)
+                        yield f"event: complete\ndata: {payload}\n\n"
+                    return
+            err = json.dumps("timeout waiting for result")
+            yield f"event: error\ndata: {err}\n\n"
+
+        return StreamingResponse(sse_gen(), media_type="text/event-stream")
+
+    return call_post, call_get
+
+
+async def gradio_file_handler(request: Request) -> Response:
+    from pathlib import Path
+    from urllib.parse import unquote
+
+    rest = request.path_params.get("rest", "")
+    if not rest.startswith("file="):
+        return Response("Not found", status_code=404)
+    fs_path = unquote(rest[5:])
+    fp = Path(fs_path)
+    if fp.is_file():
+        return FileResponse(str(fp))
+    return Response("Not found", status_code=404)
+
+
+async def startup_events_handler(request: Request) -> Response:
+    return JSONResponse({"status": "ok"})
+
+
+def create_trackio_starlette_app(
+    oauth_routes: list[Route],
+    api_registry: dict[str, Callable[..., Any]],
+    mcp_lifespan: Any = None,
+) -> Starlette:
+    call_post, call_get = build_gradio_compat_handlers(api_registry)
+    routes: list[Any] = list(oauth_routes)
+    routes.append(
+        Route(
+            API_PREFIX + "/call/{api_name:path}",
+            endpoint=call_post,
+            methods=["POST"],
+        )
+    )
+    routes.append(
+        Route(
+            API_PREFIX + "/call/{api_name:path}/{event_id}",
+            endpoint=call_get,
+            methods=["GET"],
+        )
+    )
+    routes.append(
+        Route(
+            API_PREFIX + "/startup-events",
+            endpoint=startup_events_handler,
+            methods=["GET"],
+        )
+    )
+    routes.append(
+        Route(
+            API_PREFIX + "/{rest:path}", endpoint=gradio_file_handler, methods=["GET"]
+        )
+    )
+    return Starlette(routes=routes, lifespan=mcp_lifespan)

--- a/trackio/asgi_app.py
+++ b/trackio/asgi_app.py
@@ -17,6 +17,9 @@ from starlette.routing import Route
 from trackio.exceptions import TrackioAPIError
 from trackio.remote_client import HTTP_API_VERSION
 
+_PACKAGE_JSON_PATH = Path(__file__).parent / "package.json"
+_TRACKIO_PACKAGE_VERSION = json.loads(_PACKAGE_JSON_PATH.read_text())["version"]
+
 
 def _normalize_allowed_file_roots(
     allowed_file_roots: list[str | Path] | None,
@@ -121,12 +124,10 @@ def _invoke_handler(
 
 
 async def version_handler(request: Request) -> Response:
-    package_json = Path(__file__).parent / "package.json"
-    version = json.loads(package_json.read_text())["version"]
     mcp_enabled = bool(getattr(request.app.state, "mcp_enabled", False))
     return JSONResponse(
         {
-            "version": version,
+            "version": _TRACKIO_PACKAGE_VERSION,
             "api_version": HTTP_API_VERSION,
             "api_transport": "http",
             "mcp_enabled": mcp_enabled,
@@ -197,7 +198,7 @@ async def file_handler(request: Request) -> Response:
     fs_path = request.query_params.get("path")
     if fs_path is None:
         return Response("Missing path", status_code=400)
-    fp = Path(unquote(fs_path))
+    fp = Path(unquote(fs_path)).resolve(strict=False)
     allowed_roots = getattr(request.app.state, "allowed_file_roots", ())
     if fp.is_file() and _is_allowed_file_path(fp, allowed_roots):
         return FileResponse(str(fp))

--- a/trackio/asgi_app.py
+++ b/trackio/asgi_app.py
@@ -4,6 +4,7 @@ import inspect
 import json
 import math
 import tempfile
+import threading
 from pathlib import Path
 from typing import Any
 from urllib.parse import unquote
@@ -52,6 +53,31 @@ def _json_safe(data: Any) -> Any:
         except Exception:
             pass
     return str(data)
+
+
+def register_uploaded_temp_file(request: Request, file_path: str | Path) -> None:
+    resolved_path = Path(file_path).resolve(strict=False)
+    with request.app.state.uploaded_temp_files_lock:
+        request.app.state.uploaded_temp_files.add(resolved_path)
+
+
+def consume_uploaded_temp_file(request: Request, file_data: Any) -> Path:
+    file_path = file_data.get("path") if isinstance(file_data, dict) else None
+    if not isinstance(file_path, str) or not file_path:
+        raise TrackioAPIError("Expected uploaded file metadata with a valid path.")
+
+    resolved_path = Path(file_path).resolve(strict=False)
+    with request.app.state.uploaded_temp_files_lock:
+        if resolved_path not in request.app.state.uploaded_temp_files:
+            raise TrackioAPIError(
+                "Uploaded file was not created by this Trackio server."
+            )
+        request.app.state.uploaded_temp_files.remove(resolved_path)
+
+    if not resolved_path.is_file():
+        raise TrackioAPIError("Uploaded file is missing.")
+
+    return resolved_path
 
 
 def _invoke_handler(
@@ -162,6 +188,7 @@ async def upload_handler(request: Request) -> Response:
             suffix=suffix,
         ) as tmp:
             tmp.write(await upload.read())
+            register_uploaded_temp_file(request, tmp.name)
             saved_paths.append(tmp.name)
     return JSONResponse({"paths": saved_paths})
 
@@ -199,4 +226,6 @@ def create_trackio_starlette_app(
     app.state.api_registry = api_registry
     app.state.mcp_enabled = mcp_enabled
     app.state.allowed_file_roots = _normalize_allowed_file_roots(allowed_file_roots)
+    app.state.uploaded_temp_files = set()
+    app.state.uploaded_temp_files_lock = threading.Lock()
     return app

--- a/trackio/asgi_app.py
+++ b/trackio/asgi_app.py
@@ -17,6 +17,26 @@ from trackio.exceptions import TrackioAPIError
 from trackio.remote_client import HTTP_API_VERSION
 
 
+def _normalize_allowed_file_roots(
+    allowed_file_roots: list[str | Path] | None,
+) -> tuple[Path, ...]:
+    roots = []
+    for root in allowed_file_roots or []:
+        roots.append(Path(root).resolve())
+    return tuple(roots)
+
+
+def _is_allowed_file_path(path: Path, allowed_roots: tuple[Path, ...]) -> bool:
+    resolved_path = path.resolve(strict=False)
+    for root in allowed_roots:
+        try:
+            resolved_path.relative_to(root)
+            return True
+        except ValueError:
+            continue
+    return False
+
+
 def _json_safe(data: Any) -> Any:
     if data is None or isinstance(data, (str, bool, int)):
         return data
@@ -51,13 +71,25 @@ def _invoke_handler(
     for param in params:
         if param.name == "request":
             keyword_args["request"] = request
+        elif param.kind == inspect.Parameter.VAR_POSITIONAL:
+            positional_args.extend(args[data_index:])
+            data_index = len(args)
+        elif param.kind == inspect.Parameter.VAR_KEYWORD:
+            keyword_args.update(kwargs)
+            kwargs.clear()
         elif param.name in kwargs:
             keyword_args[param.name] = kwargs.pop(param.name)
-        elif data_index < len(args):
+        elif param.kind in (
+            inspect.Parameter.POSITIONAL_ONLY,
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+        ) and data_index < len(args):
             positional_args.append(args[data_index])
             data_index += 1
-        elif param.default is inspect.Signature.empty:
-            positional_args.append(None)
+        elif param.default is inspect.Signature.empty and param.kind not in (
+            inspect.Parameter.VAR_POSITIONAL,
+            inspect.Parameter.VAR_KEYWORD,
+        ):
+            raise TrackioAPIError(f"Missing required parameter: {param.name}")
 
     return fn(*positional_args, **keyword_args)
 
@@ -139,7 +171,8 @@ async def file_handler(request: Request) -> Response:
     if fs_path is None:
         return Response("Missing path", status_code=400)
     fp = Path(unquote(fs_path))
-    if fp.is_file():
+    allowed_roots = getattr(request.app.state, "allowed_file_roots", ())
+    if fp.is_file() and _is_allowed_file_path(fp, allowed_roots):
         return FileResponse(str(fp))
     return Response("Not found", status_code=404)
 
@@ -150,6 +183,7 @@ def create_trackio_starlette_app(
     extra_routes: list[Any] | None = None,
     mcp_lifespan: Any = None,
     mcp_enabled: bool = False,
+    allowed_file_roots: list[str | Path] | None = None,
 ) -> Starlette:
     routes: list[Any] = list(oauth_routes)
     routes.extend(
@@ -164,4 +198,5 @@ def create_trackio_starlette_app(
     app = Starlette(routes=routes, lifespan=mcp_lifespan)
     app.state.api_registry = api_registry
     app.state.mcp_enabled = mcp_enabled
+    app.state.allowed_file_roots = _normalize_allowed_file_roots(allowed_file_roots)
     return app

--- a/trackio/deploy.py
+++ b/trackio/deploy.py
@@ -15,7 +15,6 @@ if sys.version_info >= (3, 11):
 else:
     import tomli as tomllib
 
-import gradio
 import httpx
 import huggingface_hub
 from gradio_client import Client, handle_file
@@ -194,7 +193,7 @@ def deploy_as_space(
         else:
             raise ValueError(f"Failed to create Space: {e}")
 
-    # We can assume pandas, gradio, and huggingface-hub are already installed in a Gradio Space.
+    # We can assume pandas and huggingface-hub are available; requirements.txt pins trackio.
     # Make sure necessary dependencies are installed by creating a requirements.txt.
     is_source_install = _is_trackio_installed_from_source()
 
@@ -203,7 +202,7 @@ def deploy_as_space(
 
     with open(Path(trackio_path, "README.md"), "r") as f:
         readme_content = f.read()
-        readme_content = readme_content.replace("{GRADIO_VERSION}", gradio.__version__)
+        readme_content = readme_content.replace("{GRADIO_VERSION}", trackio.__version__)
         readme_content = readme_content.replace("{APP_FILE}", "app.py")
         readme_content = readme_content.replace(
             "{LINKED_HUB_METADATA}", _readme_linked_hub_yaml(dataset_id)

--- a/trackio/deploy.py
+++ b/trackio/deploy.py
@@ -199,7 +199,7 @@ def deploy_as_space(
         else:
             raise ValueError(f"Failed to create Space: {e}")
 
-    # We can assume pandas and huggingface-hub are available; requirements.txt pins trackio.
+    # We can assume huggingface-hub is available; requirements.txt pins trackio.
     # Make sure necessary dependencies are installed by creating a requirements.txt.
     is_source_install = _is_trackio_installed_from_source()
 

--- a/trackio/deploy.py
+++ b/trackio/deploy.py
@@ -889,9 +889,7 @@ def sync(
                     space_id, bucket_id=bucket_id, private=private
                 )
                 _wait_for_remote_sync(
-                    RemoteClient(
-                        space_id, verbose=False, httpx_kwargs={"timeout": 90}
-                    ),
+                    RemoteClient(space_id, verbose=False, httpx_kwargs={"timeout": 90}),
                     project,
                     Counter(
                         log["run"]

--- a/trackio/deploy.py
+++ b/trackio/deploy.py
@@ -208,7 +208,7 @@ def deploy_as_space(
 
     with open(Path(trackio_path, "README.md"), "r") as f:
         readme_content = f.read()
-        readme_content = readme_content.replace("{GRADIO_VERSION}", trackio.__version__)
+        readme_content = readme_content.replace("sdk_version: {GRADIO_VERSION}\n", "")
         readme_content = readme_content.replace("{APP_FILE}", "app.py")
         readme_content = readme_content.replace(
             "{LINKED_HUB_METADATA}", _readme_linked_hub_yaml(dataset_id)

--- a/trackio/deploy.py
+++ b/trackio/deploy.py
@@ -17,7 +17,7 @@ else:
 
 import httpx
 import huggingface_hub
-from gradio_client import Client, handle_file
+from gradio_client import handle_file
 from httpx import ReadTimeout
 from huggingface_hub import Volume
 from huggingface_hub.errors import HfHubHTTPError, RepositoryNotFoundError
@@ -29,6 +29,7 @@ from trackio.bucket_storage import (
     upload_project_to_bucket,
     upload_project_to_bucket_for_static,
 )
+from trackio.remote_client import RemoteClient
 from trackio.sqlite_storage import SQLiteStorage
 from trackio.utils import (
     MEDIA_DIR,
@@ -120,7 +121,12 @@ def _get_source_install_dependencies() -> str:
     spaces_deps = (
         pyproject["project"].get("optional-dependencies", {}).get("spaces", [])
     )
-    return "\n".join(deps + spaces_deps)
+    mcp_deps = pyproject["project"].get("optional-dependencies", {}).get("mcp", [])
+    return "\n".join(deps + spaces_deps + mcp_deps)
+
+
+def _get_space_install_requirement() -> str:
+    return f"trackio[spaces,mcp]=={trackio.__version__}"
 
 
 def _is_trackio_installed_from_source() -> bool:
@@ -218,7 +224,7 @@ def deploy_as_space(
     if is_source_install:
         requirements_content = _get_source_install_dependencies()
     else:
-        requirements_content = f"trackio[spaces]=={trackio.__version__}"
+        requirements_content = _get_space_install_requirement()
 
     requirements_buffer = io.BytesIO(requirements_content.encode("utf-8"))
     hf_api.upload_file(
@@ -432,8 +438,8 @@ def upload_db_to_space(project: str, space_id: str, force: bool = False) -> None
     """
     Uploads the database of a local Trackio project to a Hugging Face Space.
 
-    This uses the Gradio Client to upload since we do not want to trigger a new build of
-    the Space, which would happen if we used `huggingface_hub.upload_file`.
+    This uses the Trackio remote client so newer Trackio Spaces can speak the direct
+    HTTP API while older Gradio-based Spaces still work through `gradio_client`.
 
     Args:
         project (`str`):
@@ -445,7 +451,11 @@ def upload_db_to_space(project: str, space_id: str, force: bool = False) -> None
             prompts for confirmation.
     """
     db_path = SQLiteStorage.get_project_db_path(project)
-    client = Client(space_id, verbose=False, httpx_kwargs={"timeout": 90})
+    client = RemoteClient(
+        space_id,
+        hf_token=huggingface_hub.utils.get_token(),
+        httpx_kwargs={"timeout": 90},
+    )
 
     if not force:
         try:
@@ -494,9 +504,13 @@ def sync_incremental(
     )
     create_space_if_not_exists(space_id, private=private)
     wait_until_space_exists(space_id)
-
-    client = Client(space_id, verbose=False, httpx_kwargs={"timeout": 90})
     hf_token = huggingface_hub.utils.get_token()
+
+    client = RemoteClient(
+        space_id,
+        hf_token=hf_token,
+        httpx_kwargs={"timeout": 90},
+    )
 
     if pending_only:
         pending_logs = SQLiteStorage.get_pending_logs(project)

--- a/trackio/exceptions.py
+++ b/trackio/exceptions.py
@@ -1,0 +1,2 @@
+class TrackioAPIError(Exception):
+    pass

--- a/trackio/frontend/src/lib/api.js
+++ b/trackio/frontend/src/lib/api.js
@@ -39,49 +39,22 @@ function getOauthSessionHeader() {
 }
 
 export async function callApi(apiName, params = {}) {
-  const url = `${BASE}/gradio_api/call${apiName}`;
+  const cleanApiName = apiName.startsWith("/") ? apiName.slice(1) : apiName;
+  const url = `${BASE}/api/${cleanApiName}`;
   const resp = await fetch(url, {
     method: "POST",
     credentials: "include",
     headers: { "Content-Type": "application/json", ...getOauthSessionHeader() },
-    body: JSON.stringify({ data: Object.values(params) }),
+    body: JSON.stringify(params),
   });
   if (!resp.ok) {
     throw new Error(`API call ${apiName} failed: ${resp.status}`);
   }
   const json = await resp.json();
-  const eventId = json.event_id;
-
-  const dataResp = await fetch(`${BASE}/gradio_api/call${apiName}/${eventId}`, {
-    credentials: "include",
-  });
-  if (!dataResp.ok) {
-    throw new Error(`API result ${apiName} failed: ${dataResp.status}`);
+  if (json.error) {
+    throw new Error(json.error);
   }
-
-  const text = await dataResp.text();
-  const lines = text.trim().split("\n");
-  for (let i = 0; i < lines.length; i++) {
-    if (lines[i].startsWith("event: complete")) {
-      const dataLine = lines[i + 1];
-      if (dataLine && dataLine.startsWith("data: ")) {
-        const raw = dataLine.slice(6);
-        const sanitized = raw
-          .replace(/:\s*Infinity\b/g, ": null")
-          .replace(/:\s*-Infinity\b/g, ": null")
-          .replace(/:\s*NaN\b/g, ": null");
-        const parsed = JSON.parse(sanitized);
-        return Array.isArray(parsed) ? parsed[0] : parsed;
-      }
-    }
-    if (lines[i].startsWith("event: error")) {
-      const dataLine = lines[i + 1];
-      if (dataLine && dataLine.startsWith("data: ")) {
-        throw new Error(JSON.parse(dataLine.slice(6)));
-      }
-    }
-  }
-  throw new Error(`No complete event for ${apiName}`);
+  return json.data;
 }
 
 export async function getAllProjects() {
@@ -190,17 +163,17 @@ export function setMediaDir(dir) {
 
 export function getAssetUrl(path) {
   if (_staticMode) return staticApi.getAssetUrl(path);
-  return `${BASE}/gradio_api/file=${_mediaDir}${path}`;
+  return `${BASE}/file?path=${encodeURIComponent(`${_mediaDir}${path}`)}`;
 }
 
 export function getMediaUrl(path) {
   if (_staticMode) return staticApi.getMediaUrl(path);
-  return `${BASE}/gradio_api/file=${_mediaDir}${path}`;
+  return `${BASE}/file?path=${encodeURIComponent(`${_mediaDir}${path}`)}`;
 }
 
 export function getFileUrl(path) {
   if (_staticMode) return staticApi.getMediaUrl(path);
-  return `${BASE}/gradio_api/file=${path}`;
+  return `${BASE}/file?path=${encodeURIComponent(path)}`;
 }
 
 export async function getReadOnlySource() {

--- a/trackio/frontend_server.py
+++ b/trackio/frontend_server.py
@@ -1,4 +1,4 @@
-"""Serves the built Svelte frontend alongside the Gradio API."""
+"""Serves the built Svelte frontend alongside the Trackio HTTP API."""
 
 import logging
 import re

--- a/trackio/imports.py
+++ b/trackio/imports.py
@@ -1,7 +1,6 @@
+import csv
 import os
 from pathlib import Path
-
-import pandas as pd
 
 from trackio import deploy, utils
 from trackio.sqlite_storage import SQLiteStorage
@@ -57,15 +56,22 @@ def import_csv(
     if not csv_path.exists():
         raise FileNotFoundError(f"CSV file not found: {csv_path}")
 
-    df = pd.read_csv(csv_path)
-    if df.empty:
+    with csv_path.open(newline="", encoding="utf-8") as csv_file:
+        reader = csv.DictReader(csv_file)
+        source_columns = reader.fieldnames or []
+        rows = list(reader)
+
+    if not rows:
         raise ValueError("CSV file is empty")
 
-    column_mapping = utils.simplify_column_names(df.columns.tolist())
-    df = df.rename(columns=column_mapping)
+    column_mapping = utils.simplify_column_names(source_columns)
+    normalized_rows = [
+        {column_mapping[key]: value for key, value in row.items()} for row in rows
+    ]
+    columns = list(normalized_rows[0].keys())
 
     step_column = None
-    for col in df.columns:
+    for col in columns:
         if col.lower() == "step":
             step_column = col
             break
@@ -81,30 +87,34 @@ def import_csv(
     timestamps = []
 
     numeric_columns = []
-    for column in df.columns:
+    for column in columns:
         if column == step_column:
             continue
         if column == "timestamp":
             continue
 
         try:
-            pd.to_numeric(df[column], errors="raise")
-            numeric_columns.append(column)
+            for row in normalized_rows:
+                value = row[column]
+                if value in ("", None):
+                    continue
+                float(value)
         except (ValueError, TypeError):
             continue
+        numeric_columns.append(column)
 
-    for _, row in df.iterrows():
+    for row in normalized_rows:
         metrics = {}
         for column in numeric_columns:
             value = row[column]
-            if bool(pd.notna(value)):
+            if value not in ("", None):
                 metrics[column] = float(value)
 
         if metrics:
             metrics_list.append(metrics)
-            steps.append(int(row[step_column]))
+            steps.append(int(float(row[step_column])))
 
-            if "timestamp" in df.columns and bool(pd.notna(row["timestamp"])):
+            if "timestamp" in row and row["timestamp"] not in ("", None):
                 timestamps.append(str(row["timestamp"]))
             else:
                 timestamps.append("")
@@ -236,8 +246,8 @@ def import_tf_events(
                 steps.append(step)
 
                 # Use wall_time if present, else fallback
-                if "wall_time" in group_df.columns and not bool(
-                    pd.isna(row["wall_time"])
+                if "wall_time" in group_df.columns and not utils.is_missing_value(
+                    row["wall_time"]
                 ):
                     timestamps.append(str(row["wall_time"]))
                 else:

--- a/trackio/launch.py
+++ b/trackio/launch.py
@@ -1,0 +1,211 @@
+from __future__ import annotations
+
+import os
+import secrets
+import socket
+import threading
+import time
+import warnings
+from typing import Any
+
+import httpx
+import uvicorn
+from uvicorn.config import Config
+
+from trackio.launch_utils import colab_check, is_hosted_notebook
+
+INITIAL_PORT_VALUE = int(os.getenv("GRADIO_SERVER_PORT", "7860"))
+TRY_NUM_PORTS = int(os.getenv("GRADIO_NUM_PORTS", "100"))
+LOCALHOST_NAME = os.getenv("GRADIO_SERVER_NAME", "127.0.0.1")
+
+
+class _UvicornServer(uvicorn.Server):
+    def install_signal_handlers(self) -> None:
+        pass
+
+    def run_in_thread(self) -> None:
+        self.thread = threading.Thread(target=self.run, daemon=True)
+        self.thread.start()
+        start = time.time()
+        while not self.started:
+            time.sleep(1e-3)
+            if time.time() - start > 60:
+                raise RuntimeError(
+                    "Server failed to start. Please check that the port is available."
+                )
+
+
+def _bind_host(server_name: str) -> str:
+    if server_name.startswith("[") and server_name.endswith("]"):
+        return server_name[1:-1]
+    return server_name
+
+
+def start_server(
+    app: Any,
+    server_name: str | None = None,
+    server_port: int | None = None,
+    ssl_keyfile: str | None = None,
+    ssl_certfile: str | None = None,
+    ssl_keyfile_password: str | None = None,
+) -> tuple[str, int, str, _UvicornServer]:
+    server_name = server_name or LOCALHOST_NAME
+    url_host_name = "localhost" if server_name == "0.0.0.0" else server_name
+
+    host = _bind_host(server_name)
+
+    server_ports = (
+        [server_port]
+        if server_port is not None
+        else range(INITIAL_PORT_VALUE, INITIAL_PORT_VALUE + TRY_NUM_PORTS)
+    )
+
+    port_used = None
+    server = None
+    for port in server_ports:
+        try:
+            s = socket.socket()
+            s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            s.bind((LOCALHOST_NAME, port))
+            s.close()
+            config = Config(
+                app=app,
+                port=port,
+                host=host,
+                log_level="warning",
+                ssl_keyfile=ssl_keyfile,
+                ssl_certfile=ssl_certfile,
+                ssl_keyfile_password=ssl_keyfile_password,
+            )
+            server = _UvicornServer(config=config)
+            server.run_in_thread()
+            port_used = port
+            break
+        except (OSError, RuntimeError):
+            continue
+    else:
+        raise OSError(
+            f"Cannot find empty port in range: {min(server_ports)}-{max(server_ports)}. "
+            "Set GRADIO_SERVER_PORT or pass server_port to trackio.show()."
+        )
+
+    assert port_used is not None and server is not None
+
+    if ssl_keyfile is not None:
+        path_to_local_server = f"https://{url_host_name}:{port_used}/"
+    else:
+        path_to_local_server = f"http://{url_host_name}:{port_used}/"
+
+    return server_name, port_used, path_to_local_server, server
+
+
+def launch_trackio_dashboard(
+    starlette_app: Any,
+    *,
+    server_name: str | None = None,
+    server_port: int | None = None,
+    share: bool | None = None,
+    share_server_address: str | None = None,
+    share_server_protocol: str | None = None,
+    share_server_tls_certificate: str | None = None,
+    mcp_server: bool = False,
+    ssl_verify: bool = True,
+    quiet: bool = False,
+) -> tuple[str | None, str | None, str | None, Any]:
+    from pathlib import Path
+
+    from trackio._vendor.networking import normalize_share_url, setup_tunnel
+    from trackio._vendor.tunneling import BINARY_PATH
+
+    is_colab = colab_check()
+    is_hosted_nb = is_hosted_notebook()
+    space_id = os.getenv("SPACE_ID")
+
+    if share is None:
+        if is_colab or is_hosted_nb:
+            if not quiet:
+                print(
+                    "It looks like you are running Trackio on a hosted Jupyter notebook, which requires "
+                    "`share=True`. Automatically setting `share=True` "
+                    "(set `share=False` in `show()` to disable).\n"
+                )
+            share = True
+        else:
+            share = os.getenv("GRADIO_SHARE", "").lower() == "true"
+
+    sn = server_name
+    if sn is None and os.getenv("SYSTEM") == "spaces":
+        sn = "0.0.0.0"
+    elif sn is None:
+        sn = LOCALHOST_NAME
+
+    server_name_r, server_port_r, local_url, uv_server = start_server(
+        starlette_app,
+        server_name=sn,
+        server_port=server_port,
+    )
+
+    local_api_url = f"{local_url.rstrip('/')}/gradio_api/"
+    try:
+        httpx.get(f"{local_api_url}startup-events", verify=ssl_verify, timeout=10)
+    except Exception as e:
+        raise RuntimeError(
+            f"Could not reach startup-events at {local_api_url}startup-events: {e}"
+        ) from e
+
+    if share and space_id:
+        warnings.warn("Setting share=True is not supported on Hugging Face Spaces")
+        share = False
+
+    share_url: str | None = None
+    if share:
+        try:
+            share_tok = secrets.token_urlsafe(32)
+            proto = share_server_protocol or (
+                "http" if share_server_address is not None else "https"
+            )
+            raw = setup_tunnel(
+                local_host=server_name_r,
+                local_port=server_port_r,
+                share_token=share_tok,
+                share_server_address=share_server_address,
+                share_server_tls_certificate=share_server_tls_certificate,
+            )
+            share_url = normalize_share_url(raw, proto)
+            if not quiet:
+                print(f"* Running on public URL: {share_url}")
+                print(
+                    "\nThis share link expires in 1 week. For permanent hosting, deploy to Hugging Face Spaces."
+                )
+        except Exception as e:
+            share_url = None
+            if not quiet:
+                from trackio._vendor.gradio_exceptions import ChecksumMismatchError
+
+                if isinstance(e, ChecksumMismatchError):
+                    print(
+                        "\nCould not create share link. Checksum mismatch for frpc binary."
+                    )
+                elif Path(BINARY_PATH).exists():
+                    print(
+                        "\nCould not create share link. Check your internet connection or https://status.gradio.app."
+                    )
+                else:
+                    print(
+                        f"\nCould not create share link. Missing frpc at {BINARY_PATH}. {e}"
+                    )
+
+    if not share_url and not quiet:
+        print("* To create a public link, set `share=True` in `trackio.show()`.")
+
+    if mcp_server and not quiet:
+        base = share_url or local_url.rstrip("/")
+        print(f"\n* MCP streamable HTTP: {base}/gradio_api/mcp/")
+
+    return local_url, share_url, local_api_url, uv_server
+
+
+def url_ok_local(local_url: str) -> bool:
+    from trackio._vendor.networking import url_ok
+
+    return url_ok(local_url)

--- a/trackio/launch.py
+++ b/trackio/launch.py
@@ -145,12 +145,12 @@ def launch_trackio_dashboard(
         server_port=server_port,
     )
 
-    local_api_url = f"{local_url.rstrip('/')}/gradio_api/"
+    local_api_url = f"{local_url.rstrip('/')}/api/"
     try:
-        httpx.get(f"{local_api_url}startup-events", verify=ssl_verify, timeout=10)
+        httpx.get(f"{local_url.rstrip('/')}/version", verify=ssl_verify, timeout=10)
     except Exception as e:
         raise RuntimeError(
-            f"Could not reach startup-events at {local_api_url}startup-events: {e}"
+            f"Could not reach Trackio server at {local_url.rstrip('/')}/version: {e}"
         ) from e
 
     if share and space_id:
@@ -197,10 +197,6 @@ def launch_trackio_dashboard(
 
     if not share_url and not quiet:
         print("* To create a public link, set `share=True` in `trackio.show()`.")
-
-    if mcp_server and not quiet:
-        base = share_url or local_url.rstrip("/")
-        print(f"\n* MCP streamable HTTP: {base}/gradio_api/mcp/")
 
     return local_url, share_url, local_api_url, uv_server
 

--- a/trackio/launch.py
+++ b/trackio/launch.py
@@ -6,12 +6,16 @@ import socket
 import threading
 import time
 import warnings
+from pathlib import Path
 from typing import Any
 
 import httpx
 import uvicorn
 from uvicorn.config import Config
 
+from trackio._vendor.gradio_exceptions import ChecksumMismatchError
+from trackio._vendor.networking import normalize_share_url, setup_tunnel, url_ok
+from trackio._vendor.tunneling import BINARY_PATH
 from trackio.launch_utils import colab_check, is_hosted_notebook
 
 INITIAL_PORT_VALUE = int(os.getenv("GRADIO_SERVER_PORT", "7860"))
@@ -112,11 +116,6 @@ def launch_trackio_dashboard(
     ssl_verify: bool = True,
     quiet: bool = False,
 ) -> tuple[str | None, str | None, str | None, Any]:
-    from pathlib import Path
-
-    from trackio._vendor.networking import normalize_share_url, setup_tunnel
-    from trackio._vendor.tunneling import BINARY_PATH
-
     is_colab = colab_check()
     is_hosted_nb = is_hosted_notebook()
     space_id = os.getenv("SPACE_ID")
@@ -180,8 +179,6 @@ def launch_trackio_dashboard(
         except Exception as e:
             share_url = None
             if not quiet:
-                from trackio._vendor.gradio_exceptions import ChecksumMismatchError
-
                 if isinstance(e, ChecksumMismatchError):
                     print(
                         "\nCould not create share link. Checksum mismatch for frpc binary."
@@ -202,6 +199,4 @@ def launch_trackio_dashboard(
 
 
 def url_ok_local(local_url: str) -> bool:
-    from trackio._vendor.networking import url_ok
-
     return url_ok(local_url)

--- a/trackio/launch.py
+++ b/trackio/launch.py
@@ -68,10 +68,10 @@ def start_server(
     server = None
     for port in server_ports:
         try:
-            s = socket.socket()
-            s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-            s.bind((LOCALHOST_NAME, port))
-            s.close()
+            socket_family = socket.AF_INET6 if ":" in host else socket.AF_INET
+            with socket.socket(socket_family, socket.SOCK_STREAM) as s:
+                s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+                s.bind((host, port))
             config = Config(
                 app=app,
                 port=port,

--- a/trackio/launch_utils.py
+++ b/trackio/launch_utils.py
@@ -4,7 +4,7 @@ import os
 def colab_check() -> bool:
     is_colab = False
     try:
-        from IPython.core.getipython import get_ipython
+        from IPython.core.getipython import get_ipython  # noqa: PLC0415
 
         from_ipynb = get_ipython()
         if "google.colab" in str(from_ipynb):
@@ -24,7 +24,7 @@ def is_hosted_notebook() -> bool:
 def ipython_check() -> bool:
     is_ipython = False
     try:
-        from IPython.core.getipython import get_ipython
+        from IPython.core.getipython import get_ipython  # noqa: PLC0415
 
         if get_ipython() is not None:
             is_ipython = True

--- a/trackio/launch_utils.py
+++ b/trackio/launch_utils.py
@@ -1,0 +1,33 @@
+import os
+
+
+def colab_check() -> bool:
+    is_colab = False
+    try:
+        from IPython.core.getipython import get_ipython
+
+        from_ipynb = get_ipython()
+        if "google.colab" in str(from_ipynb):
+            is_colab = True
+    except (ImportError, NameError):
+        pass
+    return is_colab
+
+
+def is_hosted_notebook() -> bool:
+    return bool(
+        os.environ.get("KAGGLE_KERNEL_RUN_TYPE")
+        or os.path.exists("/home/ec2-user/SageMaker")
+    )
+
+
+def ipython_check() -> bool:
+    is_ipython = False
+    try:
+        from IPython.core.getipython import get_ipython
+
+        if get_ipython() is not None:
+            is_ipython = True
+    except (ImportError, NameError):
+        pass
+    return is_ipython

--- a/trackio/mcp_setup.py
+++ b/trackio/mcp_setup.py
@@ -1,0 +1,6 @@
+from contextlib import asynccontextmanager
+
+
+@asynccontextmanager
+async def mcp_lifespan_context(app):
+    yield

--- a/trackio/mcp_setup.py
+++ b/trackio/mcp_setup.py
@@ -14,16 +14,16 @@ def _assert_mcp_mutation_access(
     hf_token: str | None = None,
     write_token: str | None = None,
 ) -> None:
-    from trackio.server import check_hf_token_has_write_access, write_token as server_token  # noqa: I001, PLC0415
+    import trackio.server as trackio_server  # noqa: PLC0415
 
     if os.getenv("SYSTEM") == "spaces":
         try:
-            check_hf_token_has_write_access(hf_token)
+            trackio_server.check_hf_token_has_write_access(hf_token)
         except PermissionError as e:
             raise ValueError(str(e)) from e
         return
 
-    if write_token != server_token:
+    if write_token != trackio_server.write_token:
         raise ValueError(
             "A write_token is required for Trackio MCP mutations. "
             "Use the write token from the dashboard URL."
@@ -33,21 +33,7 @@ def _assert_mcp_mutation_access(
 def create_mcp_integration() -> tuple[list[Any], Any]:
     from mcp.server.fastmcp import FastMCP  # noqa: PLC0415
 
-    from trackio.server import (  # noqa: PLC0415
-        force_sync,
-        get_alerts,
-        get_all_projects,
-        get_logs,
-        get_metric_values,
-        get_metrics_for_run,
-        get_project_summary,
-        get_run_summary,
-        get_runs_for_project,
-        get_settings,
-        get_snapshot,
-        get_system_logs,
-        get_system_metrics_for_run,
-    )
+    import trackio.server as trackio_server  # noqa: PLC0415
 
     mcp = FastMCP(
         "Trackio",
@@ -57,62 +43,62 @@ def create_mcp_integration() -> tuple[list[Any], Any]:
     )
 
     mcp.add_tool(
-        get_all_projects,
+        trackio_server.get_all_projects,
         description="List all Trackio projects available on this server.",
         structured_output=True,
     )
     mcp.add_tool(
-        get_runs_for_project,
+        trackio_server.get_runs_for_project,
         description="List runs for a given Trackio project.",
         structured_output=True,
     )
     mcp.add_tool(
-        get_metrics_for_run,
+        trackio_server.get_metrics_for_run,
         description="List metric names recorded for a given Trackio run.",
         structured_output=True,
     )
     mcp.add_tool(
-        get_project_summary,
+        trackio_server.get_project_summary,
         description="Return summary metadata for a Trackio project.",
         structured_output=True,
     )
     mcp.add_tool(
-        get_run_summary,
+        trackio_server.get_run_summary,
         description="Return summary metadata for a Trackio run.",
         structured_output=True,
     )
     mcp.add_tool(
-        get_metric_values,
+        trackio_server.get_metric_values,
         description="Fetch metric values for a run, optionally around a step or time.",
         structured_output=True,
     )
     mcp.add_tool(
-        get_system_metrics_for_run,
+        trackio_server.get_system_metrics_for_run,
         description="List system metric names recorded for a run.",
         structured_output=True,
     )
     mcp.add_tool(
-        get_system_logs,
+        trackio_server.get_system_logs,
         description="Fetch system metric logs for a run.",
         structured_output=True,
     )
     mcp.add_tool(
-        get_snapshot,
+        trackio_server.get_snapshot,
         description="Fetch a single Trackio snapshot around a step or timestamp.",
         structured_output=True,
     )
     mcp.add_tool(
-        get_logs,
+        trackio_server.get_logs,
         description="Fetch Trackio metric logs for a run.",
         structured_output=True,
     )
     mcp.add_tool(
-        get_alerts,
+        trackio_server.get_alerts,
         description="Fetch alerts for a project, optionally filtered by run or level.",
         structured_output=True,
     )
     mcp.add_tool(
-        get_settings,
+        trackio_server.get_settings,
         description="Return Trackio dashboard settings and asset configuration.",
         structured_output=True,
     )
@@ -157,7 +143,7 @@ def create_mcp_integration() -> tuple[list[Any], Any]:
         write_token: str | None = None,
     ) -> bool:
         _assert_mcp_mutation_access(hf_token=hf_token, write_token=write_token)
-        return force_sync()
+        return trackio_server.force_sync()
 
     mcp_app = mcp.streamable_http_app()
 

--- a/trackio/mcp_setup.py
+++ b/trackio/mcp_setup.py
@@ -1,6 +1,169 @@
+from __future__ import annotations
+
+import os
 from contextlib import asynccontextmanager
+from typing import Any
+
+from starlette.routing import Mount
+
+from trackio.sqlite_storage import SQLiteStorage
 
 
-@asynccontextmanager
-async def mcp_lifespan_context(app):
-    yield
+def _assert_mcp_mutation_access(
+    *,
+    hf_token: str | None = None,
+    write_token: str | None = None,
+) -> None:
+    from trackio.server import check_hf_token_has_write_access, write_token as server_token  # noqa: I001, PLC0415
+
+    if os.getenv("SYSTEM") == "spaces":
+        try:
+            check_hf_token_has_write_access(hf_token)
+        except PermissionError as e:
+            raise ValueError(str(e)) from e
+        return
+
+    if write_token != server_token:
+        raise ValueError(
+            "A write_token is required for Trackio MCP mutations. "
+            "Use the write token from the dashboard URL."
+        )
+
+
+def create_mcp_integration() -> tuple[list[Any], Any]:
+    from mcp.server.fastmcp import FastMCP  # noqa: PLC0415
+
+    from trackio.server import (  # noqa: PLC0415
+        force_sync,
+        get_alerts,
+        get_all_projects,
+        get_logs,
+        get_metric_values,
+        get_metrics_for_run,
+        get_project_summary,
+        get_run_summary,
+        get_runs_for_project,
+        get_settings,
+        get_snapshot,
+        get_system_logs,
+        get_system_metrics_for_run,
+    )
+
+    mcp = FastMCP(
+        "Trackio",
+        instructions="Inspect and manage Trackio experiment data.",
+        streamable_http_path="/",
+        log_level="WARNING",
+    )
+
+    mcp.add_tool(
+        get_all_projects,
+        description="List all Trackio projects available on this server.",
+        structured_output=True,
+    )
+    mcp.add_tool(
+        get_runs_for_project,
+        description="List runs for a given Trackio project.",
+        structured_output=True,
+    )
+    mcp.add_tool(
+        get_metrics_for_run,
+        description="List metric names recorded for a given Trackio run.",
+        structured_output=True,
+    )
+    mcp.add_tool(
+        get_project_summary,
+        description="Return summary metadata for a Trackio project.",
+        structured_output=True,
+    )
+    mcp.add_tool(
+        get_run_summary,
+        description="Return summary metadata for a Trackio run.",
+        structured_output=True,
+    )
+    mcp.add_tool(
+        get_metric_values,
+        description="Fetch metric values for a run, optionally around a step or time.",
+        structured_output=True,
+    )
+    mcp.add_tool(
+        get_system_metrics_for_run,
+        description="List system metric names recorded for a run.",
+        structured_output=True,
+    )
+    mcp.add_tool(
+        get_system_logs,
+        description="Fetch system metric logs for a run.",
+        structured_output=True,
+    )
+    mcp.add_tool(
+        get_snapshot,
+        description="Fetch a single Trackio snapshot around a step or timestamp.",
+        structured_output=True,
+    )
+    mcp.add_tool(
+        get_logs,
+        description="Fetch Trackio metric logs for a run.",
+        structured_output=True,
+    )
+    mcp.add_tool(
+        get_alerts,
+        description="Fetch alerts for a project, optionally filtered by run or level.",
+        structured_output=True,
+    )
+    mcp.add_tool(
+        get_settings,
+        description="Return Trackio dashboard settings and asset configuration.",
+        structured_output=True,
+    )
+
+    @mcp.tool(
+        description="Delete a run. On Spaces, pass an hf_token with write access.",
+        structured_output=True,
+    )
+    def delete_run(
+        project: str,
+        run: str,
+        hf_token: str | None = None,
+        write_token: str | None = None,
+    ) -> bool:
+        _assert_mcp_mutation_access(hf_token=hf_token, write_token=write_token)
+        return SQLiteStorage.delete_run(project, run)
+
+    @mcp.tool(
+        description="Rename a run. On Spaces, pass an hf_token with write access.",
+        structured_output=True,
+    )
+    def rename_run(
+        project: str,
+        old_name: str,
+        new_name: str,
+        hf_token: str | None = None,
+        write_token: str | None = None,
+    ) -> bool:
+        _assert_mcp_mutation_access(hf_token=hf_token, write_token=write_token)
+        SQLiteStorage.rename_run(project, old_name, new_name)
+        return True
+
+    @mcp.tool(
+        description=(
+            "Trigger a Trackio export/sync pass. On Spaces, pass an hf_token with "
+            "write access."
+        ),
+        structured_output=True,
+    )
+    def trigger_sync(
+        hf_token: str | None = None,
+        write_token: str | None = None,
+    ) -> bool:
+        _assert_mcp_mutation_access(hf_token=hf_token, write_token=write_token)
+        return force_sync()
+
+    mcp_app = mcp.streamable_http_app()
+
+    @asynccontextmanager
+    async def mcp_lifespan_context(app):
+        async with mcp.session_manager.run():
+            yield
+
+    return [Mount("/mcp", app=mcp_app)], mcp_lifespan_context

--- a/trackio/mcp_setup.py
+++ b/trackio/mcp_setup.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import secrets
 from contextlib import asynccontextmanager
 from typing import Any
 
@@ -23,7 +24,7 @@ def _assert_mcp_mutation_access(
             raise ValueError(str(e)) from e
         return
 
-    if write_token != trackio_server.write_token:
+    if not secrets.compare_digest(write_token or "", trackio_server.write_token or ""):
         raise ValueError(
             "A write_token is required for Trackio MCP mutations. "
             "Use the write token from the dashboard URL."

--- a/trackio/remote_client.py
+++ b/trackio/remote_client.py
@@ -1,28 +1,179 @@
 from __future__ import annotations
 
-from gradio_client import Client
+from pathlib import Path
+from typing import Any
+from urllib.parse import urljoin
+
+import httpx
+from gradio_client import Client as GradioClient
+from huggingface_hub.utils import build_hf_headers
+
+HTTP_API_VERSION = 1
 
 
-class RemoteClient:
-    def __init__(self, space: str, hf_token: str | None = None):
-        self._space = space
-        kwargs: dict = {"verbose": False}
+def _normalize_src(src: str) -> str:
+    return src if src.endswith("/") else src + "/"
+
+
+def _space_id_to_url(space_id: str) -> str:
+    namespace, name = space_id.split("/", 1)
+    return f"https://{namespace}-{name}.hf.space/"
+
+
+def _resolve_src_url(src: str) -> str:
+    if src.startswith(("http://", "https://")):
+        return _normalize_src(src)
+    if "/" in src:
+        return _space_id_to_url(src)
+    raise ValueError(
+        f"Could not resolve Trackio remote source '{src}'. "
+        "Pass a full Space id like 'user/space' or a URL."
+    )
+
+
+def _is_local_file_data(value: Any) -> bool:
+    return (
+        isinstance(value, dict)
+        and "path" in value
+        and isinstance(value["path"], str)
+        and value.get("meta", {}).get("_type") == "gradio.FileData"
+        and Path(value["path"]).exists()
+    )
+
+
+class _TrackioHTTPClient:
+    def __init__(
+        self,
+        src: str,
+        hf_token: str | None = None,
+        httpx_kwargs: dict[str, Any] | None = None,
+    ) -> None:
+        self.src = _resolve_src_url(src)
+        self.httpx_kwargs = dict(httpx_kwargs or {})
+        self.headers = build_hf_headers(token=hf_token)
+
+    def _upload_file(self, file_data: dict[str, Any]) -> dict[str, Any]:
+        path = Path(file_data["path"])
+        with path.open("rb") as f:
+            resp = httpx.post(
+                urljoin(self.src, "api/upload"),
+                headers=self.headers,
+                files={"files": (path.name, f)},
+                **self.httpx_kwargs,
+            )
+        resp.raise_for_status()
+        uploaded_path = resp.json()["paths"][0]
+        return {
+            **file_data,
+            "path": uploaded_path,
+            "orig_name": file_data.get("orig_name", path.name),
+        }
+
+    def _prepare_value(self, value: Any) -> Any:
+        if _is_local_file_data(value):
+            return self._upload_file(value)
+        if isinstance(value, list):
+            return [self._prepare_value(item) for item in value]
+        if isinstance(value, tuple):
+            return [self._prepare_value(item) for item in value]
+        if isinstance(value, dict):
+            return {k: self._prepare_value(v) for k, v in value.items()}
+        return value
+
+    def predict(self, *args, api_name: str, **kwargs) -> Any:
+        api_name = api_name.lstrip("/")
+        payload = {
+            "args": self._prepare_value(list(args)),
+            "kwargs": self._prepare_value(kwargs),
+        }
+        resp = httpx.post(
+            urljoin(self.src, f"api/{api_name}"),
+            headers=self.headers,
+            json=payload,
+            **self.httpx_kwargs,
+        )
+        if resp.status_code == 404:
+            raise RuntimeError(
+                f"Space '{self.src}' does not support '/{api_name}'. Redeploy with `trackio sync`."
+            )
+        resp.raise_for_status()
+        body = resp.json()
+        if body.get("error") is not None:
+            raise RuntimeError(body["error"])
+        return body.get("data")
+
+
+class _TrackioGradioCompatClient:
+    def __init__(
+        self,
+        src: str,
+        hf_token: str | None = None,
+        httpx_kwargs: dict[str, Any] | None = None,
+        verbose: bool = False,
+    ) -> None:
+        kwargs: dict[str, Any] = {"verbose": verbose}
         if hf_token:
             kwargs["hf_token"] = hf_token
-        try:
-            self._client = Client(space, **kwargs)
-        except Exception as e:
-            raise ConnectionError(
-                f"Could not connect to Space '{space}'. Is it running?\n{e}"
-            )
+        if httpx_kwargs:
+            kwargs["httpx_kwargs"] = httpx_kwargs
+        self._client = GradioClient(src, **kwargs)
 
-    def predict(self, *args, api_name: str):
+    def predict(self, *args, api_name: str, **kwargs) -> Any:
         try:
-            return self._client.predict(*args, api_name=api_name)
+            return self._client.predict(*args, api_name=api_name, **kwargs)
         except Exception as e:
             if "API Not Found" in str(e) or "api_name" in str(e):
                 raise RuntimeError(
-                    f"Space '{self._space}' does not support '{api_name}'. "
+                    f"Space '{self._client.src}' does not support '{api_name}'. "
                     "Redeploy with `trackio sync`."
-                )
+                ) from e
             raise
+
+
+def _supports_http_api(
+    src: str,
+    hf_token: str | None = None,
+    httpx_kwargs: dict[str, Any] | None = None,
+) -> bool:
+    url = _resolve_src_url(src)
+    headers = build_hf_headers(token=hf_token)
+    kwargs = dict(httpx_kwargs or {})
+    kwargs.setdefault("timeout", 10)
+    try:
+        resp = httpx.get(urljoin(url, "version"), headers=headers, **kwargs)
+        if not resp.is_success:
+            return False
+        data = resp.json()
+        return data.get("api_version") == HTTP_API_VERSION
+    except Exception:
+        return False
+
+
+class RemoteClient:
+    def __init__(
+        self,
+        space: str,
+        hf_token: str | None = None,
+        httpx_kwargs: dict[str, Any] | None = None,
+        verbose: bool = False,
+    ) -> None:
+        self._space = space
+        try:
+            if _supports_http_api(space, hf_token=hf_token, httpx_kwargs=httpx_kwargs):
+                self._client = _TrackioHTTPClient(
+                    space, hf_token=hf_token, httpx_kwargs=httpx_kwargs
+                )
+            else:
+                self._client = _TrackioGradioCompatClient(
+                    space,
+                    hf_token=hf_token,
+                    httpx_kwargs=httpx_kwargs,
+                    verbose=verbose,
+                )
+        except Exception as e:
+            raise ConnectionError(
+                f"Could not connect to Space '{space}'. Is it running?\n{e}"
+            ) from e
+
+    def predict(self, *args, api_name: str, **kwargs) -> Any:
+        return self._client.predict(*args, api_name=api_name, **kwargs)

--- a/trackio/remote_client.py
+++ b/trackio/remote_client.py
@@ -17,7 +17,8 @@ def _normalize_src(src: str) -> str:
 
 def _space_id_to_url(space_id: str) -> str:
     namespace, name = space_id.split("/", 1)
-    return f"https://{namespace}-{name}.hf.space/"
+    subdomain = f"{namespace}-{name}".lower().replace("_", "-").replace(".", "-")
+    return f"https://{subdomain}.hf.space/"
 
 
 def _resolve_src_url(src: str) -> str:

--- a/trackio/remote_client.py
+++ b/trackio/remote_client.py
@@ -51,6 +51,7 @@ class _TrackioHTTPClient:
     ) -> None:
         self.src = _resolve_src_url(src)
         self.httpx_kwargs = dict(httpx_kwargs or {})
+        self.httpx_kwargs.setdefault("timeout", 60)
         self.headers = build_hf_headers(token=hf_token)
 
     def _upload_file(self, file_data: dict[str, Any]) -> dict[str, Any]:

--- a/trackio/remote_client.py
+++ b/trackio/remote_client.py
@@ -170,6 +170,8 @@ class RemoteClient:
                     httpx_kwargs=httpx_kwargs,
                     verbose=verbose,
                 )
+        except ValueError:
+            raise
         except Exception as e:
             raise ConnectionError(
                 f"Could not connect to Space '{space}'. Is it running?\n{e}"

--- a/trackio/run.py
+++ b/trackio/run.py
@@ -5,9 +5,10 @@ import uuid
 import warnings
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import Any
 
 import huggingface_hub
-from gradio_client import Client, handle_file
+from gradio_client import handle_file
 
 from trackio import utils
 from trackio.alerts import (
@@ -22,6 +23,7 @@ from trackio.gpu import GpuMonitor, gpu_available
 from trackio.histogram import Histogram
 from trackio.markdown import Markdown
 from trackio.media import TrackioMedia, get_project_media_path
+from trackio.remote_client import RemoteClient
 from trackio.sqlite_storage import SQLiteStorage
 from trackio.table import Table
 from trackio.typehints import AlertEntry, LogEntry, SystemLogEntry, UploadEntry
@@ -36,7 +38,7 @@ class Run:
         self,
         url: str | None,
         project: str,
-        client: Client | None,
+        client: Any | None,
         name: str | None = None,
         group: str | None = None,
         config: dict | None = None,
@@ -50,9 +52,9 @@ class Run:
         Initialize a Run for logging metrics to Trackio.
 
         Args:
-            url: The URL of the Trackio server (local Gradio app or HF Space).
+            url: The URL or Space id of the Trackio server.
             project: The name of the project to log metrics to.
-            client: A pre-configured gradio_client.Client instance, or None to
+            client: A pre-configured Trackio-compatible client instance, or None to
                 create one automatically in a background thread with retry logic.
                 Passing None is recommended for normal usage. Passing a client
                 is useful for testing (e.g., injecting a mock client).
@@ -481,7 +483,11 @@ class Run:
                 if self._stop_flag.is_set():
                     break
                 try:
-                    client = Client(self.url, verbose=False)
+                    client = RemoteClient(
+                        self.url,
+                        hf_token=huggingface_hub.utils.get_token(),
+                        verbose=False,
+                    )
 
                     with self._client_lock:
                         self._client = client

--- a/trackio/server.py
+++ b/trackio/server.py
@@ -22,7 +22,10 @@ from starlette.responses import RedirectResponse
 from starlette.routing import Route
 
 import trackio.utils as utils
-from trackio.asgi_app import create_trackio_starlette_app
+from trackio.asgi_app import (
+    consume_uploaded_temp_file,
+    create_trackio_starlette_app,
+)
 from trackio.exceptions import TrackioAPIError
 from trackio.media import get_project_media_path
 from trackio.sqlite_storage import SQLiteStorage
@@ -377,23 +380,34 @@ def get_run_mutation_status(request: Request) -> dict[str, Any]:
     return {"spaces": True, "allowed": False, "auth": "none"}
 
 
-def upload_db_to_space(project: str, uploaded_db: dict, hf_token: str | None) -> None:
+def upload_db_to_space(
+    request: Request,
+    project: str,
+    uploaded_db: dict,
+    hf_token: str | None,
+) -> None:
     check_hf_token_has_write_access(hf_token)
+    uploaded_path = consume_uploaded_temp_file(request, uploaded_db)
     db_project_path = SQLiteStorage.get_project_db_path(project)
     os.makedirs(os.path.dirname(db_project_path), exist_ok=True)
-    shutil.copy(uploaded_db["path"], db_project_path)
+    shutil.copy(uploaded_path, db_project_path)
 
 
-def bulk_upload_media(uploads: list[UploadEntry], hf_token: str | None) -> None:
+def bulk_upload_media(
+    request: Request,
+    uploads: list[UploadEntry],
+    hf_token: str | None,
+) -> None:
     check_hf_token_has_write_access(hf_token)
     for upload in uploads:
+        uploaded_path = consume_uploaded_temp_file(request, upload["uploaded_file"])
         media_path = get_project_media_path(
             project=upload["project"],
             run=upload["run"],
             step=upload["step"],
             relative_path=upload["relative_path"],
         )
-        shutil.copy(upload["uploaded_file"]["path"], media_path)
+        shutil.copy(uploaded_path, media_path)
 
 
 def log(

--- a/trackio/server.py
+++ b/trackio/server.py
@@ -768,6 +768,11 @@ def build_starlette_app_only(mcp_server: bool = False) -> tuple[Any, str]:
         extra_routes=mcp_routes,
         mcp_lifespan=mcp_lifespan,
         mcp_enabled=mcp_enabled,
+        allowed_file_roots=[
+            utils.MEDIA_DIR,
+            utils.TRACKIO_DIR,
+            utils.TRACKIO_LOGO_DIR,
+        ],
     )
     from trackio.frontend_server import mount_frontend  # noqa: PLC0415
 

--- a/trackio/server.py
+++ b/trackio/server.py
@@ -328,15 +328,16 @@ def check_oauth_token_has_write_access(oauth_token: str | None) -> None:
 
 
 def check_write_access(request: Request, token: str) -> bool:
+    expected_token = token or ""
     cookies = request.headers.get("cookie", "")
     if cookies:
         for cookie in cookies.split(";"):
             parts = cookie.strip().split("=", 1)
             if len(parts) == 2 and parts[0] == "trackio_write_token":
-                return parts[1] == token
+                return secrets.compare_digest(parts[1], expected_token)
     if hasattr(request, "query_params") and request.query_params:
         qp = request.query_params.get("write_token")
-        return qp == token
+        return secrets.compare_digest(qp or "", expected_token)
     return False
 
 

--- a/trackio/server.py
+++ b/trackio/server.py
@@ -9,6 +9,7 @@ import shutil
 import sqlite3
 import threading
 import time
+import warnings
 from collections import deque
 from functools import lru_cache
 from typing import Any
@@ -522,7 +523,7 @@ def get_alerts(
     run: str | None = None,
     level: str | None = None,
     since: str | None = None,
-) -> list[dict]:
+) -> list[dict[str, Any]]:
     return SQLiteStorage.get_alerts(project, run_name=run, level=level, since=since)
 
 
@@ -534,7 +535,7 @@ def get_metric_values(
     around_step: int | None = None,
     at_time: str | None = None,
     window: int | None = None,
-) -> list[dict]:
+) -> list[dict[str, Any]]:
     return SQLiteStorage.get_metric_values(
         project,
         run,
@@ -570,7 +571,7 @@ def get_all_projects() -> list[str]:
     return SQLiteStorage.get_projects()
 
 
-def get_project_summary(project: str) -> dict:
+def get_project_summary(project: str) -> dict[str, Any]:
     runs = SQLiteStorage.get_runs(project)
     if not runs:
         return {"project": project, "num_runs": 0, "runs": [], "last_activity": None}
@@ -585,7 +586,7 @@ def get_project_summary(project: str) -> dict:
     }
 
 
-def get_run_summary(project: str, run: str) -> dict:
+def get_run_summary(project: str, run: str) -> dict[str, Any]:
     num_logs = SQLiteStorage.get_log_count(project, run)
     if num_logs == 0:
         return {
@@ -615,7 +616,7 @@ def get_system_metrics_for_run(project: str, run: str) -> list[str]:
     return SQLiteStorage.get_all_system_metrics_for_run(project, run)
 
 
-def get_system_logs(project: str, run: str) -> list[dict]:
+def get_system_logs(project: str, run: str) -> list[dict[str, Any]]:
     return SQLiteStorage.get_system_logs(project, run)
 
 
@@ -626,17 +627,17 @@ def get_snapshot(
     around_step: int | None = None,
     at_time: str | None = None,
     window: int | None = None,
-) -> dict:
+) -> dict[str, Any]:
     return SQLiteStorage.get_snapshot(
         project, run, step=step, around_step=around_step, at_time=at_time, window=window
     )
 
 
-def get_logs(project: str, run: str) -> list[dict]:
+def get_logs(project: str, run: str) -> list[dict[str, Any]]:
     return SQLiteStorage.get_logs(project, run, max_points=1500)
 
 
-def get_settings() -> dict:
+def get_settings() -> dict[str, Any]:
     return {
         "logo_urls": utils.get_logo_urls(),
         "color_palette": utils.get_color_palette(),
@@ -652,7 +653,7 @@ def get_settings() -> dict:
     }
 
 
-def get_project_files(project: str) -> list[dict]:
+def get_project_files(project: str) -> list[dict[str, Any]]:
     files_dir = utils.MEDIA_DIR / project / "files"
     if not files_dir.exists():
         return []
@@ -746,19 +747,29 @@ def build_starlette_app_only(mcp_server: bool = False) -> tuple[Any, str]:
         Route("/oauth/logout", oauth_logout, methods=["GET"]),
     ]
     mcp_lifespan = None
+    mcp_routes: list[Any] = []
+    mcp_enabled = False
     if mcp_server:
         try:
-            from trackio.mcp_setup import mcp_lifespan_context
+            from trackio.mcp_setup import create_mcp_integration  # noqa: PLC0415
 
-            mcp_lifespan = mcp_lifespan_context
+            mcp_routes, mcp_lifespan = create_mcp_integration()
+            mcp_enabled = True
         except ImportError:
-            pass
+            warnings.warn(
+                "MCP support requested, but the optional `mcp` package is not installed. "
+                "Install `trackio[mcp]` to expose `/mcp`.",
+                UserWarning,
+                stacklevel=2,
+            )
     starlette_app = create_trackio_starlette_app(
         oauth_routes,
         _api_registry(),
+        extra_routes=mcp_routes,
         mcp_lifespan=mcp_lifespan,
+        mcp_enabled=mcp_enabled,
     )
-    from trackio.frontend_server import mount_frontend
+    from trackio.frontend_server import mount_frontend  # noqa: PLC0415
 
     mount_frontend(starlette_app)
     return starlette_app, write_token

--- a/trackio/server.py
+++ b/trackio/server.py
@@ -14,13 +14,15 @@ from functools import lru_cache
 from typing import Any
 from urllib.parse import urlencode
 
-import gradio as gr
 import httpx
 import huggingface_hub as hf
 from starlette.requests import Request
 from starlette.responses import RedirectResponse
+from starlette.routing import Route
 
 import trackio.utils as utils
+from trackio.asgi_app import create_trackio_starlette_app
+from trackio.exceptions import TrackioAPIError
 from trackio.media import get_project_media_path
 from trackio.sqlite_storage import SQLiteStorage
 from trackio.typehints import AlertEntry, LogEntry, SystemLogEntry, UploadEntry
@@ -93,7 +95,7 @@ OAUTH_CALLBACK_PATH = "/login/callback"
 OAUTH_START_PATH = "/oauth/hf/start"
 
 
-def _hf_access_token(request: gr.Request) -> str | None:
+def _hf_access_token(request: Request) -> str | None:
     session_id = None
     try:
         session_id = request.headers.get("x-trackio-oauth-session")
@@ -123,14 +125,6 @@ def _oauth_redirect_uri(request: Request) -> str:
         space_host = space_host.split(",")[0]
         return f"https://{space_host}{OAUTH_CALLBACK_PATH}"
     return str(request.base_url).rstrip("/") + OAUTH_CALLBACK_PATH
-
-
-class TrackioServer(gr.Server):
-    def close(self, verbose: bool = True) -> None:
-        if self.blocks is None:
-            return
-        if self.blocks.is_running:
-            self.blocks.close(verbose=verbose)
 
 
 _OAUTH_STATE_TTL = 86400
@@ -329,7 +323,7 @@ def check_oauth_token_has_write_access(oauth_token: str | None) -> None:
     )
 
 
-def check_write_access(request: gr.Request, token: str) -> bool:
+def check_write_access(request: Request, token: str) -> bool:
     cookies = request.headers.get("cookie", "")
     if cookies:
         for cookie in cookies.split(";"):
@@ -342,11 +336,11 @@ def check_write_access(request: gr.Request, token: str) -> bool:
     return False
 
 
-def assert_can_mutate_runs(request: gr.Request) -> None:
+def assert_can_mutate_runs(request: Request) -> None:
     if os.getenv("SYSTEM") != "spaces":
         if check_write_access(request, write_token):
             return
-        raise gr.Error(
+        raise TrackioAPIError(
             "A write_token is required to delete or rename runs. "
             "Open the dashboard using the link that includes the write_token query parameter."
         )
@@ -355,17 +349,17 @@ def assert_can_mutate_runs(request: gr.Request) -> None:
         try:
             check_oauth_token_has_write_access(hf_tok)
         except PermissionError as e:
-            raise gr.Error(str(e)) from e
+            raise TrackioAPIError(str(e)) from e
         return
     if check_write_access(request, write_token):
         return
-    raise gr.Error(
+    raise TrackioAPIError(
         "Sign in with Hugging Face to delete or rename runs. You need write access to this Space, "
         "or open the dashboard using a link that includes the write_token query parameter."
     )
 
 
-def get_run_mutation_status(request: gr.Request) -> dict[str, Any]:
+def get_run_mutation_status(request: Request) -> dict[str, Any]:
     if os.getenv("SYSTEM") != "spaces":
         if check_write_access(request, write_token):
             return {"spaces": False, "allowed": True, "auth": "local"}
@@ -382,9 +376,7 @@ def get_run_mutation_status(request: gr.Request) -> dict[str, Any]:
     return {"spaces": True, "allowed": False, "auth": "none"}
 
 
-def upload_db_to_space(
-    project: str, uploaded_db: gr.FileData, hf_token: str | None
-) -> None:
+def upload_db_to_space(project: str, uploaded_db: dict, hf_token: str | None) -> None:
     check_hf_token_has_write_access(hf_token)
     db_project_path = SQLiteStorage.get_project_db_path(project)
     os.makedirs(os.path.dirname(db_project_path), exist_ok=True)
@@ -678,13 +670,13 @@ def get_project_files(project: str) -> list[dict]:
     return results
 
 
-def delete_run(request: gr.Request, project: str, run: str) -> bool:
+def delete_run(request: Request, project: str, run: str) -> bool:
     assert_can_mutate_runs(request)
     return SQLiteStorage.delete_run(project, run)
 
 
 def rename_run(
-    request: gr.Request,
+    request: Request,
     project: str,
     old_name: str,
     new_name: str,
@@ -707,36 +699,71 @@ def force_sync() -> bool:
 CSS = ""
 HEAD = ""
 
-gr.set_static_paths(paths=[utils.MEDIA_DIR])
+
+def _api_registry() -> dict[str, Any]:
+    return {
+        "get_run_mutation_status": get_run_mutation_status,
+        "upload_db_to_space": upload_db_to_space,
+        "bulk_upload_media": bulk_upload_media,
+        "log": log,
+        "bulk_log": bulk_log,
+        "bulk_log_system": bulk_log_system,
+        "bulk_alert": bulk_alert,
+        "get_alerts": get_alerts,
+        "get_metric_values": get_metric_values,
+        "get_runs_for_project": get_runs_for_project,
+        "get_metrics_for_run": get_metrics_for_run,
+        "get_all_projects": get_all_projects,
+        "get_project_summary": get_project_summary,
+        "get_run_summary": get_run_summary,
+        "get_system_metrics_for_run": get_system_metrics_for_run,
+        "get_system_logs": get_system_logs,
+        "get_snapshot": get_snapshot,
+        "get_logs": get_logs,
+        "get_settings": get_settings,
+        "get_project_files": get_project_files,
+        "delete_run": delete_run,
+        "rename_run": rename_run,
+        "force_sync": force_sync,
+    }
 
 
-def make_trackio_server() -> TrackioServer:
-    server = TrackioServer(title="Trackio Dashboard")
-    server.add_api_route(OAUTH_START_PATH, oauth_hf_start, methods=["GET"])
-    server.add_api_route(OAUTH_CALLBACK_PATH, oauth_hf_callback, methods=["GET"])
-    server.add_api_route("/oauth/logout", oauth_logout, methods=["GET"])
-    server.api(fn=get_run_mutation_status, name="get_run_mutation_status")
-    server.api(fn=upload_db_to_space, name="upload_db_to_space")
-    server.api(fn=bulk_upload_media, name="bulk_upload_media")
-    server.api(fn=log, name="log")
-    server.api(fn=bulk_log, name="bulk_log")
-    server.api(fn=bulk_log_system, name="bulk_log_system")
-    server.api(fn=bulk_alert, name="bulk_alert")
-    server.api(fn=get_alerts, name="get_alerts")
-    server.api(fn=get_metric_values, name="get_metric_values")
-    server.api(fn=get_runs_for_project, name="get_runs_for_project")
-    server.api(fn=get_metrics_for_run, name="get_metrics_for_run")
-    server.api(fn=get_all_projects, name="get_all_projects")
-    server.api(fn=get_project_summary, name="get_project_summary")
-    server.api(fn=get_run_summary, name="get_run_summary")
-    server.api(fn=get_system_metrics_for_run, name="get_system_metrics_for_run")
-    server.api(fn=get_system_logs, name="get_system_logs")
-    server.api(fn=get_snapshot, name="get_snapshot")
-    server.api(fn=get_logs, name="get_logs")
-    server.api(fn=get_settings, name="get_settings")
-    server.api(fn=get_project_files, name="get_project_files")
-    server.api(fn=delete_run, name="delete_run")
-    server.api(fn=rename_run, name="rename_run")
-    server.api(fn=force_sync, name="force_sync")
-    server.write_token = write_token
-    return server
+class TrackioDashboardApp:
+    def __init__(self, starlette_app, uvicorn_server: Any, write_token: str) -> None:
+        self.app = starlette_app
+        self._uvicorn_server = uvicorn_server
+        self.write_token = write_token
+
+    def close(self, verbose: bool = True) -> None:
+        if self._uvicorn_server is not None:
+            self._uvicorn_server.should_exit = True
+
+
+def build_starlette_app_only(mcp_server: bool = False) -> tuple[Any, str]:
+    oauth_routes = [
+        Route(OAUTH_START_PATH, oauth_hf_start, methods=["GET"]),
+        Route(OAUTH_CALLBACK_PATH, oauth_hf_callback, methods=["GET"]),
+        Route("/oauth/logout", oauth_logout, methods=["GET"]),
+    ]
+    mcp_lifespan = None
+    if mcp_server:
+        try:
+            from trackio.mcp_setup import mcp_lifespan_context
+
+            mcp_lifespan = mcp_lifespan_context
+        except ImportError:
+            pass
+    starlette_app = create_trackio_starlette_app(
+        oauth_routes,
+        _api_registry(),
+        mcp_lifespan=mcp_lifespan,
+    )
+    from trackio.frontend_server import mount_frontend
+
+    mount_frontend(starlette_app)
+    return starlette_app, write_token
+
+
+def make_trackio_server(mcp_server: bool = False) -> TrackioDashboardApp:
+    app, wt = build_starlette_app_only(mcp_server=mcp_server)
+    return TrackioDashboardApp(app, None, wt)

--- a/trackio/sqlite_storage.py
+++ b/trackio/sqlite_storage.py
@@ -21,7 +21,6 @@ except ImportError:
 
 import huggingface_hub as hf
 import orjson
-import pandas as pd
 
 from trackio.commit_scheduler import CommitScheduler
 from trackio.dummy_commit_scheduler import DummyCommitScheduler
@@ -283,29 +282,123 @@ class SQLiteStorage:
         return db_path
 
     @staticmethod
-    def _flatten_json_column(df: pd.DataFrame, col: str) -> pd.DataFrame:
-        if df.empty:
-            return df
-        expanded = df[col].copy()
-        expanded = pd.DataFrame(
-            expanded.apply(
-                lambda x: deserialize_values(orjson.loads(x))
-            ).values.tolist(),
-            index=df.index,
-        )
-        df = df.drop(columns=[col])
-        expanded = expanded.loc[:, ~expanded.columns.isin(df.columns)]
-        return pd.concat([df, expanded], axis=1)
+    def _require_pyarrow():
+        try:
+            import pyarrow as pa
+            import pyarrow.parquet as pq
+        except ImportError as e:
+            raise ImportError(
+                "Parquet import/export requires `trackio[spaces]`."
+            ) from e
+        return pa, pq
 
     @staticmethod
-    def _read_table(db_path: Path, table: str) -> pd.DataFrame:
+    def _read_table_rows(db_path: Path, table: str) -> list[dict[str, object]]:
         try:
             with SQLiteStorage._get_connection(
-                db_path, timeout=5.0, configure_pragmas=False, row_factory=None
+                db_path, timeout=5.0, configure_pragmas=False
             ) as conn:
-                return pd.read_sql(f"SELECT * FROM {table}", conn)
+                cursor = conn.cursor()
+                cursor.execute(f"SELECT * FROM {table}")
+                return [dict(row) for row in cursor.fetchall()]
         except Exception:
-            return pd.DataFrame()
+            return []
+
+    @staticmethod
+    def _decode_json_blob(value: object) -> dict[str, object]:
+        if value is None:
+            return {}
+        if isinstance(value, memoryview):
+            value = value.tobytes()
+        return deserialize_values(orjson.loads(value))
+
+    @staticmethod
+    def _flatten_json_rows(
+        rows: list[dict[str, object]], json_col: str
+    ) -> list[dict[str, object]]:
+        flattened_rows = []
+        for row in rows:
+            flat_row = {key: value for key, value in row.items() if key != json_col}
+            expanded = SQLiteStorage._decode_json_blob(row.get(json_col))
+            for key, value in expanded.items():
+                if key not in flat_row:
+                    flat_row[key] = value
+            flattened_rows.append(flat_row)
+        return flattened_rows
+
+    @staticmethod
+    def _write_parquet_rows(parquet_path: Path, rows: list[dict[str, object]]) -> None:
+        if not rows:
+            return
+        pa, pq = SQLiteStorage._require_pyarrow()
+        table = pa.Table.from_pylist(rows)
+        write_kwargs = {
+            "write_page_index": True,
+            "use_content_defined_chunking": True,
+        }
+        try:
+            pq.write_table(table, parquet_path, **write_kwargs)
+        except TypeError:
+            pq.write_table(table, parquet_path)
+
+    @staticmethod
+    def _read_parquet_rows(parquet_path: Path) -> list[dict[str, object]]:
+        _, pq = SQLiteStorage._require_pyarrow()
+        return pq.read_table(parquet_path).to_pylist()
+
+    @staticmethod
+    def _normalize_json_column_value(value: object) -> object:
+        if value is None:
+            return orjson.dumps({})
+        if isinstance(value, memoryview):
+            return value.tobytes()
+        if isinstance(value, (bytes, bytearray, str)):
+            return value
+        return orjson.dumps(serialize_values(value))
+
+    @staticmethod
+    def _rows_to_sql_table_rows(
+        rows: list[dict[str, object]],
+        *,
+        json_col: str,
+        structural_cols: list[str],
+    ) -> list[dict[str, object]]:
+        sql_rows = []
+        for row in rows:
+            sql_row = {col: row.get(col) for col in structural_cols}
+            if json_col in row:
+                sql_row[json_col] = SQLiteStorage._normalize_json_column_value(
+                    row.get(json_col)
+                )
+            else:
+                payload = {
+                    key: value
+                    for key, value in row.items()
+                    if key not in structural_cols and key != json_col
+                }
+                sql_row[json_col] = orjson.dumps(serialize_values(payload))
+            sql_rows.append(sql_row)
+        return sql_rows
+
+    @staticmethod
+    def _replace_table_rows(
+        db_path: Path,
+        table: str,
+        rows: list[dict[str, object]],
+        columns: list[str],
+    ) -> None:
+        with SQLiteStorage._get_connection(
+            db_path, configure_pragmas=False, row_factory=None
+        ) as conn:
+            cursor = conn.cursor()
+            cursor.execute(f"DELETE FROM {table}")
+            if rows:
+                placeholders = ", ".join(["?"] * len(columns))
+                cursor.executemany(
+                    f"INSERT INTO {table} ({', '.join(columns)}) VALUES ({placeholders})",
+                    [[row.get(column) for column in columns] for row in rows],
+                )
+            conn.commit()
 
     @staticmethod
     def _flatten_and_write_parquet(
@@ -316,15 +409,11 @@ class SQLiteStorage:
             and db_path.stat().st_mtime <= parquet_path.stat().st_mtime
         ):
             return
-        df = SQLiteStorage._read_table(db_path, table)
-        if df.empty:
+        rows = SQLiteStorage._read_table_rows(db_path, table)
+        if not rows:
             return
-        df = SQLiteStorage._flatten_json_column(df, json_col)
-        df.to_parquet(
-            parquet_path,
-            write_page_index=True,
-            use_content_defined_chunking=True,
-        )
+        flat_rows = SQLiteStorage._flatten_json_rows(rows, json_col)
+        SQLiteStorage._write_parquet_rows(parquet_path, flat_rows)
 
     @staticmethod
     def export_to_parquet():
@@ -380,20 +469,20 @@ class SQLiteStorage:
         aux_dir = output_dir / "aux"
         aux_dir.mkdir(parents=True, exist_ok=True)
 
-        metrics_df = SQLiteStorage._read_table(db_path, "metrics")
-        if not metrics_df.empty:
-            flat = SQLiteStorage._flatten_json_column(metrics_df.copy(), "metrics")
-            flat.to_parquet(output_dir / "metrics.parquet")
+        metrics_rows = SQLiteStorage._read_table_rows(db_path, "metrics")
+        if metrics_rows:
+            flat = SQLiteStorage._flatten_json_rows(metrics_rows, "metrics")
+            SQLiteStorage._write_parquet_rows(output_dir / "metrics.parquet", flat)
 
-        sys_df = SQLiteStorage._read_table(db_path, "system_metrics")
-        if not sys_df.empty:
-            flat = SQLiteStorage._flatten_json_column(sys_df.copy(), "metrics")
-            flat.to_parquet(aux_dir / "system_metrics.parquet")
+        sys_rows = SQLiteStorage._read_table_rows(db_path, "system_metrics")
+        if sys_rows:
+            flat = SQLiteStorage._flatten_json_rows(sys_rows, "metrics")
+            SQLiteStorage._write_parquet_rows(aux_dir / "system_metrics.parquet", flat)
 
-        configs_df = SQLiteStorage._read_table(db_path, "configs")
-        if not configs_df.empty:
-            flat = SQLiteStorage._flatten_json_column(configs_df.copy(), "config")
-            flat.to_parquet(aux_dir / "configs.parquet")
+        configs_rows = SQLiteStorage._read_table_rows(db_path, "configs")
+        if configs_rows:
+            flat = SQLiteStorage._flatten_json_rows(configs_rows, "config")
+            SQLiteStorage._write_parquet_rows(aux_dir / "configs.parquet", flat)
 
         try:
             with SQLiteStorage._get_connection(db_path) as conn:
@@ -463,29 +552,35 @@ class SQLiteStorage:
 
             SQLiteStorage._cleanup_wal_sidecars(db_path)
 
-            df = pd.read_parquet(parquet_path)
-            if "metrics" not in df.columns:
-                metrics = df.copy()
-                structural_cols = [
+            rows = SQLiteStorage._read_parquet_rows(parquet_path)
+            project = db_path.stem
+            SQLiteStorage.init_db(project)
+            metrics_rows = SQLiteStorage._rows_to_sql_table_rows(
+                rows,
+                json_col="metrics",
+                structural_cols=[
                     "id",
                     "timestamp",
                     "run_name",
                     "step",
                     "log_id",
                     "space_id",
-                ]
-                df = df[[c for c in structural_cols if c in df.columns]]
-                for col in structural_cols:
-                    if col in metrics.columns:
-                        del metrics[col]
-                metrics = orjson.loads(metrics.to_json(orient="records"))
-                df["metrics"] = [orjson.dumps(serialize_values(row)) for row in metrics]
-
-            with SQLiteStorage._get_connection(
-                db_path, configure_pragmas=False, row_factory=None
-            ) as conn:
-                df.to_sql("metrics", conn, if_exists="replace", index=False)
-                conn.commit()
+                ],
+            )
+            SQLiteStorage._replace_table_rows(
+                db_path,
+                "metrics",
+                metrics_rows,
+                [
+                    "id",
+                    "timestamp",
+                    "run_name",
+                    "step",
+                    "metrics",
+                    "log_id",
+                    "space_id",
+                ],
+            )
 
         system_parquet_names = [f for f in all_paths if f.endswith("_system.parquet")]
         for pq_name in system_parquet_names:
@@ -496,22 +591,19 @@ class SQLiteStorage:
             if project_name not in imported_projects and not db_path.exists():
                 continue
 
-            df = pd.read_parquet(parquet_path)
-            if "metrics" not in df.columns:
-                metrics = df.copy()
-                other_cols = ["id", "timestamp", "run_name"]
-                df = df[[c for c in other_cols if c in df.columns]]
-                for col in other_cols:
-                    if col in metrics.columns:
-                        del metrics[col]
-                metrics = orjson.loads(metrics.to_json(orient="records"))
-                df["metrics"] = [orjson.dumps(serialize_values(row)) for row in metrics]
-
-            with SQLiteStorage._get_connection(
-                db_path, configure_pragmas=False, row_factory=None
-            ) as conn:
-                df.to_sql("system_metrics", conn, if_exists="replace", index=False)
-                conn.commit()
+            rows = SQLiteStorage._read_parquet_rows(parquet_path)
+            SQLiteStorage.init_db(project_name)
+            system_rows = SQLiteStorage._rows_to_sql_table_rows(
+                rows,
+                json_col="metrics",
+                structural_cols=["id", "timestamp", "run_name", "log_id", "space_id"],
+            )
+            SQLiteStorage._replace_table_rows(
+                db_path,
+                "system_metrics",
+                system_rows,
+                ["id", "timestamp", "run_name", "metrics", "log_id", "space_id"],
+            )
 
         configs_parquet_names = [f for f in all_paths if f.endswith("_configs.parquet")]
         for pq_name in configs_parquet_names:
@@ -522,24 +614,19 @@ class SQLiteStorage:
             if project_name not in imported_projects and not db_path.exists():
                 continue
 
-            df = pd.read_parquet(parquet_path)
-            if "config" not in df.columns:
-                config_data = df.copy()
-                other_cols = ["id", "run_name", "created_at"]
-                df = df[[c for c in other_cols if c in df.columns]]
-                for col in other_cols:
-                    if col in config_data.columns:
-                        del config_data[col]
-                config_data = orjson.loads(config_data.to_json(orient="records"))
-                df["config"] = [
-                    orjson.dumps(serialize_values(row)) for row in config_data
-                ]
-
-            with SQLiteStorage._get_connection(
-                db_path, configure_pragmas=False, row_factory=None
-            ) as conn:
-                df.to_sql("configs", conn, if_exists="replace", index=False)
-                conn.commit()
+            rows = SQLiteStorage._read_parquet_rows(parquet_path)
+            SQLiteStorage.init_db(project_name)
+            config_rows = SQLiteStorage._rows_to_sql_table_rows(
+                rows,
+                json_col="config",
+                structural_cols=["id", "run_name", "created_at"],
+            )
+            SQLiteStorage._replace_table_rows(
+                db_path,
+                "configs",
+                config_rows,
+                ["id", "run_name", "config", "created_at"],
+            )
 
     @staticmethod
     def get_scheduler():

--- a/trackio/table.py
+++ b/trackio/table.py
@@ -119,7 +119,9 @@ class Table:
             relative_path = image_data.get("file_path", "")
             caption = image_data.get("caption", "")
             absolute_path = MEDIA_DIR / relative_path
-            return f'<img src="/file?path={quote(str(absolute_path))}" alt="{caption}" />'
+            return (
+                f'<img src="/file?path={quote(str(absolute_path))}" alt="{caption}" />'
+            )
 
         processed_data = []
         for row in table_data:

--- a/trackio/table.py
+++ b/trackio/table.py
@@ -1,5 +1,6 @@
 import os
 from typing import Any, Literal
+from urllib.parse import quote
 
 from pandas import DataFrame
 
@@ -118,7 +119,7 @@ class Table:
             relative_path = image_data.get("file_path", "")
             caption = image_data.get("caption", "")
             absolute_path = MEDIA_DIR / relative_path
-            return f'<img src="/gradio_api/file={absolute_path}" alt="{caption}" />'
+            return f'<img src="/file?path={quote(str(absolute_path))}" alt="{caption}" />'
 
         processed_data = []
         for row in table_data:

--- a/trackio/table.py
+++ b/trackio/table.py
@@ -2,8 +2,6 @@ import os
 from typing import Any, Literal
 from urllib.parse import quote
 
-from pandas import DataFrame
-
 from trackio.media.media import TrackioMedia
 from trackio.utils import MEDIA_DIR
 
@@ -41,7 +39,7 @@ class Table:
         self,
         columns: list[str] | None = None,
         data: list[list[Any]] | None = None,
-        dataframe: DataFrame | None = None,
+        dataframe: Any | None = None,
         rows: list[list[Any]] | None = None,
         optional: bool | list[bool] = True,
         allow_mixed_types: bool = False,
@@ -49,52 +47,79 @@ class Table:
     ):
         # TODO: implement support for columns, dtype, optional, allow_mixed_types, and log_mode.
         # for now (like `rows`) they are included for API compat but don't do anything.
-        if dataframe is None:
-            self.data = DataFrame(data) if data is not None else DataFrame()
-        else:
-            self.data = dataframe
+        self.data = self._normalize_rows(
+            columns=columns, data=data, dataframe=dataframe
+        )
 
-    def _has_media_objects(self, dataframe: DataFrame) -> bool:
-        """Check if dataframe contains any TrackioMedia objects or lists of TrackioMedia objects."""
-        for col in dataframe.columns:
-            if dataframe[col].apply(lambda x: isinstance(x, TrackioMedia)).any():
-                return True
-            if (
-                dataframe[col]
-                .apply(
-                    lambda x: (
-                        isinstance(x, list)
-                        and len(x) > 0
-                        and isinstance(x[0], TrackioMedia)
-                    )
-                )
-                .any()
-            ):
-                return True
+    @staticmethod
+    def _normalize_rows(
+        columns: list[str] | None,
+        data: list[list[Any]] | None,
+        dataframe: Any | None,
+    ) -> list[dict[str, Any]]:
+        if dataframe is not None:
+            try:
+                records = dataframe.to_dict(orient="records")
+            except Exception as e:
+                raise TypeError(
+                    "The `dataframe` argument must support `to_dict(orient='records')`."
+                ) from e
+            return [dict(row) for row in records]
+
+        if data is None:
+            return []
+
+        if data and isinstance(data[0], dict):
+            return [dict(row) for row in data]
+
+        normalized_rows: list[dict[str, Any]] = []
+        for row in data:
+            row_dict: dict[str, Any] = {}
+            if columns is None:
+                for idx, value in enumerate(row):
+                    row_dict[idx] = value
+            else:
+                for idx, column in enumerate(columns):
+                    row_dict[column] = row[idx] if idx < len(row) else None
+                for idx in range(len(columns), len(row)):
+                    row_dict[idx] = row[idx]
+            normalized_rows.append(row_dict)
+        return normalized_rows
+
+    def _has_media_objects(self, rows: list[dict[str, Any]]) -> bool:
+        """Check if rows contain any TrackioMedia objects or lists of TrackioMedia objects."""
+        for row in rows:
+            for value in row.values():
+                if isinstance(value, TrackioMedia):
+                    return True
+                if (
+                    isinstance(value, list)
+                    and len(value) > 0
+                    and isinstance(value[0], TrackioMedia)
+                ):
+                    return True
         return False
 
     def _process_data(self, project: str, run: str, step: int = 0):
-        """Convert dataframe to dict format, processing any TrackioMedia objects if present."""
-        df = self.data
-        if not self._has_media_objects(df):
-            return df.to_dict(orient="records")
+        """Convert rows to dict format, processing any TrackioMedia objects if present."""
+        if not self._has_media_objects(self.data):
+            return [dict(row) for row in self.data]
 
-        processed_df = df.copy()
-        for col in processed_df.columns:
-            for idx in processed_df.index:
-                value = processed_df.at[idx, col]
+        processed_rows = [dict(row) for row in self.data]
+        for row in processed_rows:
+            for key, value in list(row.items()):
                 if isinstance(value, TrackioMedia):
                     value._save(project, run, step)
-                    processed_df.at[idx, col] = value._to_dict()
+                    row[key] = value._to_dict()
                 if (
                     isinstance(value, list)
                     and len(value) > 0
                     and isinstance(value[0], TrackioMedia)
                 ):
                     [v._save(project, run, step) for v in value]
-                    processed_df.at[idx, col] = [v._to_dict() for v in value]
+                    row[key] = [v._to_dict() for v in value]
 
-        return processed_df.to_dict(orient="records")
+        return processed_rows
 
     @staticmethod
     def to_display_format(table_data: list[dict]) -> list[dict]:

--- a/trackio/typehints.py
+++ b/trackio/typehints.py
@@ -1,6 +1,6 @@
 from typing import Any, TypedDict
 
-from gradio import FileData
+from gradio_client import FileData
 
 
 class LogEntry(TypedDict, total=False):

--- a/trackio/utils.py
+++ b/trackio/utils.py
@@ -866,6 +866,7 @@ def serialize_values(metrics):
     Example:
         {"loss": float('inf'), "accuracy": 0.95} -> {"loss": "Infinity", "accuracy": 0.95}
     """
+
     def _serialize(value):
         if isinstance(value, dict):
             return {str(key): _serialize(item) for key, item in value.items()}

--- a/trackio/utils.py
+++ b/trackio/utils.py
@@ -856,8 +856,7 @@ def generate_embed_code(
 
 def serialize_values(metrics):
     """
-    Serialize infinity and NaN values in metrics dict to make it JSON-compliant.
-    Only handles top-level float values.
+    Serialize values to make them JSON-compliant.
 
     Converts:
     - float('inf') -> "Infinity"
@@ -867,29 +866,24 @@ def serialize_values(metrics):
     Example:
         {"loss": float('inf'), "accuracy": 0.95} -> {"loss": "Infinity", "accuracy": 0.95}
     """
-    if not isinstance(metrics, dict):
-        return metrics
-
-    result = {}
-    for key, value in metrics.items():
+    def _serialize(value):
+        if isinstance(value, dict):
+            return {str(key): _serialize(item) for key, item in value.items()}
+        if isinstance(value, (list, tuple, set)):
+            return [_serialize(item) for item in value]
+        if isinstance(value, np.generic):
+            value = value.item()
+        if isinstance(value, bool | int):
+            return value
         if isinstance(value, float):
             if math.isinf(value):
-                result[key] = "Infinity" if value > 0 else "-Infinity"
-            elif math.isnan(value):
-                result[key] = "NaN"
-            else:
-                result[key] = value
-        elif isinstance(value, np.floating):
-            float_val = float(value)
-            if math.isinf(float_val):
-                result[key] = "Infinity" if float_val > 0 else "-Infinity"
-            elif math.isnan(float_val):
-                result[key] = "NaN"
-            else:
-                result[key] = float_val
-        else:
-            result[key] = value
-    return result
+                return "Infinity" if value > 0 else "-Infinity"
+            if math.isnan(value):
+                return "NaN"
+            return float(value)
+        return value
+
+    return _serialize(metrics)
 
 
 def deserialize_values(metrics):

--- a/trackio/utils.py
+++ b/trackio/utils.py
@@ -8,6 +8,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING
 from urllib.parse import urlencode
+from urllib.parse import quote
 
 import huggingface_hub
 import numpy as np
@@ -27,11 +28,11 @@ def get_logo_urls() -> dict[str, str]:
     """Get logo URLs from environment variables or use defaults."""
     light_url = os.environ.get(
         "TRACKIO_LOGO_LIGHT_URL",
-        f"/gradio_api/file={TRACKIO_LOGO_DIR}/trackio_logo_type_light_transparent.png",
+        f"/file?path={quote(str(TRACKIO_LOGO_DIR / 'trackio_logo_type_light_transparent.png'))}",
     )
     dark_url = os.environ.get(
         "TRACKIO_LOGO_DARK_URL",
-        f"/gradio_api/file={TRACKIO_LOGO_DIR}/trackio_logo_type_dark_transparent.png",
+        f"/file?path={quote(str(TRACKIO_LOGO_DIR / 'trackio_logo_type_dark_transparent.png'))}",
     )
     return {"light": light_url, "dark": dark_url}
 

--- a/trackio/utils.py
+++ b/trackio/utils.py
@@ -7,8 +7,7 @@ import warnings
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING
-from urllib.parse import urlencode
-from urllib.parse import quote
+from urllib.parse import quote, urlencode
 
 import huggingface_hub
 import numpy as np

--- a/trackio/utils.py
+++ b/trackio/utils.py
@@ -6,12 +6,11 @@ import time
 import warnings
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 from urllib.parse import quote, urlencode
 
 import huggingface_hub
 import numpy as np
-import pandas as pd
 from huggingface_hub.constants import HF_HOME
 
 if TYPE_CHECKING:
@@ -467,7 +466,7 @@ def fibo():
 
 def format_timestamp(timestamp_str):
     """Convert ISO timestamp to human-readable format like '3 minutes ago'."""
-    if not timestamp_str or pd.isna(timestamp_str):
+    if not timestamp_str or is_missing_value(timestamp_str):
         return "Unknown"
 
     try:
@@ -537,13 +536,56 @@ def get_color_mapping(
     return color_map
 
 
+def is_missing_value(value: object) -> bool:
+    if value is None:
+        return True
+    if isinstance(value, str):
+        return False
+    try:
+        return bool(math.isnan(value))
+    except (TypeError, ValueError):
+        return False
+
+
+def _to_records_with_columns(
+    data: object,
+) -> tuple[list[dict[str, Any]], list[str], Any]:
+    if hasattr(data, "to_dict"):
+        try:
+            records = data.to_dict(orient="records")
+        except Exception:
+            pass
+        else:
+            columns = [str(column) for column in getattr(data, "columns", [])]
+            return [dict(row) for row in records], columns, data.__class__
+
+    if isinstance(data, list):
+        records = [dict(row) for row in data]
+        columns = list(records[0].keys()) if records else []
+        return records, columns, None
+
+    raise TypeError(
+        "downsample() expects a list of row dictionaries or a dataframe-like object."
+    )
+
+
+def _restore_records_shape(
+    records: list[dict[str, Any]],
+    columns: list[str],
+    dataframe_class: Any,
+) -> Any:
+    if dataframe_class is None or not hasattr(dataframe_class, "from_records"):
+        return records
+    return dataframe_class.from_records(records, columns=columns)
+
+
 def downsample(
-    df: pd.DataFrame,
+    data: object,
     x: str,
     y: str,
     color: str | None,
     x_lim: tuple[float | None, float | None] | None = None,
-) -> tuple[pd.DataFrame, tuple[float, float] | None]:
+) -> tuple[Any, tuple[float, float] | None]:
     """
     Downsample the dataframe to reduce the number of points plotted.
     Also updates the x-axis limits to the data min/max if either of the x-axis limits are None.
@@ -558,18 +600,23 @@ def downsample(
     Returns:
         A tuple containing the downsampled dataframe and the updated x-axis limits.
     """
-    if df.empty:
+    rows, columns, dataframe_class = _to_records_with_columns(data)
+
+    if not rows:
         if x_lim is not None:
             x_lim = (x_lim[0] or 0, x_lim[1] or 0)
-        return df, x_lim
+        return _restore_records_shape([], columns, dataframe_class), x_lim
 
     columns_to_keep = [x, y]
-    if color is not None and color in df.columns:
+    if color is not None and any(color in row for row in rows):
         columns_to_keep.append(color)
-    df = df[columns_to_keep].copy()
+    filtered_rows = [
+        {column: row.get(column) for column in columns_to_keep} for row in rows
+    ]
 
-    data_x_min = df[x].min()
-    data_x_max = df[x].max()
+    data_x_values = [row[x] for row in filtered_rows]
+    data_x_min = min(data_x_values)
+    data_x_max = max(data_x_values)
 
     if x_lim is not None:
         x_min, x_max = x_lim
@@ -583,83 +630,95 @@ def downsample(
 
     n_bins = 100
 
-    if color is not None and color in df.columns:
-        groups = df.groupby(color)
+    groups: dict[Any, list[tuple[int, dict[str, Any]]]] = {}
+    if color is not None and color in columns_to_keep:
+        for idx, row in enumerate(filtered_rows):
+            groups.setdefault(row.get(color), []).append((idx, row))
     else:
-        groups = [(None, df)]
+        groups[None] = list(enumerate(filtered_rows))
 
-    downsampled_indices = []
+    downsampled_indices: list[int] = []
 
-    for _, group_df in groups:
-        if group_df.empty:
+    for group_rows in groups.values():
+        if not group_rows:
             continue
 
-        group_df = group_df.sort_values(x)
+        group_rows = sorted(group_rows, key=lambda item: item[1][x])
 
         if updated_x_lim is not None:
             x_min, x_max = updated_x_lim
-            before_point = group_df[group_df[x] < x_min].tail(1)
-            after_point = group_df[group_df[x] > x_max].head(1)
-            group_df = group_df[(group_df[x] >= x_min) & (group_df[x] <= x_max)]
+            before_point = [item for item in group_rows if item[1][x] < x_min]
+            after_point = [item for item in group_rows if item[1][x] > x_max]
+            group_rows = [item for item in group_rows if x_min <= item[1][x] <= x_max]
         else:
             before_point = after_point = None
-            x_min = group_df[x].min()
-            x_max = group_df[x].max()
+            x_min = group_rows[0][1][x]
+            x_max = group_rows[-1][1][x]
 
-        if before_point is not None and not before_point.empty:
-            downsampled_indices.extend(before_point.index.tolist())
-        if after_point is not None and not after_point.empty:
-            downsampled_indices.extend(after_point.index.tolist())
+        if before_point:
+            downsampled_indices.append(before_point[-1][0])
+        if after_point:
+            downsampled_indices.append(after_point[0][0])
 
-        if group_df.empty:
+        if not group_rows:
             continue
 
         if x_min == x_max:
-            min_y_idx = group_df[y].idxmin()
-            max_y_idx = group_df[y].idxmax()
+            min_y_idx = min(group_rows, key=lambda item: item[1][y])[0]
+            max_y_idx = max(group_rows, key=lambda item: item[1][y])[0]
             if min_y_idx != max_y_idx:
                 downsampled_indices.extend([min_y_idx, max_y_idx])
             else:
                 downsampled_indices.append(min_y_idx)
             continue
 
-        if len(group_df) < 500:
-            downsampled_indices.extend(group_df.index.tolist())
+        if len(group_rows) < 500:
+            downsampled_indices.extend(idx for idx, _ in group_rows)
             continue
 
         bins = np.linspace(x_min, x_max, n_bins + 1)
-        group_df["bin"] = pd.cut(
-            group_df[x], bins=bins, labels=False, include_lowest=True
-        )
+        binned_rows: dict[int, list[tuple[int, dict[str, Any]]]] = {}
+        for idx, row in group_rows:
+            bin_idx = int(
+                np.clip(np.digitize(row[x], bins, right=False) - 1, 0, n_bins - 1)
+            )
+            binned_rows.setdefault(bin_idx, []).append((idx, row))
 
-        for bin_idx in group_df["bin"].dropna().unique():
-            bin_data = group_df[group_df["bin"] == bin_idx]
-            if bin_data.empty:
+        for bin_rows in binned_rows.values():
+            if not bin_rows:
                 continue
 
-            min_y_idx = bin_data[y].idxmin()
-            max_y_idx = bin_data[y].idxmax()
+            min_y_idx = min(bin_rows, key=lambda item: item[1][y])[0]
+            max_y_idx = max(bin_rows, key=lambda item: item[1][y])[0]
 
             downsampled_indices.append(min_y_idx)
             if min_y_idx != max_y_idx:
                 downsampled_indices.append(max_y_idx)
 
-    unique_indices = list(set(downsampled_indices))
+    unique_indices = sorted(set(downsampled_indices))
+    selected_rows = [filtered_rows[idx] for idx in unique_indices]
 
-    downsampled_df = df.loc[unique_indices].copy()
-
-    if color is not None:
-        downsampled_df = (
-            downsampled_df.groupby(color, sort=False)[downsampled_df.columns]
-            .apply(lambda group: group.sort_values(x))
-            .reset_index(drop=True)
-        )
+    if color is not None and color in columns_to_keep:
+        grouped_rows: dict[Any, list[dict[str, Any]]] = {}
+        group_order: list[Any] = []
+        for row in selected_rows:
+            group_key = row.get(color)
+            if group_key not in grouped_rows:
+                grouped_rows[group_key] = []
+                group_order.append(group_key)
+            grouped_rows[group_key].append(row)
+        downsampled_rows = []
+        for group_key in group_order:
+            downsampled_rows.extend(
+                sorted(grouped_rows[group_key], key=lambda row: row[x])
+            )
     else:
-        downsampled_df = downsampled_df.sort_values(x).reset_index(drop=True)
+        downsampled_rows = sorted(selected_rows, key=lambda row: row[x])
 
-    downsampled_df = downsampled_df.drop(columns=["bin"], errors="ignore")
-
-    return downsampled_df, updated_x_lim
+    return (
+        _restore_records_shape(downsampled_rows, columns_to_keep, dataframe_class),
+        updated_x_lim,
+    )
 
 
 def sort_metrics_by_prefix(metrics: list[str]) -> list[str]:


### PR DESCRIPTION
This PR drops the dependency on `gradio`, `fastapi`, and `pandas` for local Trackio usage. The dashboard and CLI now rely on `gradio-client`, Starlette, and Uvicorn, with small vendored copies of the Gradio pieces we still need (tunneling, networking helpers, and shared exceptions). Server startup and ASGI wiring were refactored accordingly (`launch.py`, `asgi_app.py`, `server.py`, etc.). Note that when we deploy on Gradio Spaces, we still use `gradio` as but not locally.

Before: Non-editable install (`pip install .`) on macOS, Python 3.10.19. Figures are total size of `site-packages` after dependency resolution.

| | Before (`main`) | After (this branch) |
| --- | ---: | ---: |
| `site-packages` on disk | ~230.8 MB | ~99.9 MB |
| Packages (`pip freeze`) | 57 | 37 |

Comparing to other packages:

| Package | `site-packages` on disk | Packages (`pip freeze`) |
| --- | ---: | ---: |
| Trackio (this branch) | ~99.9 MB | 37 |
| wandb | ~119.6 MB | 20 |
| mlflow | ~558.5 MB | 91 |

(It feels like the local Trackio dashboard is even snappier now though that's just based on my vibes)