### PR TITLE
Prevent trackio errors from crashing the user's training loop

### DIFF
--- a/.changeset/upset-news-end.md
+++ b/.changeset/upset-news-end.md
@@ -1,0 +1,5 @@
+---
+"trackio": minor
+---
+
+feat:Prevent trackio errors from crashing the user's training loop

--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ To get started and see basic examples of usage, see these files:
 
 `trackio.log()` is a non-blocking call that appends to an in-memory queue and returns immediately. A background thread drains the queue every **0.5 s** and writes to the local SQLite database. Because log calls never touch the network or disk on the calling thread, the client-side throughput is effectively **unlimited** -- you can burst thousands of calls per second without slowing down your training loop.
 
-Trackio is written defensively so Trackio-side failures should not take down your main experiment code. Under normal API usage, issues inside Trackio's logging, flushing, or delivery paths degrade to warnings and local buffering rather than exceptions from your training loop.
+Trackio is written defensively so Trackio-side failures should never take down your main experiment code. Under normal usage, issues inside Trackio's logging, flushing, or delivery paths degrade to warnings and local buffering rather than exceptions from your training loop.
 
 ### Logging to a Hugging Face Space
 

--- a/README.md
+++ b/README.md
@@ -245,6 +245,8 @@ To get started and see basic examples of usage, see these files:
 
 `trackio.log()` is a non-blocking call that appends to an in-memory queue and returns immediately. A background thread drains the queue every **0.5 s** and writes to the local SQLite database. Because log calls never touch the network or disk on the calling thread, the client-side throughput is effectively **unlimited** -- you can burst thousands of calls per second without slowing down your training loop.
 
+Trackio is written defensively so Trackio-side failures should not take down your main experiment code. Under normal API usage, issues inside Trackio's logging, flushing, or delivery paths degrade to warnings and local buffering rather than exceptions from your training loop.
+
 ### Logging to a Hugging Face Space
 
 When a `space_id` is provided, the same background thread batches queued entries and pushes them to the Space via the Gradio client API. The main factors that affect end-to-end throughput are:

--- a/docs/source/track.md
+++ b/docs/source/track.md
@@ -52,6 +52,8 @@ Once your run is initialized, you can start logging data using the [`log`] funct
 trackio.log({"loss": 0.05})
 ```
 
+Trackio is written defensively so Trackio-side failures should not take down your main experiment code. Under normal API usage, issues inside Trackio's logging, flushing, or delivery paths degrade to warnings and local buffering rather than exceptions from your training loop.
+
 Each call to [`log`] automatically increments the step counter.
 If you want to log multiple metrics at once, pass them together:
 

--- a/docs/source/track.md
+++ b/docs/source/track.md
@@ -52,7 +52,7 @@ Once your run is initialized, you can start logging data using the [`log`] funct
 trackio.log({"loss": 0.05})
 ```
 
-Trackio is written defensively so Trackio-side failures should not take down your main experiment code. Under normal API usage, issues inside Trackio's logging, flushing, or delivery paths degrade to warnings and local buffering rather than exceptions from your training loop.
+Trackio is written defensively so Trackio-side failures should never take down your main experiment code. Under normal usage, issues inside Trackio's logging, flushing, or delivery paths degrade to warnings and local buffering rather than exceptions from your training loop.
 
 Each call to [`log`] automatically increments the step counter.
 If you want to log multiple metrics at once, pass them together:

--- a/tests/unit/test_run.py
+++ b/tests/unit/test_run.py
@@ -237,7 +237,8 @@ def test_finish_does_not_crash_when_pending_data_check_fails(temp_dir, monkeypat
     monkeypatch.setattr(SQLiteStorage, "has_pending_data", raise_db_error)
 
     with pytest.warns(
-        UserWarning, match="trackio.finish\\(\\) could not inspect pending buffered logs"
+        UserWarning,
+        match="trackio.finish\\(\\) could not inspect pending buffered logs",
     ):
         run.finish()
 

--- a/tests/unit/test_run.py
+++ b/tests/unit/test_run.py
@@ -1,6 +1,5 @@
 import sqlite3
 import time
-import warnings
 from unittest.mock import MagicMock
 
 import pytest
@@ -219,83 +218,3 @@ def test_local_flush_failure_does_not_crash(temp_dir, monkeypatch):
     with pytest.warns(UserWarning, match="trackio failed to flush metric logs"):
         run.finish()
 
-
-def test_finish_does_not_crash_when_pending_data_check_fails(temp_dir, monkeypatch):
-    run = Run(
-        url="fake_url",
-        project="proj",
-        client=DummyClient(),
-        name="space-run",
-        space_id="user/space",
-    )
-
-    def raise_db_error(*args, **kwargs):
-        raise sqlite3.DatabaseError("database disk image is malformed")
-
-    monkeypatch.setattr(SQLiteStorage, "has_pending_data", raise_db_error)
-
-    with pytest.warns(
-        UserWarning,
-        match="trackio.finish\\(\\) could not inspect pending buffered logs",
-    ):
-        run.finish()
-
-
-def test_nonfatal_warnings_do_not_raise_when_warning_filter_is_error(
-    temp_dir, monkeypatch
-):
-    def raise_db_error(*args, **kwargs):
-        raise sqlite3.DatabaseError("database disk image is malformed")
-
-    monkeypatch.setattr(SQLiteStorage, "get_runs", raise_db_error)
-    monkeypatch.setattr(SQLiteStorage, "get_max_step_for_run", raise_db_error)
-
-    with warnings.catch_warnings():
-        warnings.simplefilter("error")
-        run = init(project="broken-project", name="safe-run")
-
-    monkeypatch.setattr(SQLiteStorage, "bulk_log", raise_db_error)
-    run.log({"loss": 0.5})
-
-    with warnings.catch_warnings():
-        warnings.simplefilter("error")
-        run.finish()
-
-
-def test_local_logging_survives_sender_thread_start_failure(temp_dir, monkeypatch):
-    def fail_start(self, attr_name, target, **kwargs):
-        setattr(self, attr_name, None)
-        return False
-
-    monkeypatch.setattr(Run, "_start_background_thread", fail_start)
-
-    run = Run(url=None, project="proj", client=None, name="safe-run", space_id=None)
-    run.log({"loss": 0.5})
-    run.finish()
-
-    logs = SQLiteStorage.get_logs("proj", "safe-run")
-    assert len(logs) == 1
-    assert logs[0]["loss"] == 0.5
-
-
-def test_remote_logging_survives_sender_thread_start_failure(temp_dir, monkeypatch):
-    def fail_start(self, attr_name, target, **kwargs):
-        setattr(self, attr_name, None)
-        return False
-
-    monkeypatch.setattr(Run, "_start_background_thread", fail_start)
-
-    run = Run(
-        url="fake_url",
-        project="proj",
-        client=DummyClient(),
-        name="space-run",
-        space_id="user/space",
-    )
-    run.log({"loss": 0.5})
-    run.finish()
-
-    logs = SQLiteStorage.get_logs("proj", "space-run")
-    assert len(logs) == 1
-    assert logs[0]["loss"] == 0.5
-    assert SQLiteStorage.has_pending_data("proj")

--- a/tests/unit/test_run.py
+++ b/tests/unit/test_run.py
@@ -1,4 +1,6 @@
+import sqlite3
 import time
+import warnings
 from unittest.mock import MagicMock
 
 import pytest
@@ -183,3 +185,79 @@ def test_log_does_not_crash_on_bad_metrics(temp_dir, monkeypatch):
     logs = SQLiteStorage.get_logs("proj", "safe-run")
     assert len(logs) == 1
     assert logs[0]["loss"] == 0.5
+
+
+def test_init_survives_storage_read_failures(temp_dir, monkeypatch):
+    def raise_db_error(*args, **kwargs):
+        raise sqlite3.DatabaseError("database disk image is malformed")
+
+    monkeypatch.setattr(SQLiteStorage, "get_runs", raise_db_error)
+    monkeypatch.setattr(SQLiteStorage, "get_max_step_for_run", raise_db_error)
+
+    with pytest.warns(UserWarning) as record:
+        run = init(project="broken-project", name="safe-run")
+
+    messages = [str(item.message) for item in record]
+    assert any("could not inspect existing runs" in message for message in messages)
+    assert any("could not recover the previous step" in message for message in messages)
+    assert isinstance(run, Run)
+    assert run.name == "safe-run"
+    assert run._next_step == 0
+
+    run.log({"loss": 0.5})
+    run.finish()
+
+
+def test_local_flush_failure_does_not_crash(temp_dir, monkeypatch):
+    run = Run(url=None, project="proj", client=None, name="safe-run", space_id=None)
+
+    def raise_db_error(*args, **kwargs):
+        raise sqlite3.DatabaseError("database disk image is malformed")
+
+    monkeypatch.setattr(SQLiteStorage, "bulk_log", raise_db_error)
+
+    run.log({"loss": 0.5})
+
+    with pytest.warns(UserWarning, match="trackio failed to flush metric logs"):
+        run.finish()
+
+
+def test_finish_does_not_crash_when_pending_data_check_fails(temp_dir, monkeypatch):
+    run = Run(
+        url="fake_url",
+        project="proj",
+        client=DummyClient(),
+        name="space-run",
+        space_id="user/space",
+    )
+
+    def raise_db_error(*args, **kwargs):
+        raise sqlite3.DatabaseError("database disk image is malformed")
+
+    monkeypatch.setattr(SQLiteStorage, "has_pending_data", raise_db_error)
+
+    with pytest.warns(
+        UserWarning, match="trackio.finish\\(\\) could not inspect pending buffered logs"
+    ):
+        run.finish()
+
+
+def test_nonfatal_warnings_do_not_raise_when_warning_filter_is_error(
+    temp_dir, monkeypatch
+):
+    def raise_db_error(*args, **kwargs):
+        raise sqlite3.DatabaseError("database disk image is malformed")
+
+    monkeypatch.setattr(SQLiteStorage, "get_runs", raise_db_error)
+    monkeypatch.setattr(SQLiteStorage, "get_max_step_for_run", raise_db_error)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        run = init(project="broken-project", name="safe-run")
+
+    monkeypatch.setattr(SQLiteStorage, "bulk_log", raise_db_error)
+    run.log({"loss": 0.5})
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        run.finish()

--- a/tests/unit/test_run.py
+++ b/tests/unit/test_run.py
@@ -158,3 +158,28 @@ def test_run_group_added(temp_dir):
         config={"learning_rate": 0.01},
     )
     assert run.config["_Group"] == "test_group"
+
+
+def test_log_does_not_crash_on_bad_metrics(temp_dir, monkeypatch):
+    run = Run(url=None, project="proj", client=None, name="safe-run", space_id=None)
+
+    from trackio import utils
+
+    original = utils.serialize_values
+
+    def exploding_serialize(metrics):
+        if "bad" in metrics:
+            raise RuntimeError("serialize boom")
+        return original(metrics)
+
+    monkeypatch.setattr(utils, "serialize_values", exploding_serialize)
+
+    with pytest.warns(UserWarning, match="trackio.log\\(\\) failed to process metrics"):
+        run.log({"bad": 1})
+
+    run.log({"loss": 0.5})
+    run.finish()
+
+    logs = SQLiteStorage.get_logs("proj", "safe-run")
+    assert len(logs) == 1
+    assert logs[0]["loss"] == 0.5

--- a/tests/unit/test_run.py
+++ b/tests/unit/test_run.py
@@ -217,4 +217,3 @@ def test_local_flush_failure_does_not_crash(temp_dir, monkeypatch):
 
     with pytest.warns(UserWarning, match="trackio failed to flush metric logs"):
         run.finish()
-

--- a/tests/unit/test_run.py
+++ b/tests/unit/test_run.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from trackio import Markdown, Run, init
+from trackio import Markdown, Run, init, utils
 from trackio.sqlite_storage import SQLiteStorage
 
 
@@ -165,8 +165,6 @@ def test_run_group_added(temp_dir):
 def test_log_does_not_crash_on_bad_metrics(temp_dir, monkeypatch):
     run = Run(url=None, project="proj", client=None, name="safe-run", space_id=None)
 
-    from trackio import utils
-
     original = utils.serialize_values
 
     def exploding_serialize(metrics):
@@ -262,3 +260,42 @@ def test_nonfatal_warnings_do_not_raise_when_warning_filter_is_error(
     with warnings.catch_warnings():
         warnings.simplefilter("error")
         run.finish()
+
+
+def test_local_logging_survives_sender_thread_start_failure(temp_dir, monkeypatch):
+    def fail_start(self, attr_name, target, **kwargs):
+        setattr(self, attr_name, None)
+        return False
+
+    monkeypatch.setattr(Run, "_start_background_thread", fail_start)
+
+    run = Run(url=None, project="proj", client=None, name="safe-run", space_id=None)
+    run.log({"loss": 0.5})
+    run.finish()
+
+    logs = SQLiteStorage.get_logs("proj", "safe-run")
+    assert len(logs) == 1
+    assert logs[0]["loss"] == 0.5
+
+
+def test_remote_logging_survives_sender_thread_start_failure(temp_dir, monkeypatch):
+    def fail_start(self, attr_name, target, **kwargs):
+        setattr(self, attr_name, None)
+        return False
+
+    monkeypatch.setattr(Run, "_start_background_thread", fail_start)
+
+    run = Run(
+        url="fake_url",
+        project="proj",
+        client=DummyClient(),
+        name="space-run",
+        space_id="user/space",
+    )
+    run.log({"loss": 0.5})
+    run.finish()
+
+    logs = SQLiteStorage.get_logs("proj", "space-run")
+    assert len(logs) == 1
+    assert logs[0]["loss"] == 0.5
+    assert SQLiteStorage.has_pending_data("proj")

--- a/trackio/__init__.py
+++ b/trackio/__init__.py
@@ -89,6 +89,13 @@ _atexit_registered = False
 _projects_notified_auto_log_hw: set[str] = set()
 
 
+def _emit_nonfatal_warning(message: str, *args, **kwargs) -> None:
+    try:
+        warnings.warn(message, *args, **kwargs)
+    except Exception:
+        print(f"* Trackio warning: {message}")
+
+
 def _cleanup_current_run():
     run = context_vars.current_run.get()
     if run is not None:
@@ -96,6 +103,16 @@ def _cleanup_current_run():
             run.finish()
         except Exception:
             pass
+
+
+def _safe_get_runs_for_init(project: str) -> list[str]:
+    try:
+        return SQLiteStorage.get_runs(project)
+    except Exception as e:
+        _emit_nonfatal_warning(
+            f"trackio.init() could not inspect existing runs for project '{project}': {e}. Continuing without resume metadata."
+        )
+        return []
 
 
 def init(
@@ -195,7 +212,7 @@ def init(
         `Run`: A [`Run`] object that can be used to log metrics and finish the run.
     """
     if settings is not None:
-        warnings.warn(
+        _emit_nonfatal_warning(
             "* Warning: settings is not used. Provided for compatibility with wandb.init(). Please create an issue at: https://github.com/gradio-app/trackio/issues if you need a specific feature implemented."
         )
 
@@ -215,7 +232,7 @@ def init(
         ) from e
 
     if space_id is None and bucket_id is not None:
-        warnings.warn(
+        _emit_nonfatal_warning(
             "trackio.init() has `bucket_id` set but `space_id` is None: metrics will be logged "
             "locally only. Pass `space_id` to create or use a Hugging Face Space, which will be "
             "attached to the Hugging Face Bucket.",
@@ -259,32 +276,39 @@ def init(
             if not _should_embed_local:
                 utils.print_dashboard_instructions(project)
         else:
-            deploy.create_space_if_not_exists(
-                space_id,
-                space_storage,
-                dataset_id,
-                bucket_id,
-                private,
-            )
-            user_name, space_name = space_id.split("/")
-            space_url = deploy.SPACE_HOST_URL.format(
-                user_name=user_name, space_name=space_name
-            )
-            if utils.is_in_notebook() and embed:
-                utils.embed_url_in_notebook(space_url)
+            try:
+                deploy.create_space_if_not_exists(
+                    space_id,
+                    space_storage,
+                    dataset_id,
+                    bucket_id,
+                    private,
+                )
+                user_name, space_name = space_id.split("/")
+                space_url = deploy.SPACE_HOST_URL.format(
+                    user_name=user_name, space_name=space_name
+                )
+                if utils.is_in_notebook() and embed:
+                    utils.embed_url_in_notebook(space_url)
+            except Exception as e:
+                _emit_nonfatal_warning(
+                    f"trackio.init() could not prepare Space '{space_id}': {e}. Logging will continue in local fallback mode until the Space is reachable."
+                )
     context_vars.current_project.set(project)
+
+    existing_runs = _safe_get_runs_for_init(project)
 
     if resume == "must":
         if name is None:
             raise ValueError("Must provide a run name when resume='must'")
-        if name not in SQLiteStorage.get_runs(project):
+        if name not in existing_runs:
             raise ValueError(f"Run '{name}' does not exist in project '{project}'")
         resumed = True
     elif resume == "allow":
-        resumed = name is not None and name in SQLiteStorage.get_runs(project)
+        resumed = name is not None and name in existing_runs
     elif resume == "never":
-        if name is not None and name in SQLiteStorage.get_runs(project):
-            warnings.warn(
+        if name is not None and name in existing_runs:
+            _emit_nonfatal_warning(
                 f"* Warning: resume='never' but a run '{name}' already exists in "
                 f"project '{project}'. Generating a new name and instead. If you want "
                 "to resume this run, call init() with resume='must' or resume='allow'."
@@ -323,9 +347,19 @@ def init(
     )
 
     if space_id is not None:
-        SQLiteStorage.set_project_metadata(project, "space_id", space_id)
-        if SQLiteStorage.has_pending_data(project):
-            run._has_local_buffer = True
+        try:
+            SQLiteStorage.set_project_metadata(project, "space_id", space_id)
+        except Exception as e:
+            _emit_nonfatal_warning(
+                f"trackio.init() could not persist Space metadata for project '{project}': {e}. Logging will continue."
+            )
+        try:
+            if SQLiteStorage.has_pending_data(project):
+                run._has_local_buffer = True
+        except Exception as e:
+            _emit_nonfatal_warning(
+                f"trackio.init() could not inspect pending buffered data for project '{project}': {e}. Logging will continue."
+            )
 
     global _atexit_registered
     if not _atexit_registered:
@@ -341,7 +375,12 @@ def init(
     globals()["config"] = run.config
 
     if _should_embed_local:
-        show(project=project, open_browser=False, block_thread=False)
+        try:
+            show(project=project, open_browser=False, block_thread=False)
+        except Exception as e:
+            _emit_nonfatal_warning(
+                f"trackio.init() could not auto-launch the dashboard: {e}. Logging will continue."
+            )
 
     return run
 
@@ -415,7 +454,7 @@ def log_gpu(run: Run | None = None, device: int | None = None) -> dict:
     elif apple_gpu_available():
         return _log_apple_gpu(run=run)
     else:
-        warnings.warn(
+        _emit_nonfatal_warning(
             "No GPU detected. Install nvidia-ml-py for NVIDIA GPU support "
             "or psutil for Apple Silicon support."
         )
@@ -636,7 +675,7 @@ def save(
                     hf_token=huggingface_hub.utils.get_token(),
                 )
             except Exception as e:
-                warnings.warn(
+                _emit_nonfatal_warning(
                     f"Failed to upload files: {e}. "
                     "Files may not be available in the dashboard."
                 )

--- a/trackio/__init__.py
+++ b/trackio/__init__.py
@@ -39,7 +39,7 @@ from trackio.server import make_trackio_server
 from trackio.sqlite_storage import SQLiteStorage
 from trackio.table import Table
 from trackio.typehints import UploadEntry
-from trackio.utils import TRACKIO_DIR, TRACKIO_LOGO_DIR
+from trackio.utils import TRACKIO_DIR, TRACKIO_LOGO_DIR, _emit_nonfatal_warning
 
 logging.getLogger("httpx").setLevel(logging.WARNING)
 
@@ -87,13 +87,6 @@ config = {}
 
 _atexit_registered = False
 _projects_notified_auto_log_hw: set[str] = set()
-
-
-def _emit_nonfatal_warning(message: str, *args, **kwargs) -> None:
-    try:
-        warnings.warn(message, *args, **kwargs)
-    except Exception:
-        print(f"* Trackio warning: {message}")
 
 
 def _cleanup_current_run():

--- a/trackio/run.py
+++ b/trackio/run.py
@@ -163,9 +163,7 @@ class Run:
                     self._gpu_monitor = GpuMonitor(self, interval=gpu_log_interval)
                     self._gpu_monitor.start()
                 elif apple_gpu_available():
-                    self._gpu_monitor = AppleGpuMonitor(
-                        self, interval=gpu_log_interval
-                    )
+                    self._gpu_monitor = AppleGpuMonitor(self, interval=gpu_log_interval)
                     self._gpu_monitor.start()
             except Exception as e:
                 self._warn_once(

--- a/trackio/run.py
+++ b/trackio/run.py
@@ -2,7 +2,6 @@ import os
 import shutil
 import threading
 import uuid
-import warnings
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -25,17 +24,10 @@ from trackio.media import TrackioMedia, get_project_media_path
 from trackio.sqlite_storage import SQLiteStorage
 from trackio.table import Table
 from trackio.typehints import AlertEntry, LogEntry, SystemLogEntry, UploadEntry
-from trackio.utils import MEDIA_DIR, _get_default_namespace
+from trackio.utils import MEDIA_DIR, _emit_nonfatal_warning, _get_default_namespace
 
 BATCH_SEND_INTERVAL = 0.5
 MAX_BACKOFF = 30
-
-
-def _emit_nonfatal_warning(message: str, *args, **kwargs) -> None:
-    try:
-        warnings.warn(message, *args, **kwargs)
-    except Exception:
-        print(f"* Trackio warning: {message}")
 
 
 class Run:

--- a/trackio/run.py
+++ b/trackio/run.py
@@ -31,6 +31,13 @@ BATCH_SEND_INTERVAL = 0.5
 MAX_BACKOFF = 30
 
 
+def _emit_nonfatal_warning(message: str, *args, **kwargs) -> None:
+    try:
+        warnings.warn(message, *args, **kwargs)
+    except Exception:
+        print(f"* Trackio warning: {message}")
+
+
 class Run:
     def __init__(
         self,
@@ -79,14 +86,33 @@ class Run:
         self.url = url
         self.project = project
         self._client_lock = threading.Lock()
+        self._warning_lock = threading.Lock()
+        self._warned_failures: set[str] = set()
         self._client_thread = None
         self._client = client
         self._space_id = space_id
-        self.name = name or utils.generate_readable_name(
-            SQLiteStorage.get_runs(project), space_id
-        )
+        if name is not None:
+            self.name = name
+        else:
+            try:
+                self.name = utils.generate_readable_name(
+                    self._safe_get_existing_runs(), space_id
+                )
+            except Exception as e:
+                self._warn_once(
+                    "init-run-name",
+                    f"trackio.init() could not generate a run name: {e}. Falling back to a random name.",
+                )
+                self.name = f"trackio-run-{uuid.uuid4().hex[:8]}"
         self.group = group
-        self.config = utils.to_json_safe(config or {})
+        try:
+            self.config = utils.to_json_safe(config or {})
+        except Exception as e:
+            self._warn_once(
+                "init-config",
+                f"trackio.init() failed to serialize the run config: {e}. Continuing without config.",
+            )
+            self.config = {}
 
         if isinstance(self.config, dict):
             for key in self.config:
@@ -105,7 +131,7 @@ class Run:
         self._queued_alerts: list[AlertEntry] = []
         self._stop_flag = threading.Event()
         self._config_logged = False
-        max_step = SQLiteStorage.get_max_step_for_run(self.project, self.name)
+        max_step = self._safe_get_max_step_for_run()
         self._next_step = 0 if max_step is None else max_step + 1
         self._has_local_buffer = False
 
@@ -116,30 +142,88 @@ class Run:
         )
 
         if self._is_local:
-            self._local_sender_thread = threading.Thread(
-                target=self._local_batch_sender
+            self._start_background_thread(
+                "_local_sender_thread",
+                self._local_batch_sender,
+                warning_key="local-sender-thread",
+                description="local Trackio logging thread",
             )
-            self._local_sender_thread.daemon = True
-            self._local_sender_thread.start()
         else:
-            self._client_thread = threading.Thread(target=self._init_client_background)
-            self._client_thread.daemon = True
-            self._client_thread.start()
+            self._start_background_thread(
+                "_client_thread",
+                self._init_client_background,
+                warning_key="remote-sender-thread",
+                description="remote Trackio logging thread",
+            )
 
         self._gpu_monitor: "GpuMonitor | AppleGpuMonitor | None" = None
         if auto_log_gpu:
-            if gpu_available():
-                self._gpu_monitor = GpuMonitor(self, interval=gpu_log_interval)
-                self._gpu_monitor.start()
-            elif apple_gpu_available():
-                self._gpu_monitor = AppleGpuMonitor(self, interval=gpu_log_interval)
-                self._gpu_monitor.start()
+            try:
+                if gpu_available():
+                    self._gpu_monitor = GpuMonitor(self, interval=gpu_log_interval)
+                    self._gpu_monitor.start()
+                elif apple_gpu_available():
+                    self._gpu_monitor = AppleGpuMonitor(
+                        self, interval=gpu_log_interval
+                    )
+                    self._gpu_monitor.start()
+            except Exception as e:
+                self._warn_once(
+                    "gpu-monitor",
+                    f"trackio.init() failed to start automatic GPU logging: {e}. Continuing without system metric auto-logging.",
+                )
 
     def _get_username(self) -> str | None:
         try:
             return _get_default_namespace()
         except Exception:
             return None
+
+    def _warn_once(self, key: str, message: str) -> None:
+        with self._warning_lock:
+            if key in self._warned_failures:
+                return
+            self._warned_failures.add(key)
+        _emit_nonfatal_warning(message)
+
+    def _safe_get_existing_runs(self) -> list[str]:
+        try:
+            return SQLiteStorage.get_runs(self.project)
+        except Exception as e:
+            self._warn_once(
+                "init-existing-runs",
+                f"trackio.init() could not inspect existing runs for project '{self.project}': {e}. Continuing without prior-run metadata.",
+            )
+            return []
+
+    def _safe_get_max_step_for_run(self) -> int | None:
+        try:
+            return SQLiteStorage.get_max_step_for_run(self.project, self.name)
+        except Exception as e:
+            self._warn_once(
+                "init-max-step",
+                f"trackio.init() could not recover the previous step for run '{self.name}': {e}. Continuing from step 0.",
+            )
+            return None
+
+    def _start_background_thread(
+        self,
+        attr_name: str,
+        target,
+        *,
+        warning_key: str,
+        description: str,
+    ) -> None:
+        try:
+            thread = threading.Thread(target=target, daemon=True)
+            setattr(self, attr_name, thread)
+            thread.start()
+        except Exception as e:
+            setattr(self, attr_name, None)
+            self._warn_once(
+                warning_key,
+                f"trackio failed to start the {description}: {e}. Logging will continue in degraded mode.",
+            )
 
     def _local_batch_sender(self):
         while (
@@ -151,101 +235,125 @@ class Run:
             if not self._stop_flag.is_set():
                 self._stop_flag.wait(timeout=BATCH_SEND_INTERVAL)
 
-            with self._client_lock:
-                if self._queued_logs:
-                    logs_to_send = self._queued_logs.copy()
-                    self._queued_logs.clear()
-                    self._write_logs_to_sqlite(logs_to_send)
+            try:
+                with self._client_lock:
+                    if self._queued_logs:
+                        logs_to_send = self._queued_logs.copy()
+                        self._queued_logs.clear()
+                        self._write_logs_to_sqlite(logs_to_send)
 
-                if self._queued_system_logs:
-                    system_logs_to_send = self._queued_system_logs.copy()
-                    self._queued_system_logs.clear()
-                    self._write_system_logs_to_sqlite(system_logs_to_send)
+                    if self._queued_system_logs:
+                        system_logs_to_send = self._queued_system_logs.copy()
+                        self._queued_system_logs.clear()
+                        self._write_system_logs_to_sqlite(system_logs_to_send)
 
-                if self._queued_alerts:
-                    alerts_to_send = self._queued_alerts.copy()
-                    self._queued_alerts.clear()
-                    self._write_alerts_to_sqlite(alerts_to_send)
+                    if self._queued_alerts:
+                        alerts_to_send = self._queued_alerts.copy()
+                        self._queued_alerts.clear()
+                        self._write_alerts_to_sqlite(alerts_to_send)
+            except Exception as e:
+                self._warn_once(
+                    "local-sender-loop",
+                    f"trackio's local logging thread hit an internal error: {e}. User code will continue, but some Trackio data may be dropped.",
+                )
 
     def _write_logs_to_sqlite(self, logs: list[LogEntry]):
-        logs_by_run: dict[tuple, dict] = {}
-        for entry in logs:
-            key = (entry["project"], entry["run"])
-            if key not in logs_by_run:
-                logs_by_run[key] = {
-                    "metrics": [],
-                    "steps": [],
-                    "log_ids": [],
-                    "config": None,
-                }
-            logs_by_run[key]["metrics"].append(entry["metrics"])
-            logs_by_run[key]["steps"].append(entry.get("step"))
-            logs_by_run[key]["log_ids"].append(entry.get("log_id"))
-            if entry.get("config") and logs_by_run[key]["config"] is None:
-                logs_by_run[key]["config"] = entry["config"]
+        try:
+            logs_by_run: dict[tuple, dict] = {}
+            for entry in logs:
+                key = (entry["project"], entry["run"])
+                if key not in logs_by_run:
+                    logs_by_run[key] = {
+                        "metrics": [],
+                        "steps": [],
+                        "log_ids": [],
+                        "config": None,
+                    }
+                logs_by_run[key]["metrics"].append(entry["metrics"])
+                logs_by_run[key]["steps"].append(entry.get("step"))
+                logs_by_run[key]["log_ids"].append(entry.get("log_id"))
+                if entry.get("config") and logs_by_run[key]["config"] is None:
+                    logs_by_run[key]["config"] = entry["config"]
 
-        for (project, run), data in logs_by_run.items():
-            has_log_ids = any(lid is not None for lid in data["log_ids"])
-            SQLiteStorage.bulk_log(
-                project=project,
-                run=run,
-                metrics_list=data["metrics"],
-                steps=data["steps"],
-                config=data["config"],
-                log_ids=data["log_ids"] if has_log_ids else None,
+            for (project, run), data in logs_by_run.items():
+                has_log_ids = any(lid is not None for lid in data["log_ids"])
+                SQLiteStorage.bulk_log(
+                    project=project,
+                    run=run,
+                    metrics_list=data["metrics"],
+                    steps=data["steps"],
+                    config=data["config"],
+                    log_ids=data["log_ids"] if has_log_ids else None,
+                )
+        except Exception as e:
+            self._warn_once(
+                "write-logs-to-sqlite",
+                f"trackio failed to flush metric logs for run '{self.name}': {e}. User code will continue, but this batch could not be persisted.",
             )
 
     def _write_system_logs_to_sqlite(self, logs: list[SystemLogEntry]):
-        logs_by_run: dict[tuple, dict] = {}
-        for entry in logs:
-            key = (entry["project"], entry["run"])
-            if key not in logs_by_run:
-                logs_by_run[key] = {"metrics": [], "timestamps": [], "log_ids": []}
-            logs_by_run[key]["metrics"].append(entry["metrics"])
-            logs_by_run[key]["timestamps"].append(entry.get("timestamp"))
-            logs_by_run[key]["log_ids"].append(entry.get("log_id"))
+        try:
+            logs_by_run: dict[tuple, dict] = {}
+            for entry in logs:
+                key = (entry["project"], entry["run"])
+                if key not in logs_by_run:
+                    logs_by_run[key] = {"metrics": [], "timestamps": [], "log_ids": []}
+                logs_by_run[key]["metrics"].append(entry["metrics"])
+                logs_by_run[key]["timestamps"].append(entry.get("timestamp"))
+                logs_by_run[key]["log_ids"].append(entry.get("log_id"))
 
-        for (project, run), data in logs_by_run.items():
-            has_log_ids = any(lid is not None for lid in data["log_ids"])
-            SQLiteStorage.bulk_log_system(
-                project=project,
-                run=run,
-                metrics_list=data["metrics"],
-                timestamps=data["timestamps"],
-                log_ids=data["log_ids"] if has_log_ids else None,
+            for (project, run), data in logs_by_run.items():
+                has_log_ids = any(lid is not None for lid in data["log_ids"])
+                SQLiteStorage.bulk_log_system(
+                    project=project,
+                    run=run,
+                    metrics_list=data["metrics"],
+                    timestamps=data["timestamps"],
+                    log_ids=data["log_ids"] if has_log_ids else None,
+                )
+        except Exception as e:
+            self._warn_once(
+                "write-system-logs-to-sqlite",
+                f"trackio failed to flush system logs for run '{self.name}': {e}. User code will continue, but this batch could not be persisted.",
             )
 
     def _write_alerts_to_sqlite(self, alerts: list[AlertEntry]):
-        alerts_by_run: dict[tuple, dict] = {}
-        for entry in alerts:
-            key = (entry["project"], entry["run"])
-            if key not in alerts_by_run:
-                alerts_by_run[key] = {
-                    "titles": [],
-                    "texts": [],
-                    "levels": [],
-                    "steps": [],
-                    "timestamps": [],
-                    "alert_ids": [],
-                }
-            alerts_by_run[key]["titles"].append(entry["title"])
-            alerts_by_run[key]["texts"].append(entry.get("text"))
-            alerts_by_run[key]["levels"].append(entry["level"])
-            alerts_by_run[key]["steps"].append(entry.get("step"))
-            alerts_by_run[key]["timestamps"].append(entry.get("timestamp"))
-            alerts_by_run[key]["alert_ids"].append(entry.get("alert_id"))
+        try:
+            alerts_by_run: dict[tuple, dict] = {}
+            for entry in alerts:
+                key = (entry["project"], entry["run"])
+                if key not in alerts_by_run:
+                    alerts_by_run[key] = {
+                        "titles": [],
+                        "texts": [],
+                        "levels": [],
+                        "steps": [],
+                        "timestamps": [],
+                        "alert_ids": [],
+                    }
+                alerts_by_run[key]["titles"].append(entry["title"])
+                alerts_by_run[key]["texts"].append(entry.get("text"))
+                alerts_by_run[key]["levels"].append(entry["level"])
+                alerts_by_run[key]["steps"].append(entry.get("step"))
+                alerts_by_run[key]["timestamps"].append(entry.get("timestamp"))
+                alerts_by_run[key]["alert_ids"].append(entry.get("alert_id"))
 
-        for (project, run), data in alerts_by_run.items():
-            has_alert_ids = any(aid is not None for aid in data["alert_ids"])
-            SQLiteStorage.bulk_alert(
-                project=project,
-                run=run,
-                titles=data["titles"],
-                texts=data["texts"],
-                levels=data["levels"],
-                steps=data["steps"],
-                timestamps=data["timestamps"],
-                alert_ids=data["alert_ids"] if has_alert_ids else None,
+            for (project, run), data in alerts_by_run.items():
+                has_alert_ids = any(aid is not None for aid in data["alert_ids"])
+                SQLiteStorage.bulk_alert(
+                    project=project,
+                    run=run,
+                    titles=data["titles"],
+                    texts=data["texts"],
+                    levels=data["levels"],
+                    steps=data["steps"],
+                    timestamps=data["timestamps"],
+                    alert_ids=data["alert_ids"] if has_alert_ids else None,
+                )
+        except Exception as e:
+            self._warn_once(
+                "write-alerts-to-sqlite",
+                f"trackio failed to flush alerts for run '{self.name}': {e}. User code will continue, but this batch could not be persisted.",
             )
 
     def _batch_sender(self):
@@ -269,159 +377,186 @@ class Run:
             elif self._has_local_buffer:
                 self._stop_flag.wait(timeout=BATCH_SEND_INTERVAL)
 
-            with self._client_lock:
-                if self._client is None:
-                    if self._stop_flag.is_set():
-                        if self._queued_logs:
-                            self._persist_logs_locally(self._queued_logs)
-                            self._queued_logs.clear()
-                        if self._queued_system_logs:
-                            self._persist_system_logs_locally(self._queued_system_logs)
-                            self._queued_system_logs.clear()
-                        if self._queued_uploads:
-                            self._persist_uploads_locally(self._queued_uploads)
-                            self._queued_uploads.clear()
-                        if self._queued_alerts:
-                            self._write_alerts_to_sqlite(self._queued_alerts)
-                            self._queued_alerts.clear()
-                    return
+            try:
+                with self._client_lock:
+                    if self._client is None:
+                        if self._stop_flag.is_set():
+                            if self._queued_logs:
+                                self._persist_logs_locally(self._queued_logs)
+                                self._queued_logs.clear()
+                            if self._queued_system_logs:
+                                self._persist_system_logs_locally(
+                                    self._queued_system_logs
+                                )
+                                self._queued_system_logs.clear()
+                            if self._queued_uploads:
+                                self._persist_uploads_locally(self._queued_uploads)
+                                self._queued_uploads.clear()
+                            if self._queued_alerts:
+                                self._write_alerts_to_sqlite(self._queued_alerts)
+                                self._queued_alerts.clear()
+                        return
 
-                failed = False
+                    failed = False
 
-                if self._queued_logs:
-                    logs_to_send = self._queued_logs.copy()
-                    self._queued_logs.clear()
-                    try:
-                        self._client.predict(
-                            api_name="/bulk_log",
-                            logs=logs_to_send,
-                            hf_token=huggingface_hub.utils.get_token(),
-                        )
-                    except Exception:
-                        self._persist_logs_locally(logs_to_send)
-                        failed = True
+                    if self._queued_logs:
+                        logs_to_send = self._queued_logs.copy()
+                        self._queued_logs.clear()
+                        try:
+                            self._client.predict(
+                                api_name="/bulk_log",
+                                logs=logs_to_send,
+                                hf_token=huggingface_hub.utils.get_token(),
+                            )
+                        except Exception:
+                            self._persist_logs_locally(logs_to_send)
+                            failed = True
 
-                if self._queued_system_logs:
-                    system_logs_to_send = self._queued_system_logs.copy()
-                    self._queued_system_logs.clear()
-                    try:
-                        self._client.predict(
-                            api_name="/bulk_log_system",
-                            logs=system_logs_to_send,
-                            hf_token=huggingface_hub.utils.get_token(),
-                        )
-                    except Exception:
-                        self._persist_system_logs_locally(system_logs_to_send)
-                        failed = True
+                    if self._queued_system_logs:
+                        system_logs_to_send = self._queued_system_logs.copy()
+                        self._queued_system_logs.clear()
+                        try:
+                            self._client.predict(
+                                api_name="/bulk_log_system",
+                                logs=system_logs_to_send,
+                                hf_token=huggingface_hub.utils.get_token(),
+                            )
+                        except Exception:
+                            self._persist_system_logs_locally(system_logs_to_send)
+                            failed = True
 
-                if self._queued_uploads:
-                    uploads_to_send = self._queued_uploads.copy()
-                    self._queued_uploads.clear()
-                    try:
-                        self._client.predict(
-                            api_name="/bulk_upload_media",
-                            uploads=uploads_to_send,
-                            hf_token=huggingface_hub.utils.get_token(),
-                        )
-                    except Exception:
-                        self._persist_uploads_locally(uploads_to_send)
-                        failed = True
+                    if self._queued_uploads:
+                        uploads_to_send = self._queued_uploads.copy()
+                        self._queued_uploads.clear()
+                        try:
+                            self._client.predict(
+                                api_name="/bulk_upload_media",
+                                uploads=uploads_to_send,
+                                hf_token=huggingface_hub.utils.get_token(),
+                            )
+                        except Exception:
+                            self._persist_uploads_locally(uploads_to_send)
+                            failed = True
 
-                if self._queued_alerts:
-                    alerts_to_send = self._queued_alerts.copy()
-                    self._queued_alerts.clear()
-                    try:
-                        self._client.predict(
-                            api_name="/bulk_alert",
-                            alerts=alerts_to_send,
-                            hf_token=huggingface_hub.utils.get_token(),
-                        )
-                    except Exception:
-                        self._write_alerts_to_sqlite(alerts_to_send)
-                        failed = True
+                    if self._queued_alerts:
+                        alerts_to_send = self._queued_alerts.copy()
+                        self._queued_alerts.clear()
+                        try:
+                            self._client.predict(
+                                api_name="/bulk_alert",
+                                alerts=alerts_to_send,
+                                hf_token=huggingface_hub.utils.get_token(),
+                            )
+                        except Exception:
+                            self._write_alerts_to_sqlite(alerts_to_send)
+                            failed = True
 
-                if failed:
-                    consecutive_failures += 1
-                else:
-                    consecutive_failures = 0
-                    if self._has_local_buffer:
-                        self._flush_local_buffer()
+                    if failed:
+                        consecutive_failures += 1
+                    else:
+                        consecutive_failures = 0
+                        if self._has_local_buffer:
+                            self._flush_local_buffer()
+            except Exception as e:
+                consecutive_failures += 1
+                self._warn_once(
+                    "remote-sender-loop",
+                    f"trackio's remote logging thread hit an internal error: {e}. User code will continue while Trackio retries in the background.",
+                )
 
     def _persist_logs_locally(self, logs: list[LogEntry]):
         if not self._space_id:
             return
-        logs_by_run: dict[tuple, dict] = {}
-        for entry in logs:
-            key = (entry["project"], entry["run"])
-            if key not in logs_by_run:
-                logs_by_run[key] = {
-                    "metrics": [],
-                    "steps": [],
-                    "log_ids": [],
-                    "config": None,
-                }
-            logs_by_run[key]["metrics"].append(entry["metrics"])
-            logs_by_run[key]["steps"].append(entry.get("step"))
-            logs_by_run[key]["log_ids"].append(entry.get("log_id"))
-            if entry.get("config") and logs_by_run[key]["config"] is None:
-                logs_by_run[key]["config"] = entry["config"]
+        try:
+            logs_by_run: dict[tuple, dict] = {}
+            for entry in logs:
+                key = (entry["project"], entry["run"])
+                if key not in logs_by_run:
+                    logs_by_run[key] = {
+                        "metrics": [],
+                        "steps": [],
+                        "log_ids": [],
+                        "config": None,
+                    }
+                logs_by_run[key]["metrics"].append(entry["metrics"])
+                logs_by_run[key]["steps"].append(entry.get("step"))
+                logs_by_run[key]["log_ids"].append(entry.get("log_id"))
+                if entry.get("config") and logs_by_run[key]["config"] is None:
+                    logs_by_run[key]["config"] = entry["config"]
 
-        for (project, run), data in logs_by_run.items():
-            SQLiteStorage.bulk_log(
-                project=project,
-                run=run,
-                metrics_list=data["metrics"],
-                steps=data["steps"],
-                log_ids=data["log_ids"],
-                config=data["config"],
-                space_id=self._space_id,
+            for (project, run), data in logs_by_run.items():
+                SQLiteStorage.bulk_log(
+                    project=project,
+                    run=run,
+                    metrics_list=data["metrics"],
+                    steps=data["steps"],
+                    log_ids=data["log_ids"],
+                    config=data["config"],
+                    space_id=self._space_id,
+                )
+            self._has_local_buffer = True
+        except Exception as e:
+            self._warn_once(
+                "persist-logs-locally",
+                f"trackio could not persist failed remote metric logs locally for run '{self.name}': {e}. User code will continue, but this batch could be lost.",
             )
-        self._has_local_buffer = True
 
     def _persist_system_logs_locally(self, logs: list[SystemLogEntry]):
         if not self._space_id:
             return
-        logs_by_run: dict[tuple, dict] = {}
-        for entry in logs:
-            key = (entry["project"], entry["run"])
-            if key not in logs_by_run:
-                logs_by_run[key] = {"metrics": [], "timestamps": [], "log_ids": []}
-            logs_by_run[key]["metrics"].append(entry["metrics"])
-            logs_by_run[key]["timestamps"].append(entry.get("timestamp"))
-            logs_by_run[key]["log_ids"].append(entry.get("log_id"))
+        try:
+            logs_by_run: dict[tuple, dict] = {}
+            for entry in logs:
+                key = (entry["project"], entry["run"])
+                if key not in logs_by_run:
+                    logs_by_run[key] = {"metrics": [], "timestamps": [], "log_ids": []}
+                logs_by_run[key]["metrics"].append(entry["metrics"])
+                logs_by_run[key]["timestamps"].append(entry.get("timestamp"))
+                logs_by_run[key]["log_ids"].append(entry.get("log_id"))
 
-        for (project, run), data in logs_by_run.items():
-            SQLiteStorage.bulk_log_system(
-                project=project,
-                run=run,
-                metrics_list=data["metrics"],
-                timestamps=data["timestamps"],
-                log_ids=data["log_ids"],
-                space_id=self._space_id,
+            for (project, run), data in logs_by_run.items():
+                SQLiteStorage.bulk_log_system(
+                    project=project,
+                    run=run,
+                    metrics_list=data["metrics"],
+                    timestamps=data["timestamps"],
+                    log_ids=data["log_ids"],
+                    space_id=self._space_id,
+                )
+            self._has_local_buffer = True
+        except Exception as e:
+            self._warn_once(
+                "persist-system-logs-locally",
+                f"trackio could not persist failed remote system logs locally for run '{self.name}': {e}. User code will continue, but this batch could be lost.",
             )
-        self._has_local_buffer = True
 
     def _persist_uploads_locally(self, uploads: list[UploadEntry]):
         if not self._space_id:
             return
-        for entry in uploads:
-            file_data = entry.get("uploaded_file")
-            file_path = ""
-            if isinstance(file_data, dict):
-                file_path = file_data.get("path", "")
-            elif hasattr(file_data, "path"):
-                file_path = str(file_data.path)
-            else:
-                file_path = str(file_data)
-            SQLiteStorage.add_pending_upload(
-                project=entry["project"],
-                space_id=self._space_id,
-                run_name=entry.get("run"),
-                step=entry.get("step"),
-                file_path=file_path,
-                relative_path=entry.get("relative_path"),
+        try:
+            for entry in uploads:
+                file_data = entry.get("uploaded_file")
+                file_path = ""
+                if isinstance(file_data, dict):
+                    file_path = file_data.get("path", "")
+                elif hasattr(file_data, "path"):
+                    file_path = str(file_data.path)
+                else:
+                    file_path = str(file_data)
+                SQLiteStorage.add_pending_upload(
+                    project=entry["project"],
+                    space_id=self._space_id,
+                    run_name=entry.get("run"),
+                    step=entry.get("step"),
+                    file_path=file_path,
+                    relative_path=entry.get("relative_path"),
+                )
+            self._has_local_buffer = True
+        except Exception as e:
+            self._warn_once(
+                "persist-uploads-locally",
+                f"trackio could not persist failed remote file uploads locally for run '{self.name}': {e}. User code will continue, but some artifacts could be lost.",
             )
-        self._has_local_buffer = True
 
     def _flush_local_buffer(self):
         try:
@@ -471,8 +606,11 @@ class Run:
                 )
 
             self._has_local_buffer = False
-        except Exception:
-            pass
+        except Exception as e:
+            self._warn_once(
+                "flush-local-buffer",
+                f"trackio could not flush buffered remote data for run '{self.name}': {e}. It will retry later if possible.",
+            )
 
     def _init_client_background(self):
         if self._client is None:
@@ -500,18 +638,24 @@ class Run:
         relative_path: str | None = None,
         use_run_name: bool = True,
     ):
-        if self._is_local:
-            self._save_upload_locally(file_path, step, relative_path, use_run_name)
-        else:
-            upload_entry: UploadEntry = {
-                "project": self.project,
-                "run": self.name if use_run_name else None,
-                "step": step,
-                "relative_path": relative_path,
-                "uploaded_file": handle_file(file_path),
-            }
-            with self._client_lock:
-                self._queued_uploads.append(upload_entry)
+        try:
+            if self._is_local:
+                self._save_upload_locally(file_path, step, relative_path, use_run_name)
+            else:
+                upload_entry: UploadEntry = {
+                    "project": self.project,
+                    "run": self.name if use_run_name else None,
+                    "step": step,
+                    "relative_path": relative_path,
+                    "uploaded_file": handle_file(file_path),
+                }
+                with self._client_lock:
+                    self._queued_uploads.append(upload_entry)
+        except Exception as e:
+            self._warn_once(
+                "queue-upload",
+                f"trackio could not queue the artifact '{file_path}' for run '{self.name}': {e}. User code will continue, but this artifact could be missing.",
+            )
 
     def _save_upload_locally(
         self,
@@ -575,22 +719,24 @@ class Run:
                 and not self._local_sender_thread.is_alive()
                 and not self._stop_flag.is_set()
             ):
-                self._local_sender_thread = threading.Thread(
-                    target=self._local_batch_sender
+                self._start_background_thread(
+                    "_local_sender_thread",
+                    self._local_batch_sender,
+                    warning_key="local-sender-thread-restart",
+                    description="local Trackio logging thread",
                 )
-                self._local_sender_thread.daemon = True
-                self._local_sender_thread.start()
         else:
             if (
                 self._client_thread is not None
                 and not self._client_thread.is_alive()
                 and not self._stop_flag.is_set()
             ):
-                self._client_thread = threading.Thread(
-                    target=self._init_client_background
+                self._start_background_thread(
+                    "_client_thread",
+                    self._init_client_background,
+                    warning_key="remote-sender-thread-restart",
+                    description="remote Trackio logging thread",
                 )
-                self._client_thread.daemon = True
-                self._client_thread.start()
 
     def log(self, metrics: dict, step: int | None = None):
         try:
@@ -606,7 +752,9 @@ class Run:
                     new_metrics[k] = v
 
             if renamed_keys:
-                warnings.warn(f"Reserved keys renamed: {renamed_keys} → '__{{key}}'")
+                _emit_nonfatal_warning(
+                    f"Reserved keys renamed: {renamed_keys} → '__{{key}}'"
+                )
 
             metrics = new_metrics
             for key, value in metrics.items():
@@ -645,7 +793,7 @@ class Run:
                 self._queued_logs.append(log_entry)
                 self._ensure_sender_alive()
         except Exception as e:
-            warnings.warn(f"trackio.log() failed to process metrics: {e}")
+            _emit_nonfatal_warning(f"trackio.log() failed to process metrics: {e}")
 
     def alert(
         self,
@@ -695,7 +843,7 @@ class Run:
                 )
                 t.start()
         except Exception as e:
-            warnings.warn(f"trackio.alert() failed: {e}")
+            _emit_nonfatal_warning(f"trackio.alert() failed: {e}")
 
     def log_system(self, metrics: dict):
         try:
@@ -714,35 +862,54 @@ class Run:
                 self._queued_system_logs.append(system_log_entry)
                 self._ensure_sender_alive()
         except Exception as e:
-            warnings.warn(f"trackio.log_system() failed: {e}")
+            _emit_nonfatal_warning(f"trackio.log_system() failed: {e}")
 
     def finish(self):
-        if self._gpu_monitor is not None:
-            self._gpu_monitor.stop()
-
-        self._stop_flag.set()
-
-        if self._is_local:
-            if hasattr(self, "_local_sender_thread"):
-                print("* Run finished. Uploading logs to Trackio (please wait...)")
-                self._local_sender_thread.join(timeout=30)
-                if self._local_sender_thread.is_alive():
-                    warnings.warn(
-                        "Could not flush all logs within 30s. Some data may be buffered locally."
+        try:
+            if self._gpu_monitor is not None:
+                try:
+                    self._gpu_monitor.stop()
+                except Exception as e:
+                    self._warn_once(
+                        "finish-gpu-monitor",
+                        f"trackio.finish() could not stop automatic GPU logging cleanly: {e}.",
                     )
-        else:
-            if self._client_thread is not None:
-                print(
-                    "* Run finished. Uploading logs to Trackio Space (please wait...)"
-                )
-                self._client_thread.join(timeout=30)
-                if self._client_thread.is_alive():
-                    warnings.warn(
-                        "Could not flush all logs within 30s. Some data may be buffered locally."
+
+            self._stop_flag.set()
+
+            if self._is_local:
+                if hasattr(self, "_local_sender_thread"):
+                    print("* Run finished. Uploading logs to Trackio (please wait...)")
+                    self._local_sender_thread.join(timeout=30)
+                    if self._local_sender_thread.is_alive():
+                        _emit_nonfatal_warning(
+                            "Could not flush all logs within 30s. Some data may be buffered locally."
+                        )
+            else:
+                if self._client_thread is not None:
+                    print(
+                        "* Run finished. Uploading logs to Trackio Space (please wait...)"
                     )
-            if SQLiteStorage.has_pending_data(self.project):
-                warnings.warn(
-                    f"* Some logs could not be sent to the Space (it may still be starting up). "
-                    f"They have been saved locally and will be sent automatically next time you call: "
-                    f'trackio.init(project="{self.project}", space_id="{self._space_id}")'
-                )
+                    self._client_thread.join(timeout=30)
+                    if self._client_thread.is_alive():
+                        _emit_nonfatal_warning(
+                            "Could not flush all logs within 30s. Some data may be buffered locally."
+                        )
+
+                try:
+                    has_pending = SQLiteStorage.has_pending_data(self.project)
+                except Exception as e:
+                    self._warn_once(
+                        "finish-pending-data",
+                        f"trackio.finish() could not inspect pending buffered logs for project '{self.project}': {e}.",
+                    )
+                    has_pending = False
+
+                if has_pending:
+                    _emit_nonfatal_warning(
+                        f"* Some logs could not be sent to the Space (it may still be starting up). "
+                        f"They have been saved locally and will be sent automatically next time you call: "
+                        f'trackio.init(project="{self.project}", space_id="{self._space_id}")'
+                    )
+        except Exception as e:
+            _emit_nonfatal_warning(f"trackio.finish() failed: {e}")

--- a/trackio/run.py
+++ b/trackio/run.py
@@ -25,7 +25,7 @@ from trackio.media import TrackioMedia, get_project_media_path
 from trackio.sqlite_storage import SQLiteStorage
 from trackio.table import Table
 from trackio.typehints import AlertEntry, LogEntry, SystemLogEntry, UploadEntry
-from trackio.utils import _get_default_namespace
+from trackio.utils import MEDIA_DIR, _get_default_namespace
 
 BATCH_SEND_INTERVAL = 0.5
 MAX_BACKOFF = 30
@@ -88,6 +88,7 @@ class Run:
         self._client_lock = threading.Lock()
         self._warning_lock = threading.Lock()
         self._warned_failures: set[str] = set()
+        self._local_sender_thread: threading.Thread | None = None
         self._client_thread = None
         self._client = client
         self._space_id = space_id
@@ -211,17 +212,61 @@ class Run:
         *,
         warning_key: str,
         description: str,
-    ) -> None:
+    ) -> bool:
         try:
             thread = threading.Thread(target=target, daemon=True)
             setattr(self, attr_name, thread)
             thread.start()
+            return True
         except Exception as e:
             setattr(self, attr_name, None)
             self._warn_once(
                 warning_key,
                 f"trackio failed to start the {description}: {e}. Logging will continue in degraded mode.",
             )
+            return False
+
+    def _thread_is_alive(self, attr_name: str) -> bool:
+        thread = getattr(self, attr_name, None)
+        return isinstance(thread, threading.Thread) and thread.is_alive()
+
+    def _flush_queues_inline(self) -> None:
+        if self._is_local:
+            if self._queued_logs:
+                logs_to_send = self._queued_logs.copy()
+                self._queued_logs.clear()
+                self._write_logs_to_sqlite(logs_to_send)
+
+            if self._queued_system_logs:
+                system_logs_to_send = self._queued_system_logs.copy()
+                self._queued_system_logs.clear()
+                self._write_system_logs_to_sqlite(system_logs_to_send)
+
+            if self._queued_alerts:
+                alerts_to_send = self._queued_alerts.copy()
+                self._queued_alerts.clear()
+                self._write_alerts_to_sqlite(alerts_to_send)
+            return
+
+        if self._queued_logs:
+            logs_to_send = self._queued_logs.copy()
+            self._queued_logs.clear()
+            self._persist_logs_locally(logs_to_send)
+
+        if self._queued_system_logs:
+            system_logs_to_send = self._queued_system_logs.copy()
+            self._queued_system_logs.clear()
+            self._persist_system_logs_locally(system_logs_to_send)
+
+        if self._queued_uploads:
+            uploads_to_send = self._queued_uploads.copy()
+            self._queued_uploads.clear()
+            self._persist_uploads_locally(uploads_to_send)
+
+        if self._queued_alerts:
+            alerts_to_send = self._queued_alerts.copy()
+            self._queued_alerts.clear()
+            self._write_alerts_to_sqlite(alerts_to_send)
 
     def _local_batch_sender(self):
         while (
@@ -649,6 +694,9 @@ class Run:
                 }
                 with self._client_lock:
                     self._queued_uploads.append(upload_entry)
+                    self._ensure_sender_alive()
+                    if not self._thread_is_alive("_client_thread"):
+                        self._flush_queues_inline()
         except Exception as e:
             self._warn_once(
                 "queue-upload",
@@ -692,8 +740,6 @@ class Run:
                 ]:
                     file_path = value.get("file_path")
                     if file_path:
-                        from trackio.utils import MEDIA_DIR
-
                         absolute_path = MEDIA_DIR / file_path
                         self._queue_upload(absolute_path, step)
                 elif isinstance(value, list):
@@ -705,16 +751,13 @@ class Run:
                         ]:
                             file_path = item.get("file_path")
                             if file_path:
-                                from trackio.utils import MEDIA_DIR
-
                                 absolute_path = MEDIA_DIR / file_path
                                 self._queue_upload(absolute_path, step)
 
     def _ensure_sender_alive(self):
         if self._is_local:
             if (
-                hasattr(self, "_local_sender_thread")
-                and not self._local_sender_thread.is_alive()
+                not self._thread_is_alive("_local_sender_thread")
                 and not self._stop_flag.is_set()
             ):
                 self._start_background_thread(
@@ -725,8 +768,7 @@ class Run:
                 )
         else:
             if (
-                self._client_thread is not None
-                and not self._client_thread.is_alive()
+                not self._thread_is_alive("_client_thread")
                 and not self._stop_flag.is_set()
             ):
                 self._start_background_thread(
@@ -790,6 +832,10 @@ class Run:
             with self._client_lock:
                 self._queued_logs.append(log_entry)
                 self._ensure_sender_alive()
+                if not self._thread_is_alive(
+                    "_local_sender_thread" if self._is_local else "_client_thread"
+                ):
+                    self._flush_queues_inline()
         except Exception as e:
             _emit_nonfatal_warning(f"trackio.log() failed to process metrics: {e}")
 
@@ -822,6 +868,10 @@ class Run:
             with self._client_lock:
                 self._queued_alerts.append(alert_entry)
                 self._ensure_sender_alive()
+                if not self._thread_is_alive(
+                    "_local_sender_thread" if self._is_local else "_client_thread"
+                ):
+                    self._flush_queues_inline()
 
             url = webhook_url or self._webhook_url
             if url and should_send_webhook(level, self._webhook_min_level):
@@ -859,6 +909,10 @@ class Run:
             with self._client_lock:
                 self._queued_system_logs.append(system_log_entry)
                 self._ensure_sender_alive()
+                if not self._thread_is_alive(
+                    "_local_sender_thread" if self._is_local else "_client_thread"
+                ):
+                    self._flush_queues_inline()
         except Exception as e:
             _emit_nonfatal_warning(f"trackio.log_system() failed: {e}")
 
@@ -876,13 +930,16 @@ class Run:
             self._stop_flag.set()
 
             if self._is_local:
-                if hasattr(self, "_local_sender_thread"):
+                if self._local_sender_thread is not None:
                     print("* Run finished. Uploading logs to Trackio (please wait...)")
                     self._local_sender_thread.join(timeout=30)
                     if self._local_sender_thread.is_alive():
                         _emit_nonfatal_warning(
                             "Could not flush all logs within 30s. Some data may be buffered locally."
                         )
+                else:
+                    with self._client_lock:
+                        self._flush_queues_inline()
             else:
                 if self._client_thread is not None:
                     print(
@@ -893,6 +950,9 @@ class Run:
                         _emit_nonfatal_warning(
                             "Could not flush all logs within 30s. Some data may be buffered locally."
                         )
+                else:
+                    with self._client_lock:
+                        self._flush_queues_inline()
 
                 try:
                     has_pending = SQLiteStorage.has_pending_data(self.project)

--- a/trackio/run.py
+++ b/trackio/run.py
@@ -593,56 +593,59 @@ class Run:
                 self._client_thread.start()
 
     def log(self, metrics: dict, step: int | None = None):
-        renamed_keys = []
-        new_metrics = {}
+        try:
+            renamed_keys = []
+            new_metrics = {}
 
-        for k, v in metrics.items():
-            if k in utils.RESERVED_KEYS or k.startswith("__"):
-                new_key = f"__{k}"
-                renamed_keys.append(k)
-                new_metrics[new_key] = v
-            else:
-                new_metrics[k] = v
+            for k, v in metrics.items():
+                if k in utils.RESERVED_KEYS or k.startswith("__"):
+                    new_key = f"__{k}"
+                    renamed_keys.append(k)
+                    new_metrics[new_key] = v
+                else:
+                    new_metrics[k] = v
 
-        if renamed_keys:
-            warnings.warn(f"Reserved keys renamed: {renamed_keys} → '__{{key}}'")
+            if renamed_keys:
+                warnings.warn(f"Reserved keys renamed: {renamed_keys} → '__{{key}}'")
 
-        metrics = new_metrics
-        for key, value in metrics.items():
-            if isinstance(value, Table):
-                metrics[key] = value._to_dict(
-                    project=self.project, run=self.name, step=step
-                )
-                self._scan_and_queue_media_uploads(metrics[key], step)
-            elif isinstance(value, Histogram):
-                metrics[key] = value._to_dict()
-            elif isinstance(value, Markdown):
-                metrics[key] = value._to_dict()
-            elif isinstance(value, TrackioMedia):
-                metrics[key] = self._process_media(value, step)
-        metrics = utils.serialize_values(metrics)
+            metrics = new_metrics
+            for key, value in metrics.items():
+                if isinstance(value, Table):
+                    metrics[key] = value._to_dict(
+                        project=self.project, run=self.name, step=step
+                    )
+                    self._scan_and_queue_media_uploads(metrics[key], step)
+                elif isinstance(value, Histogram):
+                    metrics[key] = value._to_dict()
+                elif isinstance(value, Markdown):
+                    metrics[key] = value._to_dict()
+                elif isinstance(value, TrackioMedia):
+                    metrics[key] = self._process_media(value, step)
+            metrics = utils.serialize_values(metrics)
 
-        if step is None:
-            step = self._next_step
-        self._next_step = max(self._next_step, step + 1)
+            if step is None:
+                step = self._next_step
+            self._next_step = max(self._next_step, step + 1)
 
-        config_to_log = None
-        if not self._config_logged and self.config:
-            config_to_log = utils.to_json_safe(self.config)
-            self._config_logged = True
+            config_to_log = None
+            if not self._config_logged and self.config:
+                config_to_log = utils.to_json_safe(self.config)
+                self._config_logged = True
 
-        log_entry: LogEntry = {
-            "project": self.project,
-            "run": self.name,
-            "metrics": metrics,
-            "step": step,
-            "config": config_to_log,
-            "log_id": uuid.uuid4().hex,
-        }
+            log_entry: LogEntry = {
+                "project": self.project,
+                "run": self.name,
+                "metrics": metrics,
+                "step": step,
+                "config": config_to_log,
+                "log_id": uuid.uuid4().hex,
+            }
 
-        with self._client_lock:
-            self._queued_logs.append(log_entry)
-            self._ensure_sender_alive()
+            with self._client_lock:
+                self._queued_logs.append(log_entry)
+                self._ensure_sender_alive()
+        except Exception as e:
+            warnings.warn(f"trackio.log() failed to process metrics: {e}")
 
     def alert(
         self,
@@ -652,60 +655,66 @@ class Run:
         step: int | None = None,
         webhook_url: str | None = None,
     ):
-        if step is None:
-            step = max(self._next_step - 1, 0)
-        timestamp = datetime.now(timezone.utc).isoformat()
+        try:
+            if step is None:
+                step = max(self._next_step - 1, 0)
+            timestamp = datetime.now(timezone.utc).isoformat()
 
-        print(format_alert_terminal(level, title, text, step))
+            print(format_alert_terminal(level, title, text, step))
 
-        alert_entry: AlertEntry = {
-            "project": self.project,
-            "run": self.name,
-            "title": title,
-            "text": text,
-            "level": level.value,
-            "step": step,
-            "timestamp": timestamp,
-            "alert_id": uuid.uuid4().hex,
-        }
+            alert_entry: AlertEntry = {
+                "project": self.project,
+                "run": self.name,
+                "title": title,
+                "text": text,
+                "level": level.value,
+                "step": step,
+                "timestamp": timestamp,
+                "alert_id": uuid.uuid4().hex,
+            }
 
-        with self._client_lock:
-            self._queued_alerts.append(alert_entry)
-            self._ensure_sender_alive()
+            with self._client_lock:
+                self._queued_alerts.append(alert_entry)
+                self._ensure_sender_alive()
 
-        url = webhook_url or self._webhook_url
-        if url and should_send_webhook(level, self._webhook_min_level):
-            t = threading.Thread(
-                target=send_webhook,
-                args=(
-                    url,
-                    level,
-                    title,
-                    text,
-                    self.project,
-                    self.name,
-                    step,
-                    timestamp,
-                ),
-                daemon=True,
-            )
-            t.start()
+            url = webhook_url or self._webhook_url
+            if url and should_send_webhook(level, self._webhook_min_level):
+                t = threading.Thread(
+                    target=send_webhook,
+                    args=(
+                        url,
+                        level,
+                        title,
+                        text,
+                        self.project,
+                        self.name,
+                        step,
+                        timestamp,
+                    ),
+                    daemon=True,
+                )
+                t.start()
+        except Exception as e:
+            warnings.warn(f"trackio.alert() failed: {e}")
 
     def log_system(self, metrics: dict):
-        metrics = utils.serialize_values(metrics)
-        timestamp = datetime.now(timezone.utc).isoformat()
+        try:
+            metrics = utils.serialize_values(metrics)
+            timestamp = datetime.now(timezone.utc).isoformat()
 
-        system_log_entry: SystemLogEntry = {
-            "project": self.project,
-            "run": self.name,
-            "metrics": metrics,
-            "timestamp": timestamp,
-            "log_id": uuid.uuid4().hex,
-        }
+            system_log_entry: SystemLogEntry = {
+                "project": self.project,
+                "run": self.name,
+                "metrics": metrics,
+                "timestamp": timestamp,
+                "log_id": uuid.uuid4().hex,
+            }
 
-        with self._client_lock:
-            self._queued_system_logs.append(system_log_entry)
-            self._ensure_sender_alive()
+            with self._client_lock:
+                self._queued_system_logs.append(system_log_entry)
+                self._ensure_sender_alive()
+        except Exception as e:
+            warnings.warn(f"trackio.log_system() failed: {e}")
 
     def finish(self):
         if self._gpu_monitor is not None:

--- a/trackio/utils.py
+++ b/trackio/utils.py
@@ -23,6 +23,13 @@ RESERVED_KEYS = ["project", "run", "timestamp", "step", "time", "metrics"]
 TRACKIO_LOGO_DIR = Path(__file__).parent / "assets"
 
 
+def _emit_nonfatal_warning(message: str, *args, **kwargs) -> None:
+    try:
+        warnings.warn(message, *args, **kwargs)
+    except Exception:
+        print(f"* Trackio warning: {message}")
+
+
 def get_logo_urls() -> dict[str, str]:
     """Get logo URLs from environment variables or use defaults."""
     light_url = os.environ.get(


### PR DESCRIPTION
- hardens `trackio.init()` against corrupted/malformed sqlite metadata reads and Space/bootstrap metadata failures by falling back to safe defaults instead of raising into the caller
- hardens the local and remote sender threads so sqlite/media/upload failures are converted into nonfatal warnings instead of killing the thread or escaping into user code
- hardens local fallback buffering, artifact queueing, and `finish()` so shutdown/pending-buffer checks also stay nonfatal
- makes degraded-mode warnings nonfatal even when the caller promotes warnings to exceptions
- adds regression tests for corrupt-db init, local flush failure, `finish()` pending-data inspection failure, and `warnings.simplefilter("error")`
