### PR TITLE
Fix SQLite corruption on bucket-mounted Spaces

### DIFF
--- a/.changeset/rare-olives-find.md
+++ b/.changeset/rare-olives-find.md
@@ -1,0 +1,5 @@
+---
+"trackio": minor
+---
+
+feat:Fix SQLite corruption on bucket-mounted Spaces

--- a/.changeset/rare-olives-find.md
+++ b/.changeset/rare-olives-find.md
@@ -1,5 +1,5 @@
 ---
-"trackio": minor
+"trackio": patch
 ---
 
 feat:Fix SQLite corruption on bucket-mounted Spaces

--- a/tests/unit/test_sqlite_storage.py
+++ b/tests/unit/test_sqlite_storage.py
@@ -417,39 +417,3 @@ def test_bucket_upload_paths_match_mount_layout(temp_dir):
             f"outside TRACKIO_DIR={trackio_dir}"
         )
         assert Path(local_path).exists()
-
-
-def test_exclusive_locking_mode(temp_dir, monkeypatch):
-    monkeypatch.setenv("TRACKIO_BUCKET_ID", "user/test-bucket")
-    monkeypatch.setenv("SYSTEM", "spaces")
-    import trackio.sqlite_storage as mod
-
-    assert mod._use_exclusive_locking()
-
-    project = "excl_proj"
-    SQLiteStorage.log(project=project, run="run1", metrics={"loss": 0.5})
-    results = SQLiteStorage.get_logs(project=project, run="run1")
-    assert len(results) == 1
-    assert results[0]["loss"] == 0.5
-
-    SQLiteStorage.bulk_log(
-        project, "run1", [{"loss": 0.4}, {"loss": 0.3}], config={"lr": 0.01}
-    )
-    results = SQLiteStorage.get_logs(project=project, run="run1")
-    assert len(results) == 3
-
-    config = SQLiteStorage.get_run_config(project, "run1")
-    assert config["lr"] == 0.01
-
-    db_path = SQLiteStorage.get_project_db_path(project)
-    key = str(db_path)
-    assert key in mod._persistent_connections
-    conn = mod._persistent_connections[key]
-    locking = conn.execute("PRAGMA locking_mode").fetchone()[0]
-    assert locking.lower() == "exclusive"
-
-    mod._persistent_connections.pop(key, None)
-    try:
-        conn.close()
-    except Exception:
-        pass

--- a/tests/unit/test_sqlite_storage.py
+++ b/tests/unit/test_sqlite_storage.py
@@ -417,3 +417,47 @@ def test_bucket_upload_paths_match_mount_layout(temp_dir):
             f"outside TRACKIO_DIR={trackio_dir}"
         )
         assert Path(local_path).exists()
+
+
+def test_exclusive_locking_mode(temp_dir, monkeypatch):
+    monkeypatch.setenv("TRACKIO_BUCKET_ID", "user/test-bucket")
+    monkeypatch.setenv("SYSTEM", "spaces")
+    import trackio.sqlite_storage as mod
+
+    assert mod._use_exclusive_locking()
+
+    project = "excl_proj"
+    SQLiteStorage.log(project=project, run="run1", metrics={"loss": 0.5})
+    results = SQLiteStorage.get_logs(project=project, run="run1")
+    assert len(results) == 1
+    assert results[0]["loss"] == 0.5
+
+    SQLiteStorage.bulk_log(
+        project, "run1", [{"loss": 0.4}, {"loss": 0.3}], config={"lr": 0.01}
+    )
+    results = SQLiteStorage.get_logs(project=project, run="run1")
+    assert len(results) == 3
+
+    config = SQLiteStorage.get_run_config(project, "run1")
+    assert config["lr"] == 0.01
+
+    db_path = SQLiteStorage.get_project_db_path(project)
+    key = str(db_path)
+    assert key in mod._persistent_connections
+    conn = mod._persistent_connections[key]
+    locking = conn.execute("PRAGMA locking_mode").fetchone()[0]
+    assert locking.lower() == "exclusive"
+
+    mod._persistent_connections.pop(key, None)
+    try:
+        conn.close()
+    except Exception:
+        pass
+
+
+def test_exclusive_locking_not_enabled_by_default(temp_dir, monkeypatch):
+    monkeypatch.delenv("TRACKIO_BUCKET_ID", raising=False)
+    monkeypatch.delenv("SYSTEM", raising=False)
+    import trackio.sqlite_storage as mod
+
+    assert not mod._use_exclusive_locking()

--- a/tests/unit/test_sqlite_storage.py
+++ b/tests/unit/test_sqlite_storage.py
@@ -453,11 +453,3 @@ def test_exclusive_locking_mode(temp_dir, monkeypatch):
         conn.close()
     except Exception:
         pass
-
-
-def test_exclusive_locking_not_enabled_by_default(temp_dir, monkeypatch):
-    monkeypatch.delenv("TRACKIO_BUCKET_ID", raising=False)
-    monkeypatch.delenv("SYSTEM", raising=False)
-    import trackio.sqlite_storage as mod
-
-    assert not mod._use_exclusive_locking()

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -159,24 +159,12 @@ def test_trackio_dir_env_var(monkeypatch):
         test_path = str(tmpdir)
 
         monkeypatch.setenv("TRACKIO_DIR", test_path)
-        monkeypatch.delenv("PERSISTANT_STORAGE_ENABLED", raising=False)
         result_dir = utils._get_trackio_dir()
         assert str(result_dir) == test_path
 
         monkeypatch.delenv("TRACKIO_DIR", raising=False)
-        monkeypatch.delenv("PERSISTANT_STORAGE_ENABLED", raising=False)
         result_dir = utils._get_trackio_dir()
         assert "huggingface/trackio" in Path(result_dir).as_posix()
-
-        monkeypatch.delenv("TRACKIO_DIR", raising=False)
-        monkeypatch.setenv("PERSISTANT_STORAGE_ENABLED", "true")
-        result_dir = utils._get_trackio_dir()
-        assert Path(result_dir).as_posix() == "/data/trackio"
-
-        monkeypatch.setenv("TRACKIO_DIR", test_path)
-        monkeypatch.setenv("PERSISTANT_STORAGE_ENABLED", "true")
-        result_dir = utils._get_trackio_dir()
-        assert Path(result_dir).as_posix() == "/data/trackio"
 
 
 def test_plot_ordering():

--- a/trackio/deploy.py
+++ b/trackio/deploy.py
@@ -35,6 +35,7 @@ from trackio.sqlite_storage import SQLiteStorage
 from trackio.utils import (
     MEDIA_DIR,
     get_or_create_project_hash,
+    on_spaces,
     preprocess_space_and_dataset_ids,
 )
 
@@ -157,9 +158,7 @@ def deploy_as_space(
     bucket_id: str | None = None,
     private: bool | None = None,
 ):
-    if (
-        os.getenv("SYSTEM") == "spaces"
-    ):  # in case a repo with this function is uploaded to spaces
+    if on_spaces():  # in case a repo with this function is uploaded to spaces
         return
 
     if dataset_id is not None and bucket_id is not None:
@@ -674,7 +673,7 @@ def deploy_as_static_space(
     private: bool | None = None,
     hf_token: str | None = None,
 ) -> None:
-    if os.getenv("SYSTEM") == "spaces":
+    if on_spaces():
         return
 
     hf_api = huggingface_hub.HfApi()

--- a/trackio/server.py
+++ b/trackio/server.py
@@ -24,6 +24,7 @@ import trackio.utils as utils
 from trackio.media import get_project_media_path
 from trackio.sqlite_storage import SQLiteStorage
 from trackio.typehints import AlertEntry, LogEntry, SystemLogEntry, UploadEntry
+from trackio.utils import on_spaces
 
 HfApi = hf.HfApi()
 
@@ -207,28 +208,28 @@ def oauth_hf_callback(request: Request):
         return RedirectResponse(url=err, status_code=302)
     session_id = secrets.token_urlsafe(32)
     _oauth_sessions[session_id] = (access_token, time.monotonic())
-    on_spaces = os.getenv("SYSTEM") == "spaces"
+    _on_spaces = on_spaces()
     resp = RedirectResponse(url=f"/?oauth_session={session_id}", status_code=302)
     resp.set_cookie(
         key="trackio_hf_access_token",
         value=access_token,
         httponly=True,
-        samesite="none" if on_spaces else "lax",
+        samesite="none" if _on_spaces else "lax",
         max_age=86400 * 30,
         path="/",
-        secure=on_spaces,
+        secure=_on_spaces,
     )
     return resp
 
 
 def oauth_logout(request: Request):
-    on_spaces = os.getenv("SYSTEM") == "spaces"
+    _on_spaces = on_spaces()
     resp = RedirectResponse(url="/", status_code=302)
     resp.delete_cookie(
         "trackio_hf_access_token",
         path="/",
-        samesite="none" if on_spaces else "lax",
-        secure=on_spaces,
+        samesite="none" if _on_spaces else "lax",
+        secure=_on_spaces,
     )
     return resp
 
@@ -243,7 +244,7 @@ def check_hf_token_has_write_access(hf_token: str | None) -> None:
     - A cache of the whoami response for the hf_token using .whoami(token=hf_token, cache=True).
     - This entire function is cached using @lru_cache(maxsize=32).
     """
-    if os.getenv("SYSTEM") == "spaces":
+    if on_spaces():
         if hf_token is None:
             raise PermissionError(
                 "Expected a HF_TOKEN to be provided when logging to a Space"
@@ -297,7 +298,7 @@ _OAUTH_WRITE_CACHE_TTL = 300
 
 
 def check_oauth_token_has_write_access(oauth_token: str | None) -> None:
-    if not os.getenv("SYSTEM") == "spaces":
+    if not on_spaces():
         return
     if oauth_token is None:
         raise PermissionError(
@@ -343,7 +344,7 @@ def check_write_access(request: gr.Request, token: str) -> bool:
 
 
 def assert_can_mutate_runs(request: gr.Request) -> None:
-    if os.getenv("SYSTEM") != "spaces":
+    if not on_spaces():
         if check_write_access(request, write_token):
             return
         raise gr.Error(
@@ -366,7 +367,7 @@ def assert_can_mutate_runs(request: gr.Request) -> None:
 
 
 def get_run_mutation_status(request: gr.Request) -> dict[str, Any]:
-    if os.getenv("SYSTEM") != "spaces":
+    if not on_spaces():
         if check_write_access(request, write_token):
             return {"spaces": False, "allowed": True, "auth": "local"}
         return {"spaces": False, "allowed": False, "auth": "none"}

--- a/trackio/sqlite_storage.py
+++ b/trackio/sqlite_storage.py
@@ -1,3 +1,4 @@
+import atexit
 import json as json_mod
 import os
 import shutil
@@ -86,10 +87,10 @@ def _get_or_create_persistent_conn(
             try:
                 conn.execute("SELECT 1")
                 return conn
-            except Exception:
+            except sqlite3.Error:
                 try:
                     conn.close()
-                except Exception:
+                except sqlite3.Error:
                     pass
                 _persistent_connections.pop(key, None)
         conn = sqlite3.connect(str(db_path), timeout=timeout, check_same_thread=False)
@@ -99,9 +100,25 @@ def _get_or_create_persistent_conn(
         return conn
 
 
+def _close_all_persistent_connections() -> None:
+    with _persistent_lock:
+        for conn in _persistent_connections.values():
+            try:
+                conn.close()
+            except sqlite3.Error:
+                pass
+        _persistent_connections.clear()
+
+
+atexit.register(_close_all_persistent_connections)
+
+
 class ProcessLock:
-    """Cross-process/thread lock. Uses file-based locking normally, or an in-memory
-    threading Lock when on a bucket-mounted filesystem where file locks are unreliable."""
+    """Lock used to coordinate database access.
+
+    Normally uses file-based locking for cross-process coordination. When running
+    on a bucket-mounted filesystem where file locks are unreliable,
+    falls back to an in-memory threading Lock (single-process only)."""
 
     _thread_locks: dict[str, Lock] = {}
     _meta_lock = Lock()
@@ -170,6 +187,10 @@ class SQLiteStorage:
         row_factory=sqlite3.Row,
     ) -> Iterator[sqlite3.Connection]:
         if _use_exclusive_locking():
+            # In exclusive mode all callers share a single persistent connection
+            # that is pragma-configured at creation time. The `configure_pragmas`
+            # flag is intentionally ignored here — the pragmas (journal mode,
+            # synchronous, locking mode) don't affect query semantics.
             access_lock = _get_db_access_lock(db_path)
             access_lock.acquire()
             try:

--- a/trackio/sqlite_storage.py
+++ b/trackio/sqlite_storage.py
@@ -40,6 +40,13 @@ _JOURNAL_MODE_WHITELIST = frozenset(
 )
 
 
+def _use_exclusive_locking() -> bool:
+    return (
+        bool(os.environ.get("TRACKIO_BUCKET_ID"))
+        and os.environ.get("SYSTEM") == "spaces"
+    )
+
+
 def _configure_sqlite_pragmas(conn: sqlite3.Connection) -> None:
     override = os.environ.get("TRACKIO_SQLITE_JOURNAL_MODE", "").strip().lower()
     if override in _JOURNAL_MODE_WHITELIST:
@@ -52,16 +59,59 @@ def _configure_sqlite_pragmas(conn: sqlite3.Connection) -> None:
     conn.execute("PRAGMA synchronous = NORMAL")
     conn.execute("PRAGMA temp_store = MEMORY")
     conn.execute("PRAGMA cache_size = -20000")
+    if _use_exclusive_locking():
+        conn.execute("PRAGMA locking_mode = EXCLUSIVE")
+
+
+_persistent_connections: dict[str, sqlite3.Connection] = {}
+_persistent_lock = Lock()
+
+
+def _get_or_create_persistent_conn(
+    db_path: Path, timeout: float = 30.0
+) -> sqlite3.Connection:
+    key = str(db_path)
+    with _persistent_lock:
+        conn = _persistent_connections.get(key)
+        if conn is not None:
+            try:
+                conn.execute("SELECT 1")
+                return conn
+            except Exception:
+                try:
+                    conn.close()
+                except Exception:
+                    pass
+                _persistent_connections.pop(key, None)
+        conn = sqlite3.connect(str(db_path), timeout=timeout)
+        _configure_sqlite_pragmas(conn)
+        conn.execute("SELECT 1")
+        _persistent_connections[key] = conn
+        return conn
 
 
 class ProcessLock:
-    """A file-based lock that works across processes using fcntl (Unix) or msvcrt (Windows)."""
+    """Cross-process/thread lock. Uses file-based locking normally, or an in-memory
+    threading Lock when on a bucket-mounted filesystem where file locks are unreliable."""
+
+    _thread_locks: dict[str, Lock] = {}
+    _meta_lock = Lock()
 
     def __init__(self, lockfile_path: Path):
         self.lockfile_path = lockfile_path
         self.lockfile = None
+        self._use_thread_lock = _use_exclusive_locking()
+        if self._use_thread_lock:
+            key = str(lockfile_path)
+            with ProcessLock._meta_lock:
+                if key not in ProcessLock._thread_locks:
+                    ProcessLock._thread_locks[key] = Lock()
+                self._thread_lock = ProcessLock._thread_locks[key]
 
     def __enter__(self):
+        if self._use_thread_lock:
+            self._thread_lock.acquire()
+            return self
         if fcntl is None and _msvcrt is None:
             return self
         self.lockfile_path.parent.mkdir(parents=True, exist_ok=True)
@@ -82,6 +132,9 @@ class ProcessLock:
                     raise IOError("Could not acquire database lock after 10 seconds")
 
     def __exit__(self, exc_type, exc_val, exc_tb):
+        if self._use_thread_lock:
+            self._thread_lock.release()
+            return
         if self.lockfile:
             try:
                 if fcntl is not None:
@@ -107,16 +160,23 @@ class SQLiteStorage:
         configure_pragmas: bool = True,
         row_factory=sqlite3.Row,
     ) -> Iterator[sqlite3.Connection]:
-        conn = sqlite3.connect(str(db_path), timeout=timeout)
-        try:
-            if configure_pragmas:
-                _configure_sqlite_pragmas(conn)
+        if _use_exclusive_locking() and configure_pragmas:
+            conn = _get_or_create_persistent_conn(db_path, timeout=timeout)
             if row_factory is not None:
                 conn.row_factory = row_factory
             with conn:
                 yield conn
-        finally:
-            conn.close()
+        else:
+            conn = sqlite3.connect(str(db_path), timeout=timeout)
+            try:
+                if configure_pragmas:
+                    _configure_sqlite_pragmas(conn)
+                if row_factory is not None:
+                    conn.row_factory = row_factory
+                with conn:
+                    yield conn
+            finally:
+                conn.close()
 
     @staticmethod
     def _get_process_lock(project: str) -> ProcessLock:

--- a/trackio/sqlite_storage.py
+++ b/trackio/sqlite_storage.py
@@ -65,6 +65,15 @@ def _configure_sqlite_pragmas(conn: sqlite3.Connection) -> None:
 
 _persistent_connections: dict[str, sqlite3.Connection] = {}
 _persistent_lock = Lock()
+_db_access_locks: dict[str, Lock] = {}
+
+
+def _get_db_access_lock(db_path: Path) -> Lock:
+    key = str(db_path)
+    with _persistent_lock:
+        if key not in _db_access_locks:
+            _db_access_locks[key] = Lock()
+        return _db_access_locks[key]
 
 
 def _get_or_create_persistent_conn(
@@ -83,7 +92,7 @@ def _get_or_create_persistent_conn(
                 except Exception:
                     pass
                 _persistent_connections.pop(key, None)
-        conn = sqlite3.connect(str(db_path), timeout=timeout)
+        conn = sqlite3.connect(str(db_path), timeout=timeout, check_same_thread=False)
         _configure_sqlite_pragmas(conn)
         conn.execute("SELECT 1")
         _persistent_connections[key] = conn
@@ -160,12 +169,16 @@ class SQLiteStorage:
         configure_pragmas: bool = True,
         row_factory=sqlite3.Row,
     ) -> Iterator[sqlite3.Connection]:
-        if _use_exclusive_locking() and configure_pragmas:
-            conn = _get_or_create_persistent_conn(db_path, timeout=timeout)
-            if row_factory is not None:
+        if _use_exclusive_locking():
+            access_lock = _get_db_access_lock(db_path)
+            access_lock.acquire()
+            try:
+                conn = _get_or_create_persistent_conn(db_path, timeout=timeout)
                 conn.row_factory = row_factory
-            with conn:
-                yield conn
+                with conn:
+                    yield conn
+            finally:
+                access_lock.release()
         else:
             conn = sqlite3.connect(str(db_path), timeout=timeout)
             try:

--- a/trackio/sqlite_storage.py
+++ b/trackio/sqlite_storage.py
@@ -42,10 +42,6 @@ _JOURNAL_MODE_WHITELIST = frozenset(
 )
 
 
-def _use_exclusive_locking() -> bool:
-    return on_spaces()
-
-
 def _configure_sqlite_pragmas(conn: sqlite3.Connection) -> None:
     override = os.environ.get("TRACKIO_SQLITE_JOURNAL_MODE", "").strip().lower()
     if override in _JOURNAL_MODE_WHITELIST:
@@ -58,7 +54,7 @@ def _configure_sqlite_pragmas(conn: sqlite3.Connection) -> None:
     conn.execute("PRAGMA synchronous = NORMAL")
     conn.execute("PRAGMA temp_store = MEMORY")
     conn.execute("PRAGMA cache_size = -20000")
-    if _use_exclusive_locking():
+    if on_spaces():
         conn.execute("PRAGMA locking_mode = EXCLUSIVE")
 
 
@@ -124,7 +120,7 @@ class ProcessLock:
     def __init__(self, lockfile_path: Path):
         self.lockfile_path = lockfile_path
         self.lockfile = None
-        self._use_thread_lock = _use_exclusive_locking()
+        self._use_thread_lock = on_spaces()
         if self._use_thread_lock:
             key = str(lockfile_path)
             with ProcessLock._meta_lock:
@@ -184,8 +180,8 @@ class SQLiteStorage:
         configure_pragmas: bool = True,
         row_factory=sqlite3.Row,
     ) -> Iterator[sqlite3.Connection]:
-        if _use_exclusive_locking():
-            # In exclusive mode all callers share a single persistent connection
+        if on_spaces():
+            # On Spaces, all callers share a single persistent connection
             # that is pragma-configured at creation time. The `configure_pragmas`
             # flag is intentionally ignored here — the pragmas (journal mode,
             # synchronous, locking mode) don't affect query semantics.

--- a/trackio/sqlite_storage.py
+++ b/trackio/sqlite_storage.py
@@ -42,10 +42,7 @@ _JOURNAL_MODE_WHITELIST = frozenset(
 
 
 def _use_exclusive_locking() -> bool:
-    return (
-        bool(os.environ.get("TRACKIO_BUCKET_ID"))
-        and os.environ.get("SYSTEM") == "spaces"
-    )
+    return os.environ.get("SYSTEM") == "spaces"
 
 
 def _configure_sqlite_pragmas(conn: sqlite3.Connection) -> None:

--- a/trackio/sqlite_storage.py
+++ b/trackio/sqlite_storage.py
@@ -31,6 +31,7 @@ from trackio.utils import (
     TRACKIO_DIR,
     deserialize_values,
     get_color_palette,
+    on_spaces,
     serialize_values,
 )
 
@@ -42,14 +43,14 @@ _JOURNAL_MODE_WHITELIST = frozenset(
 
 
 def _use_exclusive_locking() -> bool:
-    return os.environ.get("SYSTEM") == "spaces"
+    return on_spaces()
 
 
 def _configure_sqlite_pragmas(conn: sqlite3.Connection) -> None:
     override = os.environ.get("TRACKIO_SQLITE_JOURNAL_MODE", "").strip().lower()
     if override in _JOURNAL_MODE_WHITELIST:
         journal = override.upper()
-    elif os.environ.get("SYSTEM") == "spaces":
+    elif on_spaces():
         journal = "DELETE"
     else:
         journal = "WAL"

--- a/trackio/utils.py
+++ b/trackio/utils.py
@@ -130,15 +130,11 @@ def order_metrics_by_plot_preference(metrics: list[str]) -> tuple[list[str], dic
     return ordered_groups, result
 
 
-def persistent_storage_enabled() -> bool:
-    return (
-        os.environ.get("PERSISTANT_STORAGE_ENABLED") == "true"
-    )  # typo in the name of the environment variable
+def on_spaces() -> bool:
+    return os.environ.get("SYSTEM") == "spaces"
 
 
 def _get_trackio_dir() -> Path:
-    if persistent_storage_enabled():
-        return Path("/data/trackio")
     if os.environ.get("TRACKIO_DIR"):
         return Path(os.environ.get("TRACKIO_DIR"))
     return Path(HF_HOME) / "trackio"


### PR DESCRIPTION
- When Trackio runs on an HF Space with a bucket mount (`hf-mount`), the FUSE filesystem doesn't support file locking. SQLite depends on `fcntl`/`flock` for internal consistency, so even a single process can see corruption when locks are silently no-ops.
- Detects bucket-mount environment (`TRACKIO_BUCKET_ID` + `SYSTEM=spaces`) and switches to a **single persistent connection** with `PRAGMA locking_mode=EXCLUSIVE`. SQLite grabs the lock once and never releases it — with only one connection open, there's no contention and no reliance on filesystem locking.
- Also switches `ProcessLock` to use in-memory `threading.Lock` instead of file-based locking in the same environment.

This is a much simpler alternative to the [Parquet storage backend approach](https://github.com/gradio-app/trackio/pull/500) (~110 lines changed vs ~3500) proposed by Claude Code and reviewed by myself to solve the same root cause.

cc @Wauplin @XciD for visibility