### PR TITLE
Add docs on SQL & Parquet schema / format, as well as a new CLI command: `trackio query --sql SQL_QUERY`

### DIFF
--- a/.agents/skills/trackio/SKILL.md
+++ b/.agents/skills/trackio/SKILL.md
@@ -14,6 +14,7 @@ Trackio is an experiment tracking library for logging and visualizing ML trainin
 | **Logging metrics** during training | Python API | [logging_metrics.md](logging_metrics.md) |
 | **Firing alerts** for training diagnostics | Python API | [alerts.md](alerts.md) |
 | **Retrieving metrics & alerts** after/during training | CLI | [retrieving_metrics.md](retrieving_metrics.md) |
+| **Inspecting storage schema and running direct SQL** | CLI | [storage_schema.md](storage_schema.md) |
 
 ## When to Use Each
 
@@ -47,15 +48,17 @@ Use the `trackio` command to query logged metrics and alerts:
 
 - `trackio list projects/runs/metrics` — discover what's available
 - `trackio get project/run/metric` — retrieve summaries and values
+- `trackio query project --project <name> --sql "SELECT ..."` — run catch-all read-only SQL
 - `trackio list alerts --project <name> --json` — retrieve alerts
 - `trackio show` — launch the dashboard
 - `trackio sync` — sync to HF Space
 
 **Key concept**: Add `--json` for programmatic output suitable for automation and LLM agents.
 
-**Remote Spaces**: Add `--space <space_id_or_url>` to any `list`/`get` command to query a remote HF Space instead of local data. Use `--hf-token` for private Spaces.
+**Remote Spaces**: Add `--space <space_id_or_url>` to any `list`/`get`/`query` command to query a remote HF Space instead of local data. Use `--hf-token` for private Spaces.
 
 → See [retrieving_metrics.md](retrieving_metrics.md) for all commands, workflows, and JSON output formats.
+→ See [storage_schema.md](storage_schema.md) for SQLite tables, parquet layout, and direct query examples.
 
 ## Minimal Logging Setup
 
@@ -73,6 +76,7 @@ trackio.finish()
 ```bash
 trackio list projects --json
 trackio get metric --project my-project --run my-run --metric loss --json
+trackio query project --project my-project --sql "SELECT name FROM sqlite_master WHERE type = 'table'" --json
 
 # Query a remote Space
 trackio list projects --space username/my-space --json

--- a/.agents/skills/trackio/retrieving_metrics.md
+++ b/.agents/skills/trackio/retrieving_metrics.md
@@ -18,6 +18,7 @@ The `trackio` CLI provides direct terminal access to query Trackio experiment tr
 | Get metric around step | `trackio get metric ... --metric <name> --around <N> --window <W>` |
 | Get all metrics snapshot | `trackio get snapshot --project <name> --run <name> --step <N>` |
 | Get system metrics | `trackio get system-metric --project <name> --run <name>` |
+| Run direct SQL | `trackio query project --project <name> --sql "SELECT ..."` |
 | Query remote Space | `trackio list projects --space <space_id_or_url>` |
 | Show dashboard | `trackio show [--project <name>]` |
 | Sync to Space | `trackio sync --project <name> --space-id <space_id>` |
@@ -69,14 +70,23 @@ trackio get system-metric --project <name> --run <name> --metric <name>  # Speci
 trackio get system-metric --project <name> --run <name> --json
 ```
 
+### Query Command
+
+```bash
+trackio query project --project <name> --sql "SELECT name FROM sqlite_master WHERE type = 'table'"
+trackio query project --project <name> --sql "PRAGMA table_info(metrics)" --json
+trackio query project --project <name> --sql "SELECT run_name, MAX(step) AS last_step FROM metrics GROUP BY run_name"
+```
+
 ### Remote Space Queries
 
-All `list` and `get` commands support querying a remote HF Space with `--space`:
+All `list`, `get`, and `query` commands support querying a remote HF Space with `--space`:
 
 ```bash
 trackio list projects --space user/my-space              # Space ID
 trackio list projects --space https://user-my-space.hf.space  # Space URL
 trackio get metric --project <name> --run <name> --metric loss --space user/my-space
+trackio query project --project <name> --sql "SELECT COUNT(*) AS num_alerts FROM alerts" --space user/my-space
 trackio list projects --space user/private-space --hf-token hf_xxx  # Private Space
 ```
 
@@ -100,7 +110,7 @@ trackio sync --project <name> --space-id <space_id> --force   # Overwrite
 
 ## Output Formats
 
-All `list` and `get` commands support two output formats:
+All `list`, `get`, and `query` commands support two output formats:
 
 - **Human-readable** (default): Formatted text for terminal viewing
 - **JSON** (with `--json` flag): Structured JSON for programmatic use
@@ -157,6 +167,9 @@ trackio get run --project my-project --run my-run --json > run_summary.json
 
 # Filter runs with jq
 trackio list runs --project my-project --json | jq '.runs[] | select(startswith("train"))'
+
+# Run a direct SQL aggregate
+trackio query project --project my-project --sql "SELECT run_name, MAX(step) AS last_step FROM metrics GROUP BY run_name" --json
 ```
 
 ### LLM Agent Workflow
@@ -179,6 +192,9 @@ trackio list alerts --project my-project --json --since "2025-06-01T00:00:00"
 
 # 6. When an alert fires at step N, get all metrics around that point
 trackio get snapshot --project my-project --run my-run --around 200 --window 5 --json
+
+# 7. Fall back to direct SQL for one-off inspection
+trackio query project --project my-project --sql "SELECT timestamp, run_name, level, title FROM alerts ORDER BY timestamp DESC LIMIT 20" --json
 ```
 
 ## Error Handling
@@ -196,9 +212,10 @@ All errors exit with non-zero status code and write to stderr.
 - `--project`: Project name (required for most commands)
 - `--run`: Run name (required for run-specific commands)
 - `--metric`: Metric name (required for metric-specific commands)
+- `--sql`: Read-only SQL query (for `trackio query`)
 - `--json`: Output in JSON format instead of human-readable
-- `--space`: HF Space ID (e.g. `user/space`) or Space URL to query remotely (for `list`/`get` commands)
-- `--hf-token`: HF token for accessing private Spaces (for `list`/`get` commands with `--space`)
+- `--space`: HF Space ID (e.g. `user/space`) or Space URL to query remotely (for `list`/`get`/`query` commands)
+- `--hf-token`: HF token for accessing private Spaces (for `list`/`get`/`query` commands with `--space`)
 - `--step`: Exact step filter (for `get metric`, `get snapshot`)
 - `--around`: Center step for window filter (for `get metric`, `get snapshot`)
 - `--at-time`: Center ISO timestamp for window filter (for `get metric`, `get snapshot`)
@@ -258,8 +275,24 @@ All errors exit with non-zero status code and write to stderr.
 }
 ```
 
+### Query Result
+```json
+{
+  "project": "my-project",
+  "query": "SELECT name FROM sqlite_master WHERE type = 'table' ORDER BY name",
+  "columns": ["name"],
+  "rows": [
+    {"name": "alerts"},
+    {"name": "configs"},
+    {"name": "metrics"}
+  ],
+  "row_count": 3
+}
+```
+
 ## References
 
 - **Complete CLI documentation**: See [docs/source/cli_commands.md](docs/source/cli_commands.md)
+- **Storage schema and direct SQL**: See [storage_schema.md](storage_schema.md)
 - **API and MCP Server**: See [docs/source/api_mcp_server.md](docs/source/api_mcp_server.md)
 

--- a/.agents/skills/trackio/storage_schema.md
+++ b/.agents/skills/trackio/storage_schema.md
@@ -1,0 +1,159 @@
+# Trackio Storage Schema and Direct SQL
+
+Use this reference when you need to inspect Trackio data directly instead of going through higher-level `trackio list` or `trackio get` commands.
+
+## Where Data Is Stored
+
+- Local project databases live in `TRACKIO_DIR`, which defaults to `~/.cache/huggingface/trackio`.
+- Each project is stored in its own SQLite file: `{project}.db`.
+- Media files live under `TRACKIO_DIR/media/`.
+- Parquet files are derived exports written from SQLite for syncing and static Spaces.
+
+## SQLite Tables
+
+Trackio defines its live schema in `trackio/sqlite_storage.py` inside `SQLiteStorage.init_db()`.
+
+### `metrics`
+
+- `id`: integer primary key
+- `timestamp`: ISO timestamp
+- `run_name`: run identifier
+- `step`: integer step
+- `metrics`: JSON text payload
+- `log_id`: optional deduplication key
+- `space_id`: optional pending-sync marker
+
+Indexes:
+
+- `(run_name, step)`
+- `(run_name, timestamp)`
+- unique partial index on `log_id`
+- partial index on `space_id`
+
+### `configs`
+
+- `id`: integer primary key
+- `run_name`: run identifier
+- `config`: JSON text payload
+- `created_at`: ISO timestamp
+
+Constraints:
+
+- unique `run_name`
+- index on `run_name`
+
+### `system_metrics`
+
+- `id`: integer primary key
+- `timestamp`: ISO timestamp
+- `run_name`: run identifier
+- `metrics`: JSON text payload
+- `log_id`: optional deduplication key
+- `space_id`: optional pending-sync marker
+
+Indexes:
+
+- `(run_name, timestamp)`
+- unique partial index on `log_id`
+- partial index on `space_id`
+
+### `project_metadata`
+
+- `key`: primary key
+- `value`: metadata value
+
+### `pending_uploads`
+
+- `id`
+- `space_id`
+- `run_name`
+- `step`
+- `file_path`
+- `relative_path`
+- `created_at`
+
+### `alerts`
+
+- `id`
+- `timestamp`
+- `run_name`
+- `title`
+- `text`
+- `level`
+- `step`
+- `alert_id`
+
+Indexes:
+
+- `run_name`
+- `timestamp`
+- unique partial index on `alert_id`
+
+## Parquet Layout
+
+Trackio flattens JSON blobs when exporting parquet:
+
+- `{project}.parquet` comes from `metrics`
+- `{project}_system.parquet` comes from `system_metrics`
+- `{project}_configs.parquet` comes from `configs`
+
+Static export layout:
+
+- `metrics.parquet`
+- `aux/system_metrics.parquet`
+- `aux/configs.parquet`
+- `runs.json`
+- `settings.json`
+
+The flattened parquet files keep structural columns such as `timestamp`, `run_name`, and `step`, then add one column per JSON key found in the source payload.
+
+## Direct SQL With The CLI
+
+Use `trackio query` for read-only SQL:
+
+```bash
+trackio query project --project my-project --sql "SELECT name FROM sqlite_master WHERE type = 'table' ORDER BY name" --json
+trackio query project --project my-project --sql "PRAGMA table_info(metrics)"
+trackio query project --project my-project --sql "SELECT run_name, MAX(step) AS last_step FROM metrics GROUP BY run_name ORDER BY last_step DESC"
+```
+
+Remote query works too:
+
+```bash
+trackio query project --project my-project --sql "SELECT COUNT(*) AS num_alerts FROM alerts" --space username/my-space --json
+```
+
+`trackio query` accepts read-only `SELECT`, `WITH`, and safe schema `PRAGMA` queries.
+
+## Common Query Patterns
+
+Recent alerts:
+
+```bash
+trackio query project --project my-project --sql "SELECT timestamp, run_name, level, title, step FROM alerts ORDER BY timestamp DESC LIMIT 20"
+```
+
+Latest step per run:
+
+```bash
+trackio query project --project my-project --sql "SELECT run_name, MAX(step) AS last_step FROM metrics GROUP BY run_name ORDER BY last_step DESC"
+```
+
+Recent configs:
+
+```bash
+trackio query project --project my-project --sql "SELECT run_name, created_at, config FROM configs ORDER BY created_at DESC"
+```
+
+Schema inspection:
+
+```bash
+trackio query project --project my-project --sql "PRAGMA index_list(metrics)"
+```
+
+## Agent Guidance
+
+- Start with `trackio list projects --json` if you do not know the project name yet.
+- Use `trackio get` for common summaries and metric retrieval.
+- Fall back to `trackio query` when you need one-off aggregates, joins, or schema introspection.
+- Prefer `--json` when another agent or script needs to consume the result.

--- a/.changeset/cyan-forks-hang.md
+++ b/.changeset/cyan-forks-hang.md
@@ -1,0 +1,5 @@
+---
+"trackio": minor
+---
+
+feat:Add docs on SQL & Parquet schema / format, as well as a new CLI command: `trackio query --sql SQL_QUERY`

--- a/.changeset/cyan-forks-hang.md
+++ b/.changeset/cyan-forks-hang.md
@@ -2,4 +2,4 @@
 "trackio": minor
 ---
 
-feat:Add docs on SQL & Parquet schema / format, as well as a new CLI command: `trackio query --sql SQL_QUERY`
+feat:Add docs on SQL & Parquet schema / format, as well as a new CLI command: `trackio query project --project PROJECT --sql SQL_QUERY`

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ Trackio's main features:
   - Persists logs in a Sqlite database locally (or, if you provide a `space_id`, in a private Hugging Face Dataset)
   - Visualize experiments with a **Svelte 5** dashboard locally (or, if you provide a `space_id`, on Hugging Face Spaces)
 - **LLM-friendly**: Built with autonomous ML experiments in mind, Trackio includes a CLI for programmatic access and a Python API for run management, making it easy for LLMs to log metrics and query experiment data.
+  - Use `trackio query project --project <name> --sql "SELECT ..."` for read-only SQL when `trackio list` and `trackio get` are not enough
+  - See the storage schema and direct query reference at https://huggingface.co/docs/trackio/storage_schema
 
 - **Free**: Everything here, including hosting on Hugging Face, is free!
 
@@ -265,6 +267,8 @@ These numbers were measured against a free-tier Hugging Face Space (2 vCPU / 16 
 ## Note: Trackio is in Beta (DB Schema May Change)
 
 Note that Trackio is in pre-release right now and we may release breaking changes. In particular, the schema of the Trackio sqlite database may change, which may require migrating or deleting existing database files (located by default at: `~/.cache/huggingface/trackio`).  
+
+The current SQLite and parquet layout is documented in the [Storage Schema and Direct Queries](https://huggingface.co/docs/trackio/storage_schema) guide, including examples for `trackio query`.
 
 Since Trackio is in beta, your feedback is welcome! Please create issues with bug reports or feature requests.
 

--- a/docs/source/_toctree.yml
+++ b/docs/source/_toctree.yml
@@ -21,6 +21,8 @@
     title: Python API for Managing Runs
   - local: cli_commands
     title: CLI Commands
+  - local: storage_schema
+    title: Storage Schema and Direct Queries
   - local: api_mcp_server
     title: API and MCP Server
   - local: alerts

--- a/docs/source/cli_commands.md
+++ b/docs/source/cli_commands.md
@@ -4,7 +4,7 @@ Trackio provides a comprehensive set of CLI commands that enable you to query pr
 
 ## Querying Remote Spaces
 
-All `list` and `get` commands support querying a remote Hugging Face Space instead of local data. Pass the `--space` flag with either a Space ID or full URL:
+All `list`, `get`, and `query` commands support querying a remote Hugging Face Space instead of local data. Pass the `--space` flag with either a Space ID or full URL:
 
 ```sh
 # Using a Space ID
@@ -13,7 +13,7 @@ trackio list projects --space username/my-space
 # Using a Space URL
 trackio list projects --space https://username-my-space.hf.space
 
-# Works with any list/get command
+# Works with any list/get/query command
 trackio get metric --project "my-project" --run "my-run" --metric "loss" --space username/my-space
 ```
 
@@ -315,9 +315,56 @@ Output in JSON format:
 trackio get report --project "my-project" --run "my-run" --report "training_report" --json
 ```
 
+## Query Command
+
+Use `trackio query` when you need a catch-all read-only SQL query that is not already covered by `trackio list` or `trackio get`.
+
+### Run a Query Against a Project Database
+
+```sh
+trackio query project --project "my-project" --sql "SELECT run_name, MAX(step) AS last_step FROM metrics GROUP BY run_name ORDER BY last_step DESC"
+```
+
+Output in JSON format:
+
+```sh
+trackio query project --project "my-project" --sql "SELECT name FROM sqlite_master WHERE type = 'table' ORDER BY name" --json
+```
+
+Query a remote Space:
+
+```sh
+trackio query project --project "my-project" --sql "SELECT COUNT(*) AS num_alerts FROM alerts" --space username/my-space --json
+```
+
+`trackio query` only supports read-only `SELECT`, `WITH`, and safe schema `PRAGMA` queries.
+
+Common schema inspection examples:
+
+```sh
+# Inspect table columns
+trackio query project --project "my-project" --sql "PRAGMA table_info(metrics)"
+
+# Inspect indexes
+trackio query project --project "my-project" --sql "PRAGMA index_list(alerts)"
+
+# List tables
+trackio query project --project "my-project" --sql "SELECT name FROM sqlite_master WHERE type = 'table' ORDER BY name"
+```
+
+The response includes:
+
+- `project`
+- `query`
+- `columns`
+- `rows`
+- `row_count`
+
+For the full SQLite and parquet layout, see the [Storage Schema and Direct Queries](./storage_schema).
+
 ## Output Formats
 
-All commands support two output formats:
+All `list`, `get`, and `query` commands support two output formats:
 
 1. **Human-readable** (default): Formatted text output suitable for terminal viewing
 2. **JSON** (with `--json` flag): Structured JSON output suitable for programmatic consumption
@@ -330,6 +377,7 @@ The CLI commands include comprehensive validation and error handling:
 - If a run doesn't exist in a project, an error message is displayed
 - If a metric doesn't exist in a run, an error message is displayed
 - If a report doesn't exist in a run, an error message is displayed
+- If a query is not read-only, the CLI exits with an error
 
 All errors are written to stderr and the command exits with a non-zero exit code.
 
@@ -367,6 +415,9 @@ trackio list reports --project "my-project" --run "my-run"
 
 # 10. Print report markdown in terminal
 trackio get report --project "my-project" --run "my-run" --report "training_report"
+
+# 11. Run a direct SQL query
+trackio query project --project "my-project" --sql "SELECT run_name, MAX(step) AS last_step FROM metrics GROUP BY run_name"
 ```
 
 ### Querying a Remote Space
@@ -389,6 +440,7 @@ These CLI commands are particularly useful for LLM agents that need to:
 - Discover available projects and runs
 - Query metric values programmatically
 - Inspect metrics around an alert with `get snapshot` or `get metric --around`
+- Run direct SQL for cases not covered by the structured commands
 - Get summaries without starting a server
 - Parse structured JSON output for further processing
 

--- a/docs/source/storage_schema.md
+++ b/docs/source/storage_schema.md
@@ -1,0 +1,199 @@
+# Storage Schema and Direct Queries
+
+Trackio stores each project in its own SQLite database and can export that data to parquet for syncing, static Spaces, and direct analysis. This page documents the live SQLite schema, the derived parquet layout, and the new `trackio query` command for running read-only SQL.
+
+## Where Data Lives
+
+- Local project databases live in `TRACKIO_DIR`, which defaults to `~/.cache/huggingface/trackio`.
+- Each project is stored as a separate SQLite file: `{project}.db`.
+- Media and uploaded files live under `TRACKIO_DIR/media/`.
+- When syncing to Hugging Face, Trackio exports parquet files from the SQLite database before upload.
+
+## Querying Data Directly
+
+Use the CLI when you need a catch-all query that is not already covered by `trackio list` or `trackio get`:
+
+```sh
+trackio query project --project "my-project" --sql "SELECT run_name, MAX(step) AS last_step FROM metrics GROUP BY run_name ORDER BY last_step DESC"
+```
+
+Add `--json` for machine-readable output:
+
+```sh
+trackio query project --project "my-project" --sql "SELECT name FROM sqlite_master WHERE type = 'table' ORDER BY name" --json
+```
+
+The same command works against a remote Space:
+
+```sh
+trackio query project --project "my-project" --sql "SELECT COUNT(*) AS num_alerts FROM alerts" --space username/my-space --json
+```
+
+`trackio query` only accepts read-only `SELECT`, `WITH`, and safe schema `PRAGMA` queries.
+
+## SQLite Schema
+
+The live schema is defined in `trackio/sqlite_storage.py` by `SQLiteStorage.init_db()`.
+
+### `metrics`
+
+| Column | Type | Notes |
+|--------|------|-------|
+| `id` | `INTEGER` | Primary key |
+| `timestamp` | `TEXT` | ISO timestamp |
+| `run_name` | `TEXT` | Run identifier |
+| `step` | `INTEGER` | Training step |
+| `metrics` | `TEXT` | JSON blob containing logged metric values |
+| `log_id` | `TEXT` | Optional deduplication key added by additive migration |
+| `space_id` | `TEXT` | Optional pending-sync marker added by additive migration |
+
+Indexes:
+
+- `idx_metrics_run_step` on `(run_name, step)`
+- `idx_metrics_run_timestamp` on `(run_name, timestamp)`
+- `idx_metrics_log_id` unique partial index on `log_id`
+- `idx_metrics_pending` partial index on `space_id`
+
+### `configs`
+
+| Column | Type | Notes |
+|--------|------|-------|
+| `id` | `INTEGER` | Primary key |
+| `run_name` | `TEXT` | Run identifier |
+| `config` | `TEXT` | JSON blob containing run config |
+| `created_at` | `TEXT` | ISO timestamp |
+
+Indexes and constraints:
+
+- `UNIQUE(run_name)`
+- `idx_configs_run_name` on `(run_name)`
+
+### `system_metrics`
+
+| Column | Type | Notes |
+|--------|------|-------|
+| `id` | `INTEGER` | Primary key |
+| `timestamp` | `TEXT` | ISO timestamp |
+| `run_name` | `TEXT` | Run identifier |
+| `metrics` | `TEXT` | JSON blob containing system metrics |
+| `log_id` | `TEXT` | Optional deduplication key added by additive migration |
+| `space_id` | `TEXT` | Optional pending-sync marker added by additive migration |
+
+Indexes:
+
+- `idx_system_metrics_run_timestamp` on `(run_name, timestamp)`
+- `idx_system_metrics_log_id` unique partial index on `log_id`
+- `idx_system_metrics_pending` partial index on `space_id`
+
+### `project_metadata`
+
+| Column | Type | Notes |
+|--------|------|-------|
+| `key` | `TEXT` | Primary key |
+| `value` | `TEXT` | Metadata value |
+
+### `pending_uploads`
+
+| Column | Type | Notes |
+|--------|------|-------|
+| `id` | `INTEGER` | Primary key |
+| `space_id` | `TEXT` | Destination Space |
+| `run_name` | `TEXT` | Optional run name |
+| `step` | `INTEGER` | Optional step |
+| `file_path` | `TEXT` | Absolute local path |
+| `relative_path` | `TEXT` | Relative media path |
+| `created_at` | `TEXT` | ISO timestamp |
+
+### `alerts`
+
+| Column | Type | Notes |
+|--------|------|-------|
+| `id` | `INTEGER` | Primary key |
+| `timestamp` | `TEXT` | ISO timestamp |
+| `run_name` | `TEXT` | Run identifier |
+| `title` | `TEXT` | Alert title |
+| `text` | `TEXT` | Optional alert body |
+| `level` | `TEXT` | `info`, `warn`, or `error` |
+| `step` | `INTEGER` | Optional training step |
+| `alert_id` | `TEXT` | Optional deduplication key |
+
+Indexes:
+
+- `idx_alerts_run` on `(run_name)`
+- `idx_alerts_timestamp` on `(timestamp)`
+- `idx_alerts_alert_id` unique partial index on `alert_id`
+
+## How Metric Payloads Are Stored
+
+- User metrics are stored as JSON text in `metrics.metrics`.
+- System metrics are stored as JSON text in `system_metrics.metrics`.
+- Run configuration is stored as JSON text in `configs.config`.
+- Trackio's higher-level APIs deserialize these JSON blobs before returning them.
+
+Common direct-query pattern:
+
+```sh
+trackio query project --project "my-project" --sql "SELECT timestamp, step, metrics FROM metrics WHERE run_name = 'run-1' ORDER BY step DESC LIMIT 5"
+```
+
+Schema introspection example:
+
+```sh
+trackio query project --project "my-project" --sql "PRAGMA table_info(metrics)"
+```
+
+## Parquet Layout
+
+Trackio derives parquet files from SQLite by flattening JSON columns into regular columns.
+
+### Local parquet exports
+
+`SQLiteStorage.export_to_parquet()` writes:
+
+- `{project}.parquet` from `metrics`
+- `{project}_system.parquet` from `system_metrics`
+- `{project}_configs.parquet` from `configs`
+
+The flattened parquet files keep the structural columns such as `timestamp`, `run_name`, and `step`, then add one column per key found in the JSON payload.
+
+### Static Space and dataset exports
+
+`SQLiteStorage.export_for_static_space()` writes:
+
+- `metrics.parquet`
+- `aux/system_metrics.parquet`
+- `aux/configs.parquet`
+- `runs.json`
+- `settings.json`
+
+This is the layout used for static Spaces and exported datasets.
+
+## Useful Query Examples
+
+List tables:
+
+```sh
+trackio query project --project "my-project" --sql "SELECT name FROM sqlite_master WHERE type = 'table' ORDER BY name"
+```
+
+Find the latest step for each run:
+
+```sh
+trackio query project --project "my-project" --sql "SELECT run_name, MAX(step) AS last_step FROM metrics GROUP BY run_name ORDER BY last_step DESC"
+```
+
+Inspect recent alerts:
+
+```sh
+trackio query project --project "my-project" --sql "SELECT timestamp, run_name, level, title, step FROM alerts ORDER BY timestamp DESC LIMIT 20"
+```
+
+Inspect stored configs:
+
+```sh
+trackio query project --project "my-project" --sql "SELECT run_name, created_at, config FROM configs ORDER BY created_at DESC"
+```
+
+## Stability Notes
+
+Trackio is still in beta. The schema is documented here so humans and agents can query it directly, but future releases may evolve the schema and require migrations or regenerated local databases.

--- a/tests/unit/test_sqlite_storage.py
+++ b/tests/unit/test_sqlite_storage.py
@@ -417,3 +417,54 @@ def test_bucket_upload_paths_match_mount_layout(temp_dir):
             f"outside TRACKIO_DIR={trackio_dir}"
         )
         assert Path(local_path).exists()
+
+
+def test_query_project_allows_select(temp_dir):
+    SQLiteStorage.log(project="qproj", run="r1", metrics={"acc": 0.9})
+    result = SQLiteStorage.query_project("qproj", "SELECT run_name FROM metrics")
+    assert result["project"] == "qproj"
+    assert result["columns"] == ["run_name"]
+    assert result["row_count"] == 1
+    assert result["rows"][0]["run_name"] == "r1"
+
+
+def test_query_project_allows_with_and_safe_pragma(temp_dir):
+    SQLiteStorage.log(project="qproj", run="r1", metrics={"acc": 0.9})
+    cte = SQLiteStorage.query_project(
+        "qproj", "WITH t AS (SELECT 1 AS x) SELECT x FROM t"
+    )
+    assert cte["rows"] == [{"x": 1}]
+    pragma = SQLiteStorage.query_project("qproj", "PRAGMA table_info(metrics)")
+    assert pragma["row_count"] > 0
+
+
+def test_query_project_denies_writes(temp_dir):
+    SQLiteStorage.log(project="qproj", run="r1", metrics={"acc": 0.9})
+    for bad in [
+        "INSERT INTO metrics (project_name, run_name, step, metrics, timestamp) VALUES ('x','y',0,'{}','t')",
+        "UPDATE metrics SET run_name='x'",
+        "DELETE FROM metrics",
+        "DROP TABLE metrics",
+        "PRAGMA journal_mode = DELETE",
+    ]:
+        with pytest.raises(ValueError):
+            SQLiteStorage.query_project("qproj", bad)
+
+
+def test_query_project_row_limit(temp_dir):
+    for i in range(5):
+        SQLiteStorage.log(project="qproj", run=f"r{i}", metrics={"a": i})
+    with pytest.raises(ValueError, match="more than"):
+        SQLiteStorage.query_project("qproj", "SELECT * FROM metrics", max_rows=2)
+
+
+def test_query_project_normalizes_bytes(temp_dir):
+    SQLiteStorage.log(project="qproj", run="r1", metrics={"a": 1})
+    result = SQLiteStorage.query_project("qproj", "SELECT randomblob(4) AS b")
+    assert isinstance(result["rows"][0]["b"], str)
+    assert len(result["rows"][0]["b"]) == 8
+
+
+def test_query_project_missing_project(temp_dir):
+    with pytest.raises(FileNotFoundError):
+        SQLiteStorage.query_project("nonexistent", "SELECT 1")

--- a/trackio/cli.py
+++ b/trackio/cli.py
@@ -9,6 +9,7 @@ from trackio.cli_helpers import (
     format_list,
     format_metric_values,
     format_project_summary,
+    format_query_result,
     format_run_summary,
     format_snapshot,
     format_system_metric_names,
@@ -128,6 +129,24 @@ def _extract_reports(
                         }
                     )
     return reports
+
+
+def _handle_query(args):
+    remote = _get_remote(args)
+    try:
+        if remote:
+            result = remote.predict(args.project, args.sql, api_name="/query_project")
+        else:
+            result = SQLiteStorage.query_project(args.project, args.sql)
+    except FileNotFoundError as e:
+        error_exit(str(e))
+    except ValueError as e:
+        error_exit(str(e))
+
+    if args.json:
+        print(format_json(result))
+    else:
+        print(format_query_result(result))
 
 
 def main():
@@ -581,6 +600,31 @@ def main():
         help="Report metric name",
     )
     get_report_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output in JSON format",
+    )
+
+    query_parser = subparsers.add_parser(
+        "query",
+        help="Run a read-only SQL query against a project database",
+    )
+    query_subparsers = query_parser.add_subparsers(dest="query_type", required=True)
+    query_project_parser = query_subparsers.add_parser(
+        "project",
+        help="Run a read-only SQL query against a project's SQLite database",
+    )
+    query_project_parser.add_argument(
+        "--project",
+        required=True,
+        help="Project name",
+    )
+    query_project_parser.add_argument(
+        "--sql",
+        required=True,
+        help="Read-only SQL query to execute",
+    )
+    query_project_parser.add_argument(
         "--json",
         action="store_true",
         help="Output in JSON format",
@@ -1152,6 +1196,9 @@ def main():
                     if idx < len(reports):
                         output.append("-" * 80)
                 print("\n".join(output))
+    elif args.command == "query":
+        if args.query_type == "project":
+            _handle_query(args)
     elif args.command == "skills":
         if args.skills_action == "add":
             _handle_skills_add(args)
@@ -1184,6 +1231,7 @@ def _handle_skills_add(args):
         "alerts.md",
         "logging_metrics.md",
         "retrieving_metrics.md",
+        "storage_schema.md",
     ]
 
     if not (args.cursor or args.claude or args.codex or args.opencode or args.dest):

--- a/trackio/cli_helpers.py
+++ b/trackio/cli_helpers.py
@@ -152,6 +152,52 @@ def format_alerts(alerts: list[dict]) -> str:
     return "\n".join(output)
 
 
+def format_query_result(result: dict[str, Any]) -> str:
+    """Format SQL query results in human-readable format."""
+    columns = result.get("columns", [])
+    rows = result.get("rows", [])
+    row_count = result.get("row_count", 0)
+
+    if not columns:
+        return f"Query returned {row_count} row(s)."
+
+    rendered_rows = []
+    for row in rows:
+        rendered_rows.append(
+            [
+                "" if row.get(column) is None else str(row.get(column))
+                for column in columns
+            ]
+        )
+
+    widths = []
+    for idx, column in enumerate(columns):
+        cell_width = max(
+            (len(rendered_row[idx]) for rendered_row in rendered_rows), default=0
+        )
+        widths.append(max(len(column), cell_width))
+
+    header = " | ".join(
+        column.ljust(width) for column, width in zip(columns, widths, strict=False)
+    )
+    separator = "-+-".join("-" * width for width in widths)
+    output = [f"Query returned {row_count} row(s).", header, separator]
+
+    if not rendered_rows:
+        output.append("(no rows)")
+        return "\n".join(output)
+
+    for rendered_row in rendered_rows:
+        output.append(
+            " | ".join(
+                value.ljust(width)
+                for value, width in zip(rendered_row, widths, strict=False)
+            )
+        )
+
+    return "\n".join(output)
+
+
 def error_exit(message: str, code: int = 1) -> None:
     """Print error message and exit."""
     print(f"Error: {message}", file=sys.stderr)

--- a/trackio/server.py
+++ b/trackio/server.py
@@ -645,6 +645,10 @@ def get_logs(project: str, run: str) -> list[dict]:
     return SQLiteStorage.get_logs(project, run, max_points=1500)
 
 
+def query_project(project: str, query: str) -> dict[str, Any]:
+    return SQLiteStorage.query_project(project, query)
+
+
 def get_settings() -> dict:
     return {
         "logo_urls": utils.get_logo_urls(),
@@ -735,6 +739,7 @@ def make_trackio_server() -> TrackioServer:
     server.api(fn=get_system_logs, name="get_system_logs")
     server.api(fn=get_snapshot, name="get_snapshot")
     server.api(fn=get_logs, name="get_logs")
+    server.api(fn=query_project, name="query_project")
     server.api(fn=get_settings, name="get_settings")
     server.api(fn=get_project_files, name="get_project_files")
     server.api(fn=delete_run, name="delete_run")

--- a/trackio/sqlite_storage.py
+++ b/trackio/sqlite_storage.py
@@ -41,6 +41,7 @@ _JOURNAL_MODE_WHITELIST = frozenset(
     {"wal", "delete", "truncate", "persist", "memory", "off"}
 )
 _READ_ONLY_QUERY_PREFIXES = ("select", "with", "pragma")
+_QUERY_MAX_ROWS = 10_000
 _READ_ONLY_PRAGMAS = frozenset(
     {"table_info", "table_xinfo", "index_list", "index_info", "index_xinfo"}
 )
@@ -1304,7 +1305,15 @@ class SQLiteStorage:
         return sqlite3.SQLITE_DENY
 
     @staticmethod
-    def query_project(project: str, query: str) -> dict[str, Any]:
+    def _normalize_query_value(value: Any) -> Any:
+        if isinstance(value, (bytes, bytearray, memoryview)):
+            return bytes(value).hex()
+        return value
+
+    @staticmethod
+    def query_project(
+        project: str, query: str, max_rows: int = _QUERY_MAX_ROWS
+    ) -> dict[str, Any]:
         SQLiteStorage._ensure_hub_loaded()
         db_path = SQLiteStorage.get_project_db_path(project)
         if not db_path.exists():
@@ -1318,9 +1327,19 @@ class SQLiteStorage:
                 cursor.execute(normalized_query)
                 description = cursor.description or []
                 columns = [column[0] for column in description]
-                rows = []
-                for row in cursor.fetchall():
-                    rows.append({column: row[column] for column in columns})
+                fetched = cursor.fetchmany(max_rows + 1)
+                if len(fetched) > max_rows:
+                    raise ValueError(
+                        f"Query returned more than {max_rows} rows. "
+                        "Refine the query or add a LIMIT clause."
+                    )
+                rows = [
+                    {
+                        column: SQLiteStorage._normalize_query_value(row[column])
+                        for column in columns
+                    }
+                    for row in fetched
+                ]
             except sqlite3.DatabaseError as e:
                 raise ValueError(str(e)) from e
             finally:

--- a/trackio/sqlite_storage.py
+++ b/trackio/sqlite_storage.py
@@ -9,6 +9,7 @@ from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
 from threading import Lock
+from typing import Any
 
 try:
     import fcntl
@@ -39,6 +40,10 @@ DB_EXT = ".db"
 
 _JOURNAL_MODE_WHITELIST = frozenset(
     {"wal", "delete", "truncate", "persist", "memory", "off"}
+)
+_READ_ONLY_QUERY_PREFIXES = ("select", "with", "pragma")
+_READ_ONLY_PRAGMAS = frozenset(
+    {"table_info", "table_xinfo", "index_list", "index_info", "index_xinfo"}
 )
 
 
@@ -1177,6 +1182,70 @@ class SQLiteStorage:
             if "no such table: metrics" in str(e):
                 return []
             raise
+
+    @staticmethod
+    def _validate_read_only_query(query: str) -> str:
+        normalized = query.strip().rstrip(";").strip()
+        if not normalized:
+            raise ValueError("Query cannot be empty.")
+        if not normalized.lower().startswith(_READ_ONLY_QUERY_PREFIXES):
+            raise ValueError(
+                "Only read-only SELECT, WITH, and safe PRAGMA queries are supported."
+            )
+        return normalized
+
+    @staticmethod
+    def _query_authorizer(
+        action_code: int,
+        arg1: str | None,
+        arg2: str | None,
+        db_name: str | None,
+        source: str | None,
+    ) -> int:
+        del arg2, db_name, source
+        if action_code in {
+            sqlite3.SQLITE_SELECT,
+            sqlite3.SQLITE_READ,
+            sqlite3.SQLITE_FUNCTION,
+        }:
+            return sqlite3.SQLITE_OK
+        pragma_code = getattr(sqlite3, "SQLITE_PRAGMA", None)
+        if action_code == pragma_code:
+            pragma_name = (arg1 or "").lower()
+            if pragma_name in _READ_ONLY_PRAGMAS:
+                return sqlite3.SQLITE_OK
+        return sqlite3.SQLITE_DENY
+
+    @staticmethod
+    def query_project(project: str, query: str) -> dict[str, Any]:
+        SQLiteStorage._ensure_hub_loaded()
+        db_path = SQLiteStorage.get_project_db_path(project)
+        if not db_path.exists():
+            raise FileNotFoundError(f"Project '{project}' not found.")
+
+        normalized_query = SQLiteStorage._validate_read_only_query(query)
+        with SQLiteStorage._get_connection(db_path) as conn:
+            conn.set_authorizer(SQLiteStorage._query_authorizer)
+            try:
+                cursor = conn.cursor()
+                cursor.execute(normalized_query)
+                description = cursor.description or []
+                columns = [column[0] for column in description]
+                rows = []
+                for row in cursor.fetchall():
+                    rows.append({column: row[column] for column in columns})
+            except sqlite3.DatabaseError as e:
+                raise ValueError(str(e)) from e
+            finally:
+                conn.set_authorizer(None)
+
+        return {
+            "project": project,
+            "query": normalized_query,
+            "columns": columns,
+            "rows": rows,
+            "row_count": len(rows),
+        }
 
     @staticmethod
     def get_max_steps_for_runs(project: str) -> dict[str, int]:


### PR DESCRIPTION
Adds a new trackio query project command so users and agents can run read-only SQL against Trackio project data locally or via --space. Also documents the SQLite/parquet storage schema and direct-query workflow across docs, README, and Trackio skill references for easier data inspection and automation.