### PR TITLE
Scope bucket sync to trackio/ subtree to avoid walking the HF cache

### DIFF
--- a/.changeset/few-bars-find.md
+++ b/.changeset/few-bars-find.md
@@ -1,0 +1,5 @@
+---
+"trackio": minor
+---
+
+feat:Scope bucket sync to trackio/ subtree to avoid walking the HF cache

--- a/.changeset/few-bars-find.md
+++ b/.changeset/few-bars-find.md
@@ -1,5 +1,5 @@
 ---
-"trackio": minor
+"trackio": patch
 ---
 
 feat:Scope bucket sync to trackio/ subtree to avoid walking the HF cache

--- a/tests/unit/test_deploy.py
+++ b/tests/unit/test_deploy.py
@@ -4,11 +4,7 @@ from unittest.mock import patch
 from huggingface_hub import Volume
 
 from trackio import deploy
-from trackio.bucket_storage import (
-    _list_bucket_file_paths,
-    download_bucket_to_trackio_dir,
-)
-from trackio.utils import TRACKIO_DIR
+from trackio.bucket_storage import _list_bucket_file_paths
 
 
 def test_get_source_install_dependencies_includes_mcp():
@@ -61,15 +57,4 @@ def test_list_bucket_file_paths_uses_list_bucket_tree(mock_list_bucket_tree):
         "abidlabs/example-bucket",
         prefix="trackio/media/proj/",
         recursive=True,
-    )
-
-
-@patch("trackio.bucket_storage.sync_bucket")
-def test_download_bucket_to_trackio_dir_scopes_walk_to_trackio_dir(mock_sync_bucket):
-    download_bucket_to_trackio_dir("abidlabs/example-bucket")
-
-    mock_sync_bucket.assert_called_once_with(
-        source="hf://buckets/abidlabs/example-bucket/trackio",
-        dest=str(TRACKIO_DIR),
-        quiet=True,
     )

--- a/tests/unit/test_deploy.py
+++ b/tests/unit/test_deploy.py
@@ -4,7 +4,11 @@ from unittest.mock import patch
 from huggingface_hub import Volume
 
 from trackio import deploy
-from trackio.bucket_storage import _list_bucket_file_paths
+from trackio.bucket_storage import (
+    _list_bucket_file_paths,
+    download_bucket_to_trackio_dir,
+)
+from trackio.utils import TRACKIO_DIR
 
 
 def test_get_source_install_dependencies_includes_mcp():
@@ -57,4 +61,15 @@ def test_list_bucket_file_paths_uses_list_bucket_tree(mock_list_bucket_tree):
         "abidlabs/example-bucket",
         prefix="trackio/media/proj/",
         recursive=True,
+    )
+
+
+@patch("trackio.bucket_storage.sync_bucket")
+def test_download_bucket_to_trackio_dir_scopes_walk_to_trackio_dir(mock_sync_bucket):
+    download_bucket_to_trackio_dir("abidlabs/example-bucket")
+
+    mock_sync_bucket.assert_called_once_with(
+        source="hf://buckets/abidlabs/example-bucket/trackio",
+        dest=str(TRACKIO_DIR),
+        quiet=True,
     )

--- a/trackio/__init__.py
+++ b/trackio/__init__.py
@@ -97,7 +97,9 @@ def _cleanup_current_run():
             pass
 
 
-def _safe_get_runs_for_init(project: str, space_id: str | None, resume: str) -> list[str]:
+def _safe_get_runs_for_init(
+    project: str, space_id: str | None, resume: str
+) -> list[str]:
     if space_id is not None:
         if resume == "never":
             return []

--- a/trackio/__init__.py
+++ b/trackio/__init__.py
@@ -97,7 +97,23 @@ def _cleanup_current_run():
             pass
 
 
-def _safe_get_runs_for_init(project: str) -> list[str]:
+def _safe_get_runs_for_init(project: str, space_id: str | None, resume: str) -> list[str]:
+    if space_id is not None:
+        if resume == "never":
+            return []
+        try:
+            client = RemoteClient(
+                space_id,
+                hf_token=huggingface_hub.utils.get_token(),
+                verbose=False,
+            )
+            runs = client.predict(project=project, api_name="/get_runs_for_project")
+            return runs if isinstance(runs, list) else []
+        except Exception as e:
+            _emit_nonfatal_warning(
+                f"trackio.init() could not inspect existing runs for project '{project}' on Space '{space_id}': {e}. Continuing without resume metadata."
+            )
+            return []
     try:
         return SQLiteStorage.get_runs(project)
     except Exception as e:
@@ -105,6 +121,38 @@ def _safe_get_runs_for_init(project: str) -> list[str]:
             f"trackio.init() could not inspect existing runs for project '{project}': {e}. Continuing without resume metadata."
         )
         return []
+
+
+def _safe_get_last_step_for_init(
+    project: str, run_name: str, space_id: str | None, resumed: bool
+) -> int | None:
+    if not resumed:
+        return None
+    if space_id is not None:
+        try:
+            client = RemoteClient(
+                space_id,
+                hf_token=huggingface_hub.utils.get_token(),
+                verbose=False,
+            )
+            summary = client.predict(
+                project=project, run=run_name, api_name="/get_run_summary"
+            )
+            if isinstance(summary, dict):
+                last_step = summary.get("last_step")
+                return last_step if isinstance(last_step, int) else None
+        except Exception as e:
+            _emit_nonfatal_warning(
+                f"trackio.init() could not recover the previous step for run '{run_name}' on Space '{space_id}': {e}. Continuing from step 0."
+            )
+            return None
+    try:
+        return SQLiteStorage.get_max_step_for_run(project, run_name)
+    except Exception as e:
+        _emit_nonfatal_warning(
+            f"trackio.init() could not recover the previous step for run '{run_name}': {e}. Continuing from step 0."
+        )
+        return None
 
 
 def init(
@@ -288,7 +336,7 @@ def init(
                 )
     context_vars.current_project.set(project)
 
-    existing_runs = _safe_get_runs_for_init(project)
+    existing_runs = _safe_get_runs_for_init(project, space_id, resume)
 
     if resume == "must":
         if name is None:
@@ -309,6 +357,12 @@ def init(
         resumed = False
     else:
         raise ValueError("resume must be one of: 'must', 'allow', or 'never'")
+
+    initial_last_step = (
+        _safe_get_last_step_for_init(project, name, space_id, resumed)
+        if name is not None
+        else None
+    )
 
     if auto_log_gpu is None:
         nvidia_available = gpu_available()
@@ -332,6 +386,8 @@ def init(
         group=group,
         config=config,
         space_id=space_id,
+        existing_runs=existing_runs,
+        initial_last_step=initial_last_step,
         auto_log_gpu=auto_log_gpu,
         gpu_log_interval=gpu_log_interval,
         webhook_url=webhook_url,

--- a/trackio/__init__.py
+++ b/trackio/__init__.py
@@ -98,13 +98,17 @@ def _cleanup_current_run():
 
 
 def _safe_get_runs_for_init(
-    project: str, space_id: str | None, resume: str
+    project: str,
+    space_id: str | None,
+    resume: str,
+    remote_client: RemoteClient | None = None,
+    check_existing_for_never: bool = False,
 ) -> list[str]:
     if space_id is not None:
-        if resume == "never":
+        if resume == "never" and not check_existing_for_never:
             return []
         try:
-            client = RemoteClient(
+            client = remote_client or RemoteClient(
                 space_id,
                 hf_token=huggingface_hub.utils.get_token(),
                 verbose=False,
@@ -126,13 +130,17 @@ def _safe_get_runs_for_init(
 
 
 def _safe_get_last_step_for_init(
-    project: str, run_name: str, space_id: str | None, resumed: bool
+    project: str,
+    run_name: str,
+    space_id: str | None,
+    resumed: bool,
+    remote_client: RemoteClient | None = None,
 ) -> int | None:
     if not resumed:
         return None
     if space_id is not None:
         try:
-            client = RemoteClient(
+            client = remote_client or RemoteClient(
                 space_id,
                 hf_token=huggingface_hub.utils.get_token(),
                 verbose=False,
@@ -143,6 +151,7 @@ def _safe_get_last_step_for_init(
             if isinstance(summary, dict):
                 last_step = summary.get("last_step")
                 return last_step if isinstance(last_step, int) else None
+            return None
         except Exception as e:
             _emit_nonfatal_warning(
                 f"trackio.init() could not recover the previous step for run '{run_name}' on Space '{space_id}': {e}. Continuing from step 0."
@@ -338,7 +347,26 @@ def init(
                 )
     context_vars.current_project.set(project)
 
-    existing_runs = _safe_get_runs_for_init(project, space_id, resume)
+    remote_client = None
+    if space_id is not None:
+        try:
+            remote_client = RemoteClient(
+                space_id,
+                hf_token=huggingface_hub.utils.get_token(),
+                verbose=False,
+            )
+        except Exception as e:
+            _emit_nonfatal_warning(
+                f"trackio.init() could not create a Space client for '{space_id}': {e}. Continuing with local fallback metadata lookups."
+            )
+
+    existing_runs = _safe_get_runs_for_init(
+        project,
+        space_id,
+        resume,
+        remote_client=remote_client,
+        check_existing_for_never=name is not None,
+    )
 
     if resume == "must":
         if name is None:
@@ -361,7 +389,13 @@ def init(
         raise ValueError("resume must be one of: 'must', 'allow', or 'never'")
 
     initial_last_step = (
-        _safe_get_last_step_for_init(project, name, space_id, resumed)
+        _safe_get_last_step_for_init(
+            project,
+            name,
+            space_id,
+            resumed,
+            remote_client=remote_client,
+        )
         if name is not None
         else None
     )

--- a/trackio/bucket_storage.py
+++ b/trackio/bucket_storage.py
@@ -25,8 +25,8 @@ def _list_bucket_file_paths(bucket_id: str, prefix: str | None = None) -> list[s
 def download_bucket_to_trackio_dir(bucket_id: str) -> None:
     TRACKIO_DIR.mkdir(parents=True, exist_ok=True)
     sync_bucket(
-        source=f"hf://buckets/{bucket_id}",
-        dest=str(TRACKIO_DIR.parent),
+        source=f"hf://buckets/{bucket_id}/trackio",
+        dest=str(TRACKIO_DIR),
         quiet=True,
     )
 

--- a/trackio/run.py
+++ b/trackio/run.py
@@ -42,6 +42,8 @@ class Run:
         group: str | None = None,
         config: dict | None = None,
         space_id: str | None = None,
+        existing_runs: list[str] | None = None,
+        initial_last_step: int | None = None,
         auto_log_gpu: bool = False,
         gpu_log_interval: float = 10.0,
         webhook_url: str | None = None,
@@ -65,6 +67,9 @@ class Run:
                 Keys starting with '_' are reserved for internal use.
             space_id: The HF Space ID if logging to a Space (e.g., "user/space").
                 If provided, media files will be uploaded to the Space.
+            existing_runs: Optional pre-fetched run names for this project. Used to
+                avoid redundant storage or remote lookups during init.
+            initial_last_step: Optional pre-fetched last step for a resumed run.
             auto_log_gpu: Whether to automatically log GPU metrics (utilization,
                 memory, temperature) at regular intervals.
             gpu_log_interval: The interval in seconds between GPU metric logs.
@@ -86,6 +91,8 @@ class Run:
         self._client_thread = None
         self._client = client
         self._space_id = space_id
+        self._existing_runs = existing_runs
+        self._initial_last_step = initial_last_step
         if name is not None:
             self.name = name
         else:
@@ -180,6 +187,8 @@ class Run:
         _emit_nonfatal_warning(message)
 
     def _safe_get_existing_runs(self) -> list[str]:
+        if self._existing_runs is not None:
+            return self._existing_runs
         try:
             return SQLiteStorage.get_runs(self.project)
         except Exception as e:
@@ -190,6 +199,8 @@ class Run:
             return []
 
     def _safe_get_max_step_for_run(self) -> int | None:
+        if self._initial_last_step is not None:
+            return self._initial_last_step
         try:
             return SQLiteStorage.get_max_step_for_run(self.project, self.name)
         except Exception as e:


### PR DESCRIPTION
## Summary

This PR fixes the long `trackio.init(..., space_id=..., bucket_id=...)` stall before the first `log()` call.

It does two things:

- scopes bucket syncs to `hf://buckets/<bucket_id>/trackio -> TRACKIO_DIR` instead of walking the full Hugging Face cache directory
- changes Space-backed resume checks to use the Space API instead of local SQLite/bucket hydration

That means:

- `resume="never"` skips run lookup entirely for Space-backed runs
- `resume in {"allow", "must"}` fetches run names from `/get_runs_for_project`
- resumed Space runs fetch `last_step` from `/get_run_summary` so step numbering continues correctly

## Why

The original hang came from `sync_bucket(...)` computing a sync plan against a very large local HF cache. On machines with lots of downloaded models, walking `~/.cache/huggingface/` can take minutes even for a tiny Trackio bucket.

Separately, `trackio.init()` was checking resume state through local SQLite, which triggered bucket hydration on Space-backed runs even though the run metadata already exists on the Space.

## Test plan

- [x] `PYTHONPATH=. pytest -q tests/unit/test_run.py`
- [x] `python -m compileall trackio/__init__.py trackio/run.py tests/unit/test_run.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes `trackio.init()` resume behavior for Space-backed runs and alters bucket hydration paths, which could affect run resumption/step continuity and local cache expectations if the Space APIs or bucket layout differ.
> 
> **Overview**
> Fixes long stalls when initializing with `space_id`+`bucket_id` by syncing only `hf://buckets/<bucket_id>/trackio` directly into `TRACKIO_DIR` (instead of walking the broader cache/parent directory).
> 
> For Space-backed runs, `trackio.init()` now avoids local SQLite/bucket hydration for resume checks: it skips run lookup entirely for `resume="never"`, fetches existing run names via `/get_runs_for_project`, and (when resuming) restores step continuity by fetching `last_step` via `/get_run_summary` and passing pre-fetched resume metadata into `Run` to avoid redundant lookups.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c360da50b6d8911c0b161b1cc0df0b1495813d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->