### PR TITLE
Fix static Space e2e repo id suffix generation

### DIFF
--- a/tests/e2e-spaces/test_sync_and_freeze.py
+++ b/tests/e2e-spaces/test_sync_and_freeze.py
@@ -56,6 +56,10 @@ def _namespace_scoped_repo_id(test_space_id: str, repo_name: str) -> str:
     return repo_name
 
 
+def _repo_safe_suffix(nbytes: int = 6) -> str:
+    return secrets.token_hex(nbytes)
+
+
 def test_sync_to_gradio_space(test_space_id, temp_dir):
     project_name = f"test_sync_gradio_{secrets.token_urlsafe(8)}"
     run_name = "run1"
@@ -90,7 +94,7 @@ def test_sync_to_gradio_space(test_space_id, temp_dir):
 def test_sync_to_static_space_incremental(test_space_id, temp_dir):
     project_name = f"test_sync_static_{secrets.token_urlsafe(8)}"
     run_name = "run1"
-    suffix = secrets.token_urlsafe(6)
+    suffix = _repo_safe_suffix()
     space_id = _namespace_scoped_repo_id(test_space_id, f"trackio-test-static-{suffix}")
     space_id, _, bucket_id = utils.preprocess_space_and_dataset_ids(space_id, None)
 
@@ -137,7 +141,7 @@ def test_sync_gradio_then_freeze_to_static(test_space_id, temp_dir):
     client.predict(api_name="/force_sync")
     time.sleep(5)
 
-    suffix = secrets.token_urlsafe(6)
+    suffix = _repo_safe_suffix()
     frozen_space_id = _namespace_scoped_repo_id(
         test_space_id, f"trackio-test-frozen-{suffix}"
     )


### PR DESCRIPTION
## Summary
- replace secrets.token_urlsafe() with a repo-safe hex suffix when generating static/frozen Space ids in the e2e sync/freeze tests
- avoid invalid Hugging Face repo ids containing -- when the random suffix starts with -

## Testing
- PYTHONPATH=. pytest -q tests/e2e-spaces/test_sync_and_freeze.py -k "sync_to_static_space_incremental or sync_gradio_then_freeze_to_static" (skipped locally because TEST_SPACE_ID is not set)
- verified with a local Python check that secrets.token_hex(6) never emits - or .

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates e2e test data generation to avoid invalid Hugging Face Space repo IDs; no production logic changes.
> 
> **Overview**
> Updates the e2e sync/freeze tests to generate **repo-id-safe** random suffixes for static and frozen Space names.
> 
> Introduces `_repo_safe_suffix()` (hex-based) and replaces `secrets.token_urlsafe()` for Space repo ID suffixes to avoid intermittent invalid IDs during test runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4812e9d1e85a2740ebfe19146317d5ef1d5a3fd7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->