### PR TITLE
Reduce HF Spaces 429s: polling tuning and batched metric logs API

### DIFF
--- a/.changeset/polite-tigers-drop.md
+++ b/.changeset/polite-tigers-drop.md
@@ -1,0 +1,5 @@
+---
+"trackio": minor
+---
+
+feat:Reduce Spaces 429s: slower polling, get_logs_batch, read cache

--- a/.changeset/polite-tigers-drop.md
+++ b/.changeset/polite-tigers-drop.md
@@ -2,4 +2,4 @@
 "trackio": minor
 ---
 
-feat:Reduce Spaces 429s: slower polling, get_logs_batch, read cache
+feat:Reduce HF Spaces 429s: polling tuning and batched metric logs API

--- a/docs/source/track.md
+++ b/docs/source/track.md
@@ -55,6 +55,8 @@ If both a Space and a self-hosted URL are configured (`space_id` / `TRACKIO_SPAC
 
 For setup steps (running `trackio show`, binding to `0.0.0.0`, write tokens), see [Self-host the Server](self_hosted_server.md).
 
+The built-in dashboard polls for new runs and metrics every **1 second** on localhost and every **2 seconds** when opened on a Hugging Face Space (`*.hf.space`), to ease rate limits on the Space URL.
+
 ## Logging Data
 
 Once your run is initialized, you can start logging data using the [`log`] function:

--- a/trackio/frontend/src/App.svelte
+++ b/trackio/frontend/src/App.svelte
@@ -20,6 +20,11 @@
     isStaticMode,
     setMediaDir,
   } from "./lib/api.js";
+  import {
+    getAppPollIntervalMs,
+    isRateLimitCooldownActive,
+    isTabHidden,
+  } from "./lib/hostPolling.js";
   import { setColorPalette } from "./lib/stores.js";
   import { getPageFromPath, navigateTo, getQueryParam } from "./lib/router.js";
   import Settings from "./pages/Settings.svelte";
@@ -159,9 +164,11 @@
     if (pollTimer) clearInterval(pollTimer);
     pollTimer = setInterval(async () => {
       if (!realtimeEnabled) return;
+      if (isTabHidden()) return;
+      if (isRateLimitCooldownActive()) return;
       await refreshRuns();
       await refreshAlerts();
-    }, 1000);
+    }, getAppPollIntervalMs());
   }
 
   function applyUrlTokens() {
@@ -382,6 +389,7 @@
           {showHeaders}
           {appBootstrapReady}
           {plotOrder}
+          {realtimeEnabled}
           bind:metricColumns
         />
       {:else if currentPage === "system"}
@@ -390,6 +398,7 @@
           selectedRuns={selectedRunRecords}
           {smoothing}
           {appBootstrapReady}
+          {realtimeEnabled}
           bind:availableDevices={availableSystemDevices}
           bind:selectedDevices={selectedSystemDevices}
         />

--- a/trackio/frontend/src/lib/api.js
+++ b/trackio/frontend/src/lib/api.js
@@ -141,6 +141,28 @@ export async function getSystemLogs(project, run) {
   return await callApi("/get_system_logs", params);
 }
 
+export async function getSystemLogsBatch(project, runs) {
+  if (await isStaticMode()) {
+    const out = [];
+    for (const run of runs) {
+      const logs = await staticApi.getSystemLogs(project, run);
+      out.push({
+        run: run?.name ?? null,
+        run_id: run?.id ?? null,
+        logs,
+      });
+    }
+    return out;
+  }
+  return await callApi("/get_system_logs_batch", {
+    project,
+    runs: runs.map((run) => ({
+      run: run?.name ?? null,
+      run_id: run?.id ?? null,
+    })),
+  });
+}
+
 export async function getSnapshot(project, run, step) {
   const params = { project, ...normalizeRun(run) };
   if (await isStaticMode()) return staticApi.getSnapshot(project, run, step);

--- a/trackio/frontend/src/lib/api.js
+++ b/trackio/frontend/src/lib/api.js
@@ -1,4 +1,5 @@
 import * as staticApi from "./staticApi.js";
+import { registerRateLimitHit } from "./hostPolling.js";
 
 const BASE = window.__trackio_base || "";
 
@@ -47,6 +48,9 @@ export async function callApi(apiName, params = {}) {
     headers: { "Content-Type": "application/json", ...getOauthSessionHeader() },
     body: JSON.stringify(params),
   });
+  if (resp.status === 429) {
+    registerRateLimitHit();
+  }
   if (!resp.ok) {
     throw new Error(`API call ${apiName} failed: ${resp.status}`);
   }
@@ -83,6 +87,29 @@ export async function getLogs(project, run) {
   const params = { project, ...normalizeRun(run) };
   if (await isStaticMode()) return staticApi.getLogs(project, run);
   return await callApi("/get_logs", params);
+}
+
+export async function getLogsBatch(project, runs) {
+  if (await isStaticMode()) {
+    const out = [];
+    for (const run of runs) {
+      const logs = await staticApi.getLogs(project, run);
+      out.push({
+        run: run?.name ?? null,
+        run_id: run?.id ?? null,
+        logs,
+      });
+    }
+    return out;
+  }
+  const payload = {
+    project,
+    runs: runs.map((run) => ({
+      run: run?.name ?? null,
+      run_id: run?.id ?? null,
+    })),
+  };
+  return await callApi("/get_logs_batch", payload);
 }
 
 export async function getProjectSummary(project) {

--- a/trackio/frontend/src/lib/hostPolling.js
+++ b/trackio/frontend/src/lib/hostPolling.js
@@ -17,11 +17,11 @@ export function isRateLimitCooldownActive() {
 }
 
 export function getAppPollIntervalMs() {
-  return isHfSpaceHost() ? 2000 : 1000;
+  return isHfSpaceHost() ? 2500 : 1000;
 }
 
 export function getMetricsPollIntervalMs() {
-  return isHfSpaceHost() ? 2000 : 1000;
+  return isHfSpaceHost() ? 3500 : 1000;
 }
 
 export function isTabHidden() {

--- a/trackio/frontend/src/lib/hostPolling.js
+++ b/trackio/frontend/src/lib/hostPolling.js
@@ -1,0 +1,29 @@
+let rateLimitCooldownUntil = 0;
+
+export function isHfSpaceHost() {
+  if (typeof window === "undefined") return false;
+  return (window.location.hostname || "")
+    .toLowerCase()
+    .endsWith(".hf.space");
+}
+
+export function registerRateLimitHit() {
+  const until = Date.now() + 12000;
+  rateLimitCooldownUntil = Math.max(rateLimitCooldownUntil, until);
+}
+
+export function isRateLimitCooldownActive() {
+  return Date.now() < rateLimitCooldownUntil;
+}
+
+export function getAppPollIntervalMs() {
+  return isHfSpaceHost() ? 2500 : 1000;
+}
+
+export function getMetricsPollIntervalMs() {
+  return isHfSpaceHost() ? 3500 : 1000;
+}
+
+export function isTabHidden() {
+  return typeof document !== "undefined" && document.hidden;
+}

--- a/trackio/frontend/src/lib/hostPolling.js
+++ b/trackio/frontend/src/lib/hostPolling.js
@@ -17,11 +17,11 @@ export function isRateLimitCooldownActive() {
 }
 
 export function getAppPollIntervalMs() {
-  return isHfSpaceHost() ? 2500 : 1000;
+  return isHfSpaceHost() ? 2000 : 1000;
 }
 
 export function getMetricsPollIntervalMs() {
-  return isHfSpaceHost() ? 3500 : 1000;
+  return isHfSpaceHost() ? 2000 : 1000;
 }
 
 export function isTabHidden() {

--- a/trackio/frontend/src/pages/Metrics.svelte
+++ b/trackio/frontend/src/pages/Metrics.svelte
@@ -180,11 +180,15 @@
     });
     let fetched = false;
     if (needFetch.length > 0) {
-      const batch = await getLogsBatch(project, needFetch);
-      for (const entry of batch) {
-        const runKey = entry.run_id ?? entry.run;
-        rawDataCache.set(runKey, entry.logs);
-        fetched = true;
+      try {
+        const batch = await getLogsBatch(project, needFetch);
+        for (const entry of batch) {
+          const runKey = entry.run_id ?? entry.run;
+          rawDataCache.set(runKey, entry.logs);
+          fetched = true;
+        }
+      } catch (e) {
+        console.error("Failed to load metric logs:", e);
       }
     }
 
@@ -200,19 +204,23 @@
     if (isTabHidden()) return;
     if (isRateLimitCooldownActive()) return;
 
-    const batch = await getLogsBatch(project, selectedRuns);
-    let changed = false;
-    for (const entry of batch) {
-      const runKey = entry.run_id ?? entry.run;
-      const logs = entry.logs;
-      const prev = rawDataCache.get(runKey);
-      if (!prev || logs.length !== prev.length) {
-        rawDataCache.set(runKey, logs);
-        changed = true;
+    try {
+      const batch = await getLogsBatch(project, selectedRuns);
+      let changed = false;
+      for (const entry of batch) {
+        const runKey = entry.run_id ?? entry.run;
+        const logs = entry.logs;
+        const prev = rawDataCache.get(runKey);
+        if (!prev || logs.length !== prev.length) {
+          rawDataCache.set(runKey, logs);
+          changed = true;
+        }
       }
-    }
-    if (changed) {
-      processFromCache();
+      if (changed) {
+        processFromCache();
+      }
+    } catch (e) {
+      console.error("Failed to refresh metric logs:", e);
     }
   }
 

--- a/trackio/frontend/src/pages/Metrics.svelte
+++ b/trackio/frontend/src/pages/Metrics.svelte
@@ -5,7 +5,12 @@
   import BarPlot from "../components/BarPlot.svelte";
   import Accordion from "../components/Accordion.svelte";
   import LoadingTrackio from "../components/LoadingTrackio.svelte";
-  import { getLogs } from "../lib/api.js";
+  import { getLogsBatch } from "../lib/api.js";
+  import {
+    getMetricsPollIntervalMs,
+    isRateLimitCooldownActive,
+    isTabHidden,
+  } from "../lib/hostPolling.js";
   import {
     processRunData,
     getMetricColumns,
@@ -27,6 +32,7 @@
     showHeaders = true,
     appBootstrapReady = false,
     plotOrder = [],
+    realtimeEnabled = true,
     // eslint-disable-next-line no-useless-assignment -- bindable out-prop to parent
     metricColumns = $bindable([]),
   } = $props();
@@ -168,12 +174,16 @@
       return;
     }
 
-    let fetched = false;
-    for (const run of selectedRuns) {
+    const needFetch = selectedRuns.filter((run) => {
       const runKey = run.id ?? run.name;
-      if (!rawDataCache.has(runKey)) {
-        const logs = await getLogs(project, run);
-        rawDataCache.set(runKey, logs);
+      return !rawDataCache.has(runKey);
+    });
+    let fetched = false;
+    if (needFetch.length > 0) {
+      const batch = await getLogsBatch(project, needFetch);
+      for (const entry of batch) {
+        const runKey = entry.run_id ?? entry.run;
+        rawDataCache.set(runKey, entry.logs);
         fetched = true;
       }
     }
@@ -185,12 +195,16 @@
   }
 
   async function refreshCachedRuns() {
+    if (!realtimeEnabled) return;
     if (!project || selectedRuns.length === 0) return;
+    if (isTabHidden()) return;
+    if (isRateLimitCooldownActive()) return;
 
+    const batch = await getLogsBatch(project, selectedRuns);
     let changed = false;
-    for (const run of selectedRuns) {
-      const logs = await getLogs(project, run);
-      const runKey = run.id ?? run.name;
+    for (const entry of batch) {
+      const runKey = entry.run_id ?? entry.run;
+      const logs = entry.logs;
       const prev = rawDataCache.get(runKey);
       if (!prev || logs.length !== prev.length) {
         rawDataCache.set(runKey, logs);
@@ -230,7 +244,10 @@
         xLim = [lo, hi];
       }
     }
-    refreshTimer = setInterval(refreshCachedRuns, 1000);
+    refreshTimer = setInterval(
+      refreshCachedRuns,
+      getMetricsPollIntervalMs(),
+    );
     return () => {
       if (refreshTimer) clearInterval(refreshTimer);
     };

--- a/trackio/frontend/src/pages/SystemMetrics.svelte
+++ b/trackio/frontend/src/pages/SystemMetrics.svelte
@@ -3,7 +3,7 @@
   import LinePlot from "../components/LinePlot.svelte";
   import Accordion from "../components/Accordion.svelte";
   import LoadingTrackio from "../components/LoadingTrackio.svelte";
-  import { getSystemLogs } from "../lib/api.js";
+  import { getSystemLogsBatch } from "../lib/api.js";
   import {
     getMetricsPollIntervalMs,
     isRateLimitCooldownActive,
@@ -189,12 +189,16 @@
       return;
     }
 
-    let fetched = false;
-    for (const run of selectedRuns) {
+    const needFetch = selectedRuns.filter((run) => {
       const runKey = run.id ?? run.name;
-      if (!rawDataCache.has(runKey)) {
-        const logs = await getSystemLogs(project, run);
-        rawDataCache.set(runKey, logs);
+      return !rawDataCache.has(runKey);
+    });
+    let fetched = false;
+    if (needFetch.length > 0) {
+      const batch = await getSystemLogsBatch(project, needFetch);
+      for (const entry of batch) {
+        const runKey = entry.run_id ?? entry.run;
+        rawDataCache.set(runKey, entry.logs);
         fetched = true;
       }
     }
@@ -211,10 +215,11 @@
     if (isTabHidden()) return;
     if (isRateLimitCooldownActive()) return;
 
+    const batch = await getSystemLogsBatch(project, selectedRuns);
     let changed = false;
-    for (const run of selectedRuns) {
-      const logs = await getSystemLogs(project, run);
-      const runKey = run.id ?? run.name;
+    for (const entry of batch) {
+      const runKey = entry.run_id ?? entry.run;
+      const logs = entry.logs;
       const prev = rawDataCache.get(runKey);
       if (!prev || logs.length !== prev.length) {
         rawDataCache.set(runKey, logs);

--- a/trackio/frontend/src/pages/SystemMetrics.svelte
+++ b/trackio/frontend/src/pages/SystemMetrics.svelte
@@ -3,7 +3,7 @@
   import LinePlot from "../components/LinePlot.svelte";
   import Accordion from "../components/Accordion.svelte";
   import LoadingTrackio from "../components/LoadingTrackio.svelte";
-  import { getSystemLogsBatch } from "../lib/api.js";
+  import { getSystemLogs, getSystemLogsBatch } from "../lib/api.js";
   import {
     getMetricsPollIntervalMs,
     isRateLimitCooldownActive,
@@ -30,6 +30,8 @@
   let metricNames = $state([]);
   let xLim = $state(null);
   let hasLoaded = $state(false);
+  let loadError = $state(null);
+  let batchEndpointAvailable = true;
   let metricOrder = $state({});
   let dragState = $state({ group: null, index: -1 });
 
@@ -177,6 +179,32 @@
     systemData = allRows;
   }
 
+  function isMissingEndpointError(e) {
+    const msg = e && e.message ? String(e.message) : "";
+    return /\b(404|405|501)\b/.test(msg);
+  }
+
+  async function fetchSystemLogsForRuns(runs) {
+    if (batchEndpointAvailable) {
+      try {
+        return await getSystemLogsBatch(project, runs);
+      } catch (e) {
+        if (!isMissingEndpointError(e)) throw e;
+        batchEndpointAvailable = false;
+      }
+    }
+    const results = [];
+    for (const run of runs) {
+      const logs = await getSystemLogs(project, run);
+      results.push({
+        run: run?.name ?? null,
+        run_id: run?.id ?? null,
+        logs,
+      });
+    }
+    return results;
+  }
+
   async function fetchNewRuns() {
     if (!appBootstrapReady) {
       hasLoaded = false;
@@ -185,6 +213,7 @@
     if (!project || selectedRuns.length === 0) {
       systemData = [];
       metricNames = [];
+      loadError = null;
       hasLoaded = true;
       return;
     }
@@ -196,20 +225,26 @@
     let fetched = false;
     if (needFetch.length > 0) {
       try {
-        const batch = await getSystemLogsBatch(project, needFetch);
+        const batch = await fetchSystemLogsForRuns(needFetch);
         for (const entry of batch) {
           const runKey = entry.run_id ?? entry.run;
           rawDataCache.set(runKey, entry.logs);
           fetched = true;
         }
+        loadError = null;
       } catch (e) {
         console.error("Failed to load system metric logs:", e);
+        if (!hasLoaded) {
+          loadError = e && e.message ? e.message : "Failed to load system metrics";
+          return;
+        }
       }
     }
 
     if (fetched || !hasLoaded) {
       processFromCache();
     }
+    loadError = null;
     hasLoaded = true;
   }
 
@@ -220,7 +255,7 @@
     if (isRateLimitCooldownActive()) return;
 
     try {
-      const batch = await getSystemLogsBatch(project, selectedRuns);
+      const batch = await fetchSystemLogsForRuns(selectedRuns);
       let changed = false;
       for (const entry of batch) {
         const runKey = entry.run_id ?? entry.run;
@@ -439,8 +474,13 @@
 </script>
 
 <div class="system-page">
-  {#if !appBootstrapReady || !hasLoaded}
+  {#if !appBootstrapReady || (!hasLoaded && !loadError)}
     <LoadingTrackio />
+  {:else if loadError && !hasLoaded}
+    <div class="empty-state">
+      <h2>Unable to load system metrics</h2>
+      <p>{loadError}</p>
+    </div>
   {:else if !project}
     <div class="empty-state">
       <h2>No projects</h2>

--- a/trackio/frontend/src/pages/SystemMetrics.svelte
+++ b/trackio/frontend/src/pages/SystemMetrics.svelte
@@ -5,6 +5,11 @@
   import LoadingTrackio from "../components/LoadingTrackio.svelte";
   import { getSystemLogs } from "../lib/api.js";
   import {
+    getMetricsPollIntervalMs,
+    isRateLimitCooldownActive,
+    isTabHidden,
+  } from "../lib/hostPolling.js";
+  import {
     groupMetricsByPrefix,
     computeMetricPlotData,
     downsample,
@@ -16,6 +21,7 @@
     selectedRuns = [],
     smoothing = 5,
     appBootstrapReady = false,
+    realtimeEnabled = true,
     availableDevices = $bindable([]),
     selectedDevices = $bindable([]),
   } = $props();
@@ -200,7 +206,10 @@
   }
 
   async function refreshCachedRuns() {
+    if (!realtimeEnabled) return;
     if (!project || selectedRuns.length === 0) return;
+    if (isTabHidden()) return;
+    if (isRateLimitCooldownActive()) return;
 
     let changed = false;
     for (const run of selectedRuns) {
@@ -264,7 +273,10 @@
   });
 
   onMount(() => {
-    refreshTimer = setInterval(refreshCachedRuns, 1000);
+    refreshTimer = setInterval(
+      refreshCachedRuns,
+      getMetricsPollIntervalMs(),
+    );
     return () => {
       if (refreshTimer) clearInterval(refreshTimer);
     };

--- a/trackio/frontend/src/pages/SystemMetrics.svelte
+++ b/trackio/frontend/src/pages/SystemMetrics.svelte
@@ -195,11 +195,15 @@
     });
     let fetched = false;
     if (needFetch.length > 0) {
-      const batch = await getSystemLogsBatch(project, needFetch);
-      for (const entry of batch) {
-        const runKey = entry.run_id ?? entry.run;
-        rawDataCache.set(runKey, entry.logs);
-        fetched = true;
+      try {
+        const batch = await getSystemLogsBatch(project, needFetch);
+        for (const entry of batch) {
+          const runKey = entry.run_id ?? entry.run;
+          rawDataCache.set(runKey, entry.logs);
+          fetched = true;
+        }
+      } catch (e) {
+        console.error("Failed to load system metric logs:", e);
       }
     }
 
@@ -215,19 +219,23 @@
     if (isTabHidden()) return;
     if (isRateLimitCooldownActive()) return;
 
-    const batch = await getSystemLogsBatch(project, selectedRuns);
-    let changed = false;
-    for (const entry of batch) {
-      const runKey = entry.run_id ?? entry.run;
-      const logs = entry.logs;
-      const prev = rawDataCache.get(runKey);
-      if (!prev || logs.length !== prev.length) {
-        rawDataCache.set(runKey, logs);
-        changed = true;
+    try {
+      const batch = await getSystemLogsBatch(project, selectedRuns);
+      let changed = false;
+      for (const entry of batch) {
+        const runKey = entry.run_id ?? entry.run;
+        const logs = entry.logs;
+        const prev = rawDataCache.get(runKey);
+        if (!prev || logs.length !== prev.length) {
+          rawDataCache.set(runKey, logs);
+          changed = true;
+        }
       }
-    }
-    if (changed) {
-      processFromCache();
+      if (changed) {
+        processFromCache();
+      }
+    } catch (e) {
+      console.error("Failed to refresh system metric logs:", e);
     }
   }
 

--- a/trackio/server.py
+++ b/trackio/server.py
@@ -713,6 +713,14 @@ def get_logs(
     return SQLiteStorage.get_logs(project, run, max_points=1500, run_id=run_id)
 
 
+def get_logs_batch(
+    project: str,
+    runs: list[dict[str, Any]],
+    max_points: int | None = 1500,
+) -> list[dict[str, Any]]:
+    return SQLiteStorage.get_logs_batch(project, runs, max_points=max_points)
+
+
 def query_project(project: str, query: str) -> dict[str, Any]:
     return SQLiteStorage.query_project(project, query)
 
@@ -808,6 +816,7 @@ def _api_registry() -> dict[str, Any]:
         "get_system_logs": get_system_logs,
         "get_snapshot": get_snapshot,
         "get_logs": get_logs,
+        "get_logs_batch": get_logs_batch,
         "query_project": query_project,
         "get_settings": get_settings,
         "get_project_files": get_project_files,

--- a/trackio/server.py
+++ b/trackio/server.py
@@ -687,6 +687,13 @@ def get_system_logs(
     return SQLiteStorage.get_system_logs(project, run, run_id=run_id)
 
 
+def get_system_logs_batch(
+    project: str,
+    runs: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    return SQLiteStorage.get_system_logs_batch(project, runs)
+
+
 def get_snapshot(
     project: str,
     run: str | None = None,
@@ -814,6 +821,7 @@ def _api_registry() -> dict[str, Any]:
         "get_run_summary": get_run_summary,
         "get_system_metrics_for_run": get_system_metrics_for_run,
         "get_system_logs": get_system_logs,
+        "get_system_logs_batch": get_system_logs_batch,
         "get_snapshot": get_snapshot,
         "get_logs": get_logs,
         "get_logs_batch": get_logs_batch,

--- a/trackio/server.py
+++ b/trackio/server.py
@@ -718,15 +718,17 @@ def get_system_metrics_for_run(
 def get_system_logs(
     project: str, run: str | None = None, run_id: str | None = None
 ) -> list[dict[str, Any]]:
-    return SQLiteStorage.get_system_logs(project, run, run_id=run_id)
+    return SQLiteStorage.get_system_logs(project, run, run_id=run_id, max_points=1500)
 
 
 def get_system_logs_batch(
     project: str,
     runs: list[dict[str, Any]],
+    max_points: int | None = 1500,
 ) -> list[dict[str, Any]]:
     runs_clean = _normalize_logs_batch_runs(runs)
-    return SQLiteStorage.get_system_logs_batch(project, runs_clean)
+    mp = _normalize_logs_batch_max_points(max_points)
+    return SQLiteStorage.get_system_logs_batch(project, runs_clean, max_points=mp)
 
 
 def get_snapshot(

--- a/trackio/server.py
+++ b/trackio/server.py
@@ -42,6 +42,40 @@ _flush_lock = threading.Lock()
 _FLUSH_INTERVAL = 2.0
 _MAX_RETRIES = 30
 
+_LOGS_BATCH_MAX_RUNS = 64
+_LOGS_BATCH_MAX_POINTS = 10_000
+
+
+def _normalize_logs_batch_runs(runs: Any) -> list[dict[str, Any]]:
+    if not isinstance(runs, list):
+        raise TrackioAPIError("runs must be a list")
+    if len(runs) > _LOGS_BATCH_MAX_RUNS:
+        raise TrackioAPIError(
+            f"runs cannot contain more than {_LOGS_BATCH_MAX_RUNS} entries"
+        )
+    out: list[dict[str, Any]] = []
+    for i, r in enumerate(runs):
+        if not isinstance(r, dict):
+            raise TrackioAPIError(f"runs[{i}] must be an object")
+        out.append({"run": r.get("run"), "run_id": r.get("run_id")})
+    return out
+
+
+def _normalize_logs_batch_max_points(max_points: Any) -> int | None:
+    if max_points is None:
+        return 1500
+    if isinstance(max_points, bool):
+        raise TrackioAPIError("max_points must be a number or null")
+    if isinstance(max_points, float):
+        if not max_points.is_integer():
+            raise TrackioAPIError("max_points must be a whole number")
+        max_points = int(max_points)
+    if not isinstance(max_points, int):
+        raise TrackioAPIError("max_points must be an integer or null")
+    if max_points < 1:
+        return 1500
+    return min(max_points, _LOGS_BATCH_MAX_POINTS)
+
 
 def _enqueue_write(kind: str, payload: Any) -> None:
     _write_queue.append((kind, payload))
@@ -691,7 +725,8 @@ def get_system_logs_batch(
     project: str,
     runs: list[dict[str, Any]],
 ) -> list[dict[str, Any]]:
-    return SQLiteStorage.get_system_logs_batch(project, runs)
+    runs_clean = _normalize_logs_batch_runs(runs)
+    return SQLiteStorage.get_system_logs_batch(project, runs_clean)
 
 
 def get_snapshot(
@@ -725,7 +760,9 @@ def get_logs_batch(
     runs: list[dict[str, Any]],
     max_points: int | None = 1500,
 ) -> list[dict[str, Any]]:
-    return SQLiteStorage.get_logs_batch(project, runs, max_points=max_points)
+    runs_clean = _normalize_logs_batch_runs(runs)
+    mp = _normalize_logs_batch_max_points(max_points)
+    return SQLiteStorage.get_logs_batch(project, runs_clean, max_points=mp)
 
 
 def query_project(project: str, query: str) -> dict[str, Any]:

--- a/trackio/sqlite_storage.py
+++ b/trackio/sqlite_storage.py
@@ -256,8 +256,15 @@ def _system_logs_read_cache_key(
     project: str,
     run: str | None,
     run_id: str | None,
+    max_points: int | None = None,
 ) -> tuple[Any, ...]:
-    return ("system_logs", project, run or "", run_id or "")
+    return (
+        "system_logs",
+        project,
+        run or "",
+        run_id or "",
+        max_points if max_points is not None else -1,
+    )
 
 
 def _system_logs_read_cache_get(
@@ -1512,6 +1519,7 @@ class SQLiteStorage:
     def _fetch_system_logs_with_cursor(
         cursor: sqlite3.Cursor,
         run_identity: tuple[str, Any],
+        max_points: int | None = None,
     ) -> list[dict[str, Any]]:
         cursor.execute(
             f"""
@@ -1523,6 +1531,7 @@ class SQLiteStorage:
             (run_identity[1],),
         )
         rows = cursor.fetchall()
+        rows = SQLiteStorage._subsample_metric_rows(rows, max_points)
         results = []
         for row in rows:
             metrics = orjson.loads(row["metrics"])
@@ -1533,14 +1542,17 @@ class SQLiteStorage:
 
     @staticmethod
     def get_system_logs(
-        project: str, run: str | None = None, run_id: str | None = None
+        project: str,
+        run: str | None = None,
+        run_id: str | None = None,
+        max_points: int | None = None,
     ) -> list[dict]:
         """Retrieve system metrics for a specific run. Returns metrics with timestamps (no steps)."""
         db_path = SQLiteStorage.get_project_db_path(project)
         if not db_path.exists():
             return []
 
-        cache_key = _system_logs_read_cache_key(project, run, run_id)
+        cache_key = _system_logs_read_cache_key(project, run, run_id, max_points)
         cached = _system_logs_read_cache_get(db_path, cache_key)
         if cached is not None:
             return cached
@@ -1555,7 +1567,7 @@ class SQLiteStorage:
                     logs: list[dict[str, Any]] = []
                 else:
                     logs = SQLiteStorage._fetch_system_logs_with_cursor(
-                        cursor, run_identity
+                        cursor, run_identity, max_points
                     )
         except sqlite3.OperationalError as e:
             if "no such table: system_metrics" in str(e):
@@ -1569,6 +1581,7 @@ class SQLiteStorage:
     def get_system_logs_batch(
         project: str,
         runs: list[dict[str, Any]] | None = None,
+        max_points: int | None = None,
     ) -> list[dict[str, Any]]:
         if not runs:
             return []
@@ -1590,7 +1603,9 @@ class SQLiteStorage:
                 for r in runs:
                     run = r.get("run")
                     run_id = r.get("run_id")
-                    cache_key = _system_logs_read_cache_key(project, run, run_id)
+                    cache_key = _system_logs_read_cache_key(
+                        project, run, run_id, max_points
+                    )
                     cached = _system_logs_read_cache_get(db_path, cache_key)
                     if cached is not None:
                         out.append(
@@ -1608,7 +1623,7 @@ class SQLiteStorage:
                         logs = []
                     else:
                         logs = SQLiteStorage._fetch_system_logs_with_cursor(
-                            cursor, run_identity
+                            cursor, run_identity, max_points
                         )
                     _system_logs_read_cache_put(db_path, cache_key, logs)
                     out.append(

--- a/trackio/sqlite_storage.py
+++ b/trackio/sqlite_storage.py
@@ -172,6 +172,68 @@ class ProcessLock:
             self.lockfile.close()
 
 
+_LOGS_READ_CACHE: dict[tuple[Any, ...], tuple[int, list[dict[str, Any]]]] = {}
+_LOGS_READ_CACHE_LOCK = Lock()
+_LOGS_READ_CACHE_MAX_KEYS = 512
+
+
+def _spaces_logs_read_cache_enabled() -> bool:
+    if not on_spaces():
+        return False
+    v = os.environ.get("TRACKIO_DISABLE_LOGS_CACHE", "").strip().lower()
+    return v not in ("1", "true", "yes")
+
+
+def _logs_read_cache_key(
+    project: str,
+    run: str | None,
+    run_id: str | None,
+    max_points: int | None,
+) -> tuple[Any, ...]:
+    return (
+        project,
+        run or "",
+        run_id or "",
+        max_points if max_points is not None else -1,
+    )
+
+
+def _logs_read_cache_get(
+    db_path: Path, key: tuple[Any, ...]
+) -> list[dict[str, Any]] | None:
+    if not _spaces_logs_read_cache_enabled():
+        return None
+    try:
+        mtime_ns = db_path.stat().st_mtime_ns
+    except OSError:
+        return None
+    with _LOGS_READ_CACHE_LOCK:
+        item = _LOGS_READ_CACHE.get(key)
+        if item is None:
+            return None
+        cached_mtime, logs = item
+        if cached_mtime != mtime_ns:
+            del _LOGS_READ_CACHE[key]
+            return None
+    return [{**d} for d in logs]
+
+
+def _logs_read_cache_put(
+    db_path: Path, key: tuple[Any, ...], logs: list[dict[str, Any]]
+) -> None:
+    if not _spaces_logs_read_cache_enabled():
+        return
+    try:
+        mtime_ns = db_path.stat().st_mtime_ns
+    except OSError:
+        return
+    snapshot = [{**d} for d in logs]
+    with _LOGS_READ_CACHE_LOCK:
+        while len(_LOGS_READ_CACHE) >= _LOGS_READ_CACHE_MAX_KEYS:
+            _LOGS_READ_CACHE.pop(next(iter(_LOGS_READ_CACHE)))
+        _LOGS_READ_CACHE[key] = (mtime_ns, snapshot)
+
+
 class SQLiteStorage:
     _dataset_import_attempted = False
     _current_scheduler: CommitScheduler | DummyCommitScheduler | None = None
@@ -1506,6 +1568,45 @@ class SQLiteStorage:
             raise
 
     @staticmethod
+    def _subsample_metric_rows(rows: list[Any], max_points: int | None) -> list[Any]:
+        if max_points is None or len(rows) <= max_points:
+            return rows
+        step = len(rows) / max_points
+        indices = {int(i * step) for i in range(max_points)}
+        indices.add(len(rows) - 1)
+        return [rows[i] for i in sorted(indices)]
+
+    @staticmethod
+    def _metric_rows_to_log_dicts(rows: list[Any]) -> list[dict[str, Any]]:
+        results = []
+        for row in rows:
+            metrics = orjson.loads(row["metrics"])
+            metrics = deserialize_values(metrics)
+            metrics["timestamp"] = row["timestamp"]
+            metrics["step"] = row["step"]
+            results.append(metrics)
+        return results
+
+    @staticmethod
+    def _fetch_metric_logs_with_cursor(
+        cursor: sqlite3.Cursor,
+        run_identity: tuple[str, Any],
+        max_points: int | None,
+    ) -> list[dict[str, Any]]:
+        cursor.execute(
+            f"""
+            SELECT timestamp, step, metrics
+            FROM metrics
+            WHERE {run_identity[0]} = ?
+            ORDER BY timestamp
+            """,
+            (run_identity[1],),
+        )
+        rows = cursor.fetchall()
+        rows = SQLiteStorage._subsample_metric_rows(rows, max_points)
+        return SQLiteStorage._metric_rows_to_log_dicts(rows)
+
+    @staticmethod
     def get_logs(
         project: str,
         run: str | None = None,
@@ -1517,6 +1618,11 @@ class SQLiteStorage:
         if not db_path.exists():
             return []
 
+        cache_key = _logs_read_cache_key(project, run, run_id, max_points)
+        cached = _logs_read_cache_get(db_path, cache_key)
+        if cached is not None:
+            return cached
+
         try:
             with SQLiteStorage._get_connection(db_path) as conn:
                 cursor = conn.cursor()
@@ -1524,36 +1630,86 @@ class SQLiteStorage:
                     conn, run_name=run, run_id=run_id
                 )
                 if run_identity is None:
-                    return []
-                cursor.execute(
-                    f"""
-                    SELECT timestamp, step, metrics
-                    FROM metrics
-                    WHERE {run_identity[0]} = ?
-                    ORDER BY timestamp
-                    """,
-                    (run_identity[1],),
-                )
-
-                rows = cursor.fetchall()
-                if max_points is not None and len(rows) > max_points:
-                    step = len(rows) / max_points
-                    indices = {int(i * step) for i in range(max_points)}
-                    indices.add(len(rows) - 1)
-                    rows = [rows[i] for i in sorted(indices)]
-
-                results = []
-                for row in rows:
-                    metrics = orjson.loads(row["metrics"])
-                    metrics = deserialize_values(metrics)
-                    metrics["timestamp"] = row["timestamp"]
-                    metrics["step"] = row["step"]
-                    results.append(metrics)
-                return results
+                    logs: list[dict[str, Any]] = []
+                else:
+                    logs = SQLiteStorage._fetch_metric_logs_with_cursor(
+                        cursor, run_identity, max_points
+                    )
         except sqlite3.OperationalError as e:
             if "no such table: metrics" in str(e):
                 return []
             raise
+
+        _logs_read_cache_put(db_path, cache_key, logs)
+        return [{**d} for d in logs]
+
+    @staticmethod
+    def get_logs_batch(
+        project: str,
+        runs: list[dict[str, Any]] | None = None,
+        max_points: int | None = None,
+    ) -> list[dict[str, Any]]:
+        if not runs:
+            return []
+        db_path = SQLiteStorage.get_project_db_path(project)
+        if not db_path.exists():
+            return [
+                {
+                    "run": r.get("run"),
+                    "run_id": r.get("run_id"),
+                    "logs": [],
+                }
+                for r in runs
+            ]
+
+        out: list[dict[str, Any]] = []
+        try:
+            with SQLiteStorage._get_connection(db_path) as conn:
+                cursor = conn.cursor()
+                for r in runs:
+                    run = r.get("run")
+                    run_id = r.get("run_id")
+                    cache_key = _logs_read_cache_key(project, run, run_id, max_points)
+                    cached = _logs_read_cache_get(db_path, cache_key)
+                    if cached is not None:
+                        out.append(
+                            {
+                                "run": run,
+                                "run_id": run_id,
+                                "logs": cached,
+                            }
+                        )
+                        continue
+                    run_identity = SQLiteStorage._resolve_run_identity(
+                        conn, run_name=run, run_id=run_id
+                    )
+                    if run_identity is None:
+                        logs = []
+                    else:
+                        logs = SQLiteStorage._fetch_metric_logs_with_cursor(
+                            cursor, run_identity, max_points
+                        )
+                    _logs_read_cache_put(db_path, cache_key, logs)
+                    out.append(
+                        {
+                            "run": run,
+                            "run_id": run_id,
+                            "logs": [{**d} for d in logs],
+                        }
+                    )
+        except sqlite3.OperationalError as e:
+            if "no such table: metrics" in str(e):
+                return [
+                    {
+                        "run": r.get("run"),
+                        "run_id": r.get("run_id"),
+                        "logs": [],
+                    }
+                    for r in runs
+                ]
+            raise
+
+        return out
 
     @staticmethod
     def load_from_dataset():

--- a/trackio/sqlite_storage.py
+++ b/trackio/sqlite_storage.py
@@ -234,6 +234,53 @@ def _logs_read_cache_put(
         _LOGS_READ_CACHE[key] = (mtime_ns, snapshot)
 
 
+_SYSTEM_LOGS_READ_CACHE: dict[tuple[Any, ...], tuple[int, list[dict[str, Any]]]] = {}
+
+
+def _system_logs_read_cache_key(
+    project: str,
+    run: str | None,
+    run_id: str | None,
+) -> tuple[Any, ...]:
+    return ("system_logs", project, run or "", run_id or "")
+
+
+def _system_logs_read_cache_get(
+    db_path: Path, key: tuple[Any, ...]
+) -> list[dict[str, Any]] | None:
+    if not _spaces_logs_read_cache_enabled():
+        return None
+    try:
+        mtime_ns = db_path.stat().st_mtime_ns
+    except OSError:
+        return None
+    with _LOGS_READ_CACHE_LOCK:
+        item = _SYSTEM_LOGS_READ_CACHE.get(key)
+        if item is None:
+            return None
+        cached_mtime, logs = item
+        if cached_mtime != mtime_ns:
+            del _SYSTEM_LOGS_READ_CACHE[key]
+            return None
+    return [{**d} for d in logs]
+
+
+def _system_logs_read_cache_put(
+    db_path: Path, key: tuple[Any, ...], logs: list[dict[str, Any]]
+) -> None:
+    if not _spaces_logs_read_cache_enabled():
+        return
+    try:
+        mtime_ns = db_path.stat().st_mtime_ns
+    except OSError:
+        return
+    snapshot = [{**d} for d in logs]
+    with _LOGS_READ_CACHE_LOCK:
+        while len(_SYSTEM_LOGS_READ_CACHE) >= _LOGS_READ_CACHE_MAX_KEYS:
+            _SYSTEM_LOGS_READ_CACHE.pop(next(iter(_SYSTEM_LOGS_READ_CACHE)))
+        _SYSTEM_LOGS_READ_CACHE[key] = (mtime_ns, snapshot)
+
+
 class SQLiteStorage:
     _dataset_import_attempted = False
     _current_scheduler: CommitScheduler | DummyCommitScheduler | None = None
@@ -1447,6 +1494,29 @@ class SQLiteStorage:
                 return 0
 
     @staticmethod
+    def _fetch_system_logs_with_cursor(
+        cursor: sqlite3.Cursor,
+        run_identity: tuple[str, Any],
+    ) -> list[dict[str, Any]]:
+        cursor.execute(
+            f"""
+            SELECT timestamp, metrics
+            FROM system_metrics
+            WHERE {run_identity[0]} = ?
+            ORDER BY timestamp
+            """,
+            (run_identity[1],),
+        )
+        rows = cursor.fetchall()
+        results = []
+        for row in rows:
+            metrics = orjson.loads(row["metrics"])
+            metrics = deserialize_values(metrics)
+            metrics["timestamp"] = row["timestamp"]
+            results.append(metrics)
+        return results
+
+    @staticmethod
     def get_system_logs(
         project: str, run: str | None = None, run_id: str | None = None
     ) -> list[dict]:
@@ -1455,36 +1525,97 @@ class SQLiteStorage:
         if not db_path.exists():
             return []
 
-        with SQLiteStorage._get_connection(db_path) as conn:
-            cursor = conn.cursor()
-            try:
+        cache_key = _system_logs_read_cache_key(project, run, run_id)
+        cached = _system_logs_read_cache_get(db_path, cache_key)
+        if cached is not None:
+            return cached
+
+        try:
+            with SQLiteStorage._get_connection(db_path) as conn:
+                cursor = conn.cursor()
                 run_identity = SQLiteStorage._resolve_run_identity(
                     conn, run_name=run, run_id=run_id, table="system_metrics"
                 )
                 if run_identity is None:
-                    return []
-                cursor.execute(
-                    f"""
-                    SELECT timestamp, metrics
-                    FROM system_metrics
-                    WHERE {run_identity[0]} = ?
-                    ORDER BY timestamp
-                    """,
-                    (run_identity[1],),
-                )
+                    logs: list[dict[str, Any]] = []
+                else:
+                    logs = SQLiteStorage._fetch_system_logs_with_cursor(
+                        cursor, run_identity
+                    )
+        except sqlite3.OperationalError as e:
+            if "no such table: system_metrics" in str(e):
+                return []
+            raise
 
-                rows = cursor.fetchall()
-                results = []
-                for row in rows:
-                    metrics = orjson.loads(row["metrics"])
-                    metrics = deserialize_values(metrics)
-                    metrics["timestamp"] = row["timestamp"]
-                    results.append(metrics)
-                return results
-            except sqlite3.OperationalError as e:
-                if "no such table: system_metrics" in str(e):
-                    return []
-                raise
+        _system_logs_read_cache_put(db_path, cache_key, logs)
+        return [{**d} for d in logs]
+
+    @staticmethod
+    def get_system_logs_batch(
+        project: str,
+        runs: list[dict[str, Any]] | None = None,
+    ) -> list[dict[str, Any]]:
+        if not runs:
+            return []
+        db_path = SQLiteStorage.get_project_db_path(project)
+        if not db_path.exists():
+            return [
+                {
+                    "run": r.get("run"),
+                    "run_id": r.get("run_id"),
+                    "logs": [],
+                }
+                for r in runs
+            ]
+
+        out: list[dict[str, Any]] = []
+        try:
+            with SQLiteStorage._get_connection(db_path) as conn:
+                cursor = conn.cursor()
+                for r in runs:
+                    run = r.get("run")
+                    run_id = r.get("run_id")
+                    cache_key = _system_logs_read_cache_key(project, run, run_id)
+                    cached = _system_logs_read_cache_get(db_path, cache_key)
+                    if cached is not None:
+                        out.append(
+                            {
+                                "run": run,
+                                "run_id": run_id,
+                                "logs": cached,
+                            }
+                        )
+                        continue
+                    run_identity = SQLiteStorage._resolve_run_identity(
+                        conn, run_name=run, run_id=run_id, table="system_metrics"
+                    )
+                    if run_identity is None:
+                        logs = []
+                    else:
+                        logs = SQLiteStorage._fetch_system_logs_with_cursor(
+                            cursor, run_identity
+                        )
+                    _system_logs_read_cache_put(db_path, cache_key, logs)
+                    out.append(
+                        {
+                            "run": run,
+                            "run_id": run_id,
+                            "logs": [{**d} for d in logs],
+                        }
+                    )
+        except sqlite3.OperationalError as e:
+            if "no such table: system_metrics" in str(e):
+                return [
+                    {
+                        "run": r.get("run"),
+                        "run_id": r.get("run_id"),
+                        "logs": [],
+                    }
+                    for r in runs
+                ]
+            raise
+
+        return out
 
     @staticmethod
     def get_all_system_metrics_for_run(

--- a/trackio/sqlite_storage.py
+++ b/trackio/sqlite_storage.py
@@ -175,6 +175,7 @@ class ProcessLock:
 _LOGS_READ_CACHE: dict[tuple[Any, ...], tuple[int, list[dict[str, Any]]]] = {}
 _LOGS_READ_CACHE_LOCK = Lock()
 _LOGS_READ_CACHE_MAX_KEYS = 512
+_LOGS_READ_CACHE_MAX_ROWS_PER_ENTRY = 4000
 
 
 def _spaces_logs_read_cache_enabled() -> bool:
@@ -182,6 +183,20 @@ def _spaces_logs_read_cache_enabled() -> bool:
         return False
     v = os.environ.get("TRACKIO_DISABLE_LOGS_CACHE", "").strip().lower()
     return v not in ("1", "true", "yes")
+
+
+def _sqlite_db_invalidation_mtime_ns(db_path: Path) -> int | None:
+    try:
+        m = db_path.stat().st_mtime_ns
+    except OSError:
+        return None
+    wal_path = db_path.with_name(db_path.name + "-wal")
+    if wal_path.is_file():
+        try:
+            m = max(m, wal_path.stat().st_mtime_ns)
+        except OSError:
+            pass
+    return m
 
 
 def _logs_read_cache_key(
@@ -203,9 +218,8 @@ def _logs_read_cache_get(
 ) -> list[dict[str, Any]] | None:
     if not _spaces_logs_read_cache_enabled():
         return None
-    try:
-        mtime_ns = db_path.stat().st_mtime_ns
-    except OSError:
+    mtime_ns = _sqlite_db_invalidation_mtime_ns(db_path)
+    if mtime_ns is None:
         return None
     with _LOGS_READ_CACHE_LOCK:
         item = _LOGS_READ_CACHE.get(key)
@@ -223,9 +237,10 @@ def _logs_read_cache_put(
 ) -> None:
     if not _spaces_logs_read_cache_enabled():
         return
-    try:
-        mtime_ns = db_path.stat().st_mtime_ns
-    except OSError:
+    if len(logs) > _LOGS_READ_CACHE_MAX_ROWS_PER_ENTRY:
+        return
+    mtime_ns = _sqlite_db_invalidation_mtime_ns(db_path)
+    if mtime_ns is None:
         return
     snapshot = [{**d} for d in logs]
     with _LOGS_READ_CACHE_LOCK:
@@ -250,9 +265,8 @@ def _system_logs_read_cache_get(
 ) -> list[dict[str, Any]] | None:
     if not _spaces_logs_read_cache_enabled():
         return None
-    try:
-        mtime_ns = db_path.stat().st_mtime_ns
-    except OSError:
+    mtime_ns = _sqlite_db_invalidation_mtime_ns(db_path)
+    if mtime_ns is None:
         return None
     with _LOGS_READ_CACHE_LOCK:
         item = _SYSTEM_LOGS_READ_CACHE.get(key)
@@ -270,9 +284,10 @@ def _system_logs_read_cache_put(
 ) -> None:
     if not _spaces_logs_read_cache_enabled():
         return
-    try:
-        mtime_ns = db_path.stat().st_mtime_ns
-    except OSError:
+    if len(logs) > _LOGS_READ_CACHE_MAX_ROWS_PER_ENTRY:
+        return
+    mtime_ns = _sqlite_db_invalidation_mtime_ns(db_path)
+    if mtime_ns is None:
         return
     snapshot = [{**d} for d in logs]
     with _LOGS_READ_CACHE_LOCK:
@@ -1700,7 +1715,9 @@ class SQLiteStorage:
 
     @staticmethod
     def _subsample_metric_rows(rows: list[Any], max_points: int | None) -> list[Any]:
-        if max_points is None or len(rows) <= max_points:
+        if max_points is None or max_points < 1:
+            return rows
+        if len(rows) <= max_points:
             return rows
         step = len(rows) / max_points
         indices = {int(i * step) for i in range(max_points)}


### PR DESCRIPTION
PR reduces **HTTP 429 (rate limit)** errors on **Hugging Face Spaces** when many people use the Trackio dashboard or when many runs are selected.

**Approach**

1. **Dashboard polling (`hostPolling.js`, `App.svelte`, `Metrics.svelte`, `SystemMetrics.svelte`)**
   - On `*.hf.space`, both the app-level poll and the metrics/system poll use **2 second** intervals; on localhost they stay at **1 second** for both. Documented in `docs/source/track.md` 
   - Skip polling while the browser tab is hidden.
   - Short backoff after API responses with status **429**.
   - The “Refresh metrics realtime” control applies to metrics-oriented polling where wired.

2. **Batched metric logs API**
   - **`POST /api/get_logs_batch`**: one request returns logs for multiple runs (Metrics page uses this instead of N× `get_logs`).
   - **`get_logs_batch` in `SQLiteStorage`**: single DB connection, one loop over runs.
