### PR TITLE
Add Gradio-compatible /gradio_api routes on Spaces

### DIFF
--- a/.changeset/silly-coats-go.md
+++ b/.changeset/silly-coats-go.md
@@ -1,0 +1,5 @@
+---
+"trackio": minor
+---
+
+feat:Add Gradio-compatible /gradio_api routes on Spaces

--- a/tests/unit/test_gradio_api_spaces.py
+++ b/tests/unit/test_gradio_api_spaces.py
@@ -63,6 +63,28 @@ def test_hf_token_from_authorization_on_spaces(monkeypatch, temp_dir):
     assert r.json()["data"] == "space-token"
 
 
+def test_hf_token_empty_or_whitespace_body_uses_bearer(monkeypatch, temp_dir):
+    monkeypatch.setenv("SYSTEM", "spaces")
+    app = create_trackio_starlette_app([], {"hf_echo": _hf_echo})
+    client = TestClient(app)
+
+    r = client.post(
+        "/api/hf_echo",
+        json={"hf_token": ""},
+        headers={"Authorization": "Bearer from-header"},
+    )
+    assert r.status_code == 200
+    assert r.json()["data"] == "from-header"
+
+    r2 = client.post(
+        "/api/hf_echo",
+        json={"hf_token": "  "},
+        headers={"Authorization": "Bearer from-header"},
+    )
+    assert r2.status_code == 200
+    assert r2.json()["data"] == "from-header"
+
+
 def test_gradio_upload_aliases_api_upload(monkeypatch, temp_dir):
     monkeypatch.setenv("SYSTEM", "spaces")
     app = create_trackio_starlette_app([], {"echo": _echo})

--- a/tests/unit/test_gradio_api_spaces.py
+++ b/tests/unit/test_gradio_api_spaces.py
@@ -1,0 +1,73 @@
+from starlette.testclient import TestClient
+
+from trackio.asgi_app import create_trackio_starlette_app
+
+
+def _echo(msg: str = "") -> str:
+    return msg
+
+
+def _hf_echo(hf_token: str | None = None) -> str | None:
+    return hf_token
+
+
+def test_gradio_api_info_call_poll_and_headers(monkeypatch, temp_dir):
+    monkeypatch.setenv("SYSTEM", "spaces")
+    app = create_trackio_starlette_app([], {"echo": _echo})
+    client = TestClient(app)
+
+    info = client.get("/gradio_api/info")
+    assert info.status_code == 200
+    body = info.json()
+    assert "/echo" in body["named_endpoints"]
+    assert body["unnamed_endpoints"] == {}
+
+    post = client.post("/gradio_api/call/echo", json={"data": ["hi"]})
+    assert post.status_code == 200
+    event_id = post.json()["event_id"]
+
+    poll = client.get(f"/gradio_api/call/echo/{event_id}")
+    assert poll.status_code == 200
+    assert poll.headers.get("cache-control") == "no-store"
+    assert poll.headers.get("x-accel-buffering") == "no"
+    assert "event: complete" in poll.text
+    assert '"hi"' in poll.text
+
+
+def test_gradio_poll_wrong_api_name_not_consumed(monkeypatch, temp_dir):
+    monkeypatch.setenv("SYSTEM", "spaces")
+    app = create_trackio_starlette_app([], {"echo": _echo})
+    client = TestClient(app)
+
+    post = client.post("/gradio_api/call/echo", json={"data": ["x"]})
+    event_id = post.json()["event_id"]
+
+    bad = client.get(f"/gradio_api/call/other/{event_id}")
+    assert bad.status_code == 404
+
+    ok = client.get(f"/gradio_api/call/echo/{event_id}")
+    assert ok.status_code == 200
+
+
+def test_hf_token_from_authorization_on_spaces(monkeypatch, temp_dir):
+    monkeypatch.setenv("SYSTEM", "spaces")
+    app = create_trackio_starlette_app([], {"hf_echo": _hf_echo})
+    client = TestClient(app)
+
+    r = client.post(
+        "/api/hf_echo",
+        json={},
+        headers={"Authorization": "Bearer space-token"},
+    )
+    assert r.status_code == 200
+    assert r.json()["data"] == "space-token"
+
+
+def test_gradio_upload_aliases_api_upload(monkeypatch, temp_dir):
+    monkeypatch.setenv("SYSTEM", "spaces")
+    app = create_trackio_starlette_app([], {"echo": _echo})
+    client = TestClient(app)
+
+    g = client.post("/gradio_api/upload", files={"files": ("a.txt", b"x")})
+    assert g.status_code == 200
+    assert "paths" in g.json()

--- a/trackio/asgi_app.py
+++ b/trackio/asgi_app.py
@@ -3,19 +3,21 @@ from __future__ import annotations
 import inspect
 import json
 import math
+import secrets
 import tempfile
 import threading
 from pathlib import Path
-from typing import Any
+from typing import Any, get_args, get_origin
 from urllib.parse import unquote
 
 from starlette.applications import Starlette
 from starlette.requests import Request
-from starlette.responses import FileResponse, JSONResponse, Response
+from starlette.responses import FileResponse, JSONResponse, Response, StreamingResponse
 from starlette.routing import Route
 
 from trackio.exceptions import TrackioAPIError
 from trackio.remote_client import HTTP_API_VERSION
+from trackio.utils import on_spaces
 
 _PACKAGE_JSON_PATH = Path(__file__).parent / "package.json"
 _TRACKIO_PACKAGE_VERSION = json.loads(_PACKAGE_JSON_PATH.read_text())["version"]
@@ -136,9 +138,94 @@ async def version_handler(request: Request) -> Response:
     )
 
 
-async def api_handler(request: Request) -> Response:
+def _json_schema_and_python_type(annotation: Any) -> tuple[dict[str, Any], str]:
+    if annotation is inspect.Parameter.empty:
+        return {"type": "object"}, "Any"
+    origin = get_origin(annotation)
+    args = get_args(annotation)
+    if origin is not None and args:
+        non_none = tuple(a for a in args if a is not type(None))
+        if len(non_none) == 1 and len(args) > 1:
+            return _json_schema_and_python_type(non_none[0])
+        if origin is list:
+            inner, py_inner = _json_schema_and_python_type(
+                args[0] if args else inspect.Parameter.empty
+            )
+            return {"type": "array", "items": inner}, f"list[{py_inner}]"
+        if origin is dict:
+            return {"type": "object"}, "dict"
+    if annotation in (str, bytes):
+        return {"type": "string"}, "str"
+    if annotation is int:
+        return {"type": "integer"}, "int"
+    if annotation is float:
+        return {"type": "number"}, "float"
+    if annotation is bool:
+        return {"type": "boolean"}, "bool"
+    name = getattr(annotation, "__name__", None)
+    if name:
+        return {"type": "object"}, name
+    return {"type": "object"}, "Any"
+
+
+def build_gradio_api_info(api_registry: dict[str, Any]) -> dict[str, Any]:
+    named_endpoints: dict[str, Any] = {}
+    for name in sorted(api_registry.keys()):
+        fn = api_registry[name]
+        if not callable(fn):
+            continue
+        sig = inspect.signature(fn)
+        parameters: list[dict[str, Any]] = []
+        for pname, param in sig.parameters.items():
+            if pname == "request":
+                continue
+            jtype, pytype = _json_schema_and_python_type(param.annotation)
+            has_default = param.default is not inspect.Parameter.empty
+            parameters.append(
+                {
+                    "label": pname,
+                    "parameter_name": pname,
+                    "parameter_has_default": has_default,
+                    "parameter_default": None if not has_default else param.default,
+                    "type": jtype,
+                    "python_type": {"type": pytype, "description": ""},
+                    "component": "Api",
+                    "example_input": None,
+                }
+            )
+        ret_ann = sig.return_annotation
+        if ret_ann is inspect.Signature.empty:
+            ret_ann = Any
+        rjtype, rpytype = _json_schema_and_python_type(ret_ann)
+        returns = [
+            {
+                "label": "result",
+                "type": rjtype,
+                "python_type": {"type": rpytype, "description": ""},
+                "component": "Api",
+            }
+        ]
+        named_endpoints[f"/{name}"] = {
+            "parameters": parameters,
+            "returns": returns,
+            "api_visibility": "public",
+        }
+    return {"named_endpoints": named_endpoints, "unnamed_endpoints": {}}
+
+
+_MAX_GRADIO_CALL_EVENTS = 256
+
+
+def _store_gradio_call_result(request: Request, event_id: str, result: Any) -> None:
+    with request.app.state.gradio_call_events_lock:
+        d = request.app.state.gradio_call_events
+        while len(d) >= _MAX_GRADIO_CALL_EVENTS:
+            d.pop(next(iter(d)))
+        d[event_id] = result
+
+
+async def run_api_request(request: Request, api_name: str) -> Response:
     api_registry = request.app.state.api_registry
-    api_name = request.path_params["api_name"]
     fn = api_registry.get(api_name)
     if fn is None:
         return JSONResponse({"error": f"Unknown API: {api_name}"}, status_code=404)
@@ -177,6 +264,43 @@ async def api_handler(request: Request) -> Response:
         return JSONResponse({"error": str(e)}, status_code=500)
 
 
+async def api_handler(request: Request) -> Response:
+    return await run_api_request(request, request.path_params["api_name"])
+
+
+async def gradio_api_info_handler(request: Request) -> Response:
+    return JSONResponse(
+        build_gradio_api_info(request.app.state.api_registry),
+        headers={"Cache-Control": "no-store"},
+    )
+
+
+async def gradio_call_post_handler(request: Request) -> Response:
+    api_name = request.path_params["api_name"]
+    resp = await run_api_request(request, api_name)
+    if resp.status_code != 200:
+        return resp
+    body = json.loads(bytes(resp.body).decode())
+    event_id = secrets.token_urlsafe(16)
+    _store_gradio_call_result(request, event_id, body["data"])
+    return JSONResponse({"event_id": event_id})
+
+
+async def gradio_call_poll_handler(request: Request) -> Response:
+    event_id = request.path_params["event_id"]
+    with request.app.state.gradio_call_events_lock:
+        data = request.app.state.gradio_call_events.pop(event_id, None)
+    if data is None:
+        return JSONResponse({"error": "Unknown or expired event_id"}, status_code=404)
+
+    payload = json.dumps(_json_safe([data]))
+
+    async def sse() -> Any:
+        yield f"event: complete\ndata: {payload}\n\n"
+
+    return StreamingResponse(sse(), media_type="text/event-stream")
+
+
 async def upload_handler(request: Request) -> Response:
     form = await request.form()
     uploads = form.getlist("files")
@@ -192,6 +316,10 @@ async def upload_handler(request: Request) -> Response:
             register_uploaded_temp_file(request, tmp.name)
             saved_paths.append(tmp.name)
     return JSONResponse({"paths": saved_paths})
+
+
+async def gradio_upload_alias_handler(request: Request) -> Response:
+    return await upload_handler(request)
 
 
 async def file_handler(request: Request) -> Response:
@@ -222,6 +350,51 @@ def create_trackio_starlette_app(
             Route("/file", endpoint=file_handler, methods=["GET"]),
         ]
     )
+    if on_spaces():
+        routes.extend(
+            [
+                Route(
+                    "/gradio_api/info",
+                    endpoint=gradio_api_info_handler,
+                    methods=["GET"],
+                ),
+                Route(
+                    "/gradio_api/info/",
+                    endpoint=gradio_api_info_handler,
+                    methods=["GET"],
+                ),
+                Route(
+                    "/gradio_api/upload",
+                    endpoint=gradio_upload_alias_handler,
+                    methods=["POST"],
+                ),
+                Route(
+                    "/gradio_api/upload/",
+                    endpoint=gradio_upload_alias_handler,
+                    methods=["POST"],
+                ),
+                Route(
+                    "/gradio_api/call/{api_name:str}",
+                    endpoint=gradio_call_post_handler,
+                    methods=["POST"],
+                ),
+                Route(
+                    "/gradio_api/call/{api_name:str}/",
+                    endpoint=gradio_call_post_handler,
+                    methods=["POST"],
+                ),
+                Route(
+                    "/gradio_api/call/{api_name:str}/{event_id:str}",
+                    endpoint=gradio_call_poll_handler,
+                    methods=["GET"],
+                ),
+                Route(
+                    "/gradio_api/call/{api_name:str}/{event_id:str}/",
+                    endpoint=gradio_call_poll_handler,
+                    methods=["GET"],
+                ),
+            ]
+        )
     routes.extend(extra_routes or [])
     app = Starlette(routes=routes, lifespan=mcp_lifespan)
     app.state.api_registry = api_registry
@@ -229,4 +402,7 @@ def create_trackio_starlette_app(
     app.state.allowed_file_roots = _normalize_allowed_file_roots(allowed_file_roots)
     app.state.uploaded_temp_files = set()
     app.state.uploaded_temp_files_lock = threading.Lock()
+    if on_spaces():
+        app.state.gradio_call_events = {}
+        app.state.gradio_call_events_lock = threading.Lock()
     return app

--- a/trackio/asgi_app.py
+++ b/trackio/asgi_app.py
@@ -216,12 +216,52 @@ def build_gradio_api_info(api_registry: dict[str, Any]) -> dict[str, Any]:
 _MAX_GRADIO_CALL_EVENTS = 256
 
 
-def _store_gradio_call_result(request: Request, event_id: str, result: Any) -> None:
+def _authorization_bearer_token(request: Request) -> str | None:
+    auth = request.headers.get("authorization") or request.headers.get("Authorization")
+    if not auth:
+        return None
+    parts = auth.split()
+    if len(parts) != 2 or parts[0].lower() != "bearer":
+        return None
+    tok = parts[1].strip()
+    return tok or None
+
+
+def _maybe_apply_hf_token_from_authorization(
+    request: Request, fn: Any, args: list[Any], kwargs: dict[str, Any]
+) -> None:
+    if not on_spaces():
+        return
+    token = _authorization_bearer_token(request)
+    if not token:
+        return
+    sig = inspect.signature(fn)
+    if "hf_token" not in sig.parameters:
+        return
+    params = [p for p in sig.parameters.values() if p.name != "request"]
+    names = [p.name for p in params]
+    if "hf_token" not in names:
+        return
+    idx = names.index("hf_token")
+    if "hf_token" in kwargs:
+        if kwargs["hf_token"] is None:
+            kwargs["hf_token"] = token
+        return
+    if idx < len(args):
+        if args[idx] is None:
+            args[idx] = token
+        return
+    kwargs["hf_token"] = token
+
+
+def _store_gradio_call_result(
+    request: Request, event_id: str, api_name: str, data: Any
+) -> None:
     with request.app.state.gradio_call_events_lock:
         d = request.app.state.gradio_call_events
         while len(d) >= _MAX_GRADIO_CALL_EVENTS:
             d.pop(next(iter(d)))
-        d[event_id] = result
+        d[event_id] = {"api_name": api_name, "data": data}
 
 
 async def run_api_request(request: Request, api_name: str) -> Response:
@@ -255,6 +295,8 @@ async def run_api_request(request: Request, api_name: str) -> Response:
     if not isinstance(kwargs, dict):
         kwargs = {}
 
+    _maybe_apply_hf_token_from_authorization(request, fn, args, kwargs)
+
     try:
         result = _invoke_handler(fn, request, args=args, kwargs=kwargs)
         return JSONResponse({"data": _json_safe(result)})
@@ -282,23 +324,37 @@ async def gradio_call_post_handler(request: Request) -> Response:
         return resp
     body = json.loads(bytes(resp.body).decode())
     event_id = secrets.token_urlsafe(16)
-    _store_gradio_call_result(request, event_id, body["data"])
+    _store_gradio_call_result(request, event_id, api_name, body["data"])
     return JSONResponse({"event_id": event_id})
 
 
 async def gradio_call_poll_handler(request: Request) -> Response:
+    api_name = request.path_params["api_name"]
     event_id = request.path_params["event_id"]
     with request.app.state.gradio_call_events_lock:
-        data = request.app.state.gradio_call_events.pop(event_id, None)
-    if data is None:
+        event = request.app.state.gradio_call_events.pop(event_id, None)
+    if event is None:
+        return JSONResponse({"error": "Unknown or expired event_id"}, status_code=404)
+    if event.get("api_name") != api_name:
+        with request.app.state.gradio_call_events_lock:
+            if len(request.app.state.gradio_call_events) < _MAX_GRADIO_CALL_EVENTS:
+                request.app.state.gradio_call_events[event_id] = event
         return JSONResponse({"error": "Unknown or expired event_id"}, status_code=404)
 
+    data = event["data"]
     payload = json.dumps(_json_safe([data]))
 
     async def sse() -> Any:
         yield f"event: complete\ndata: {payload}\n\n"
 
-    return StreamingResponse(sse(), media_type="text/event-stream")
+    return StreamingResponse(
+        sse(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-store",
+            "X-Accel-Buffering": "no",
+        },
+    )
 
 
 async def upload_handler(request: Request) -> Response:

--- a/trackio/asgi_app.py
+++ b/trackio/asgi_app.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import inspect
 import json
+import logging
 import math
 import secrets
 import tempfile
@@ -18,6 +19,8 @@ from starlette.routing import Route
 from trackio.exceptions import TrackioAPIError
 from trackio.remote_client import HTTP_API_VERSION
 from trackio.utils import on_spaces
+
+logger = logging.getLogger("trackio.asgi_app")
 
 _PACKAGE_JSON_PATH = Path(__file__).parent / "package.json"
 _TRACKIO_PACKAGE_VERSION = json.loads(_PACKAGE_JSON_PATH.read_text())["version"]
@@ -216,6 +219,14 @@ def build_gradio_api_info(api_registry: dict[str, Any]) -> dict[str, Any]:
 _MAX_GRADIO_CALL_EVENTS = 256
 
 
+def _hf_token_value_is_unset(value: Any) -> bool:
+    if value is None:
+        return True
+    if isinstance(value, str) and value.strip() == "":
+        return True
+    return False
+
+
 def _authorization_bearer_token(request: Request) -> str | None:
     auth = request.headers.get("authorization") or request.headers.get("Authorization")
     if not auth:
@@ -244,11 +255,11 @@ def _maybe_apply_hf_token_from_authorization(
         return
     idx = names.index("hf_token")
     if "hf_token" in kwargs:
-        if kwargs["hf_token"] is None:
+        if _hf_token_value_is_unset(kwargs["hf_token"]):
             kwargs["hf_token"] = token
         return
     if idx < len(args):
-        if args[idx] is None:
+        if _hf_token_value_is_unset(args[idx]):
             args[idx] = token
         return
     kwargs["hf_token"] = token
@@ -334,11 +345,19 @@ async def gradio_call_poll_handler(request: Request) -> Response:
     with request.app.state.gradio_call_events_lock:
         event = request.app.state.gradio_call_events.pop(event_id, None)
     if event is None:
+        logger.info("gradio_api poll: unknown or expired event_id")
         return JSONResponse({"error": "Unknown or expired event_id"}, status_code=404)
     if event.get("api_name") != api_name:
+        logger.info(
+            "gradio_api poll: api_name mismatch (path=%r, stored=%r)",
+            api_name,
+            event.get("api_name"),
+        )
         with request.app.state.gradio_call_events_lock:
-            if len(request.app.state.gradio_call_events) < _MAX_GRADIO_CALL_EVENTS:
-                request.app.state.gradio_call_events[event_id] = event
+            d = request.app.state.gradio_call_events
+            while len(d) >= _MAX_GRADIO_CALL_EVENTS:
+                d.pop(next(iter(d)))
+            d[event_id] = event
         return JSONResponse({"error": "Unknown or expired event_id"}, status_code=404)
 
     data = event["data"]


### PR DESCRIPTION
## Short description

This pull request registers Gradio-style HTTP routes when Trackio runs on Hugging Face Spaces (`SYSTEM=spaces`): `GET /gradio_api/info`, `POST /gradio_api/call/{api_name}`, `GET /gradio_api/call/{api_name}/{event_id}`, and `POST /gradio_api/upload` (mirroring `/api/upload`). The info endpoint returns a schema shaped like Gradio`s `named_endpoints` / `unnamed_endpoints` payload. Call endpoints reuse the existing Trackio API implementation: POST returns an `event_id`, and GET streams a single SSE `complete` event with the result, matching the pattern shown in the Spaces Agents tab.

## AI Disclosure

- [x] I used AI to draft the initial implementation and PR text; changes were self-reviewed.
- [ ] I did not use AI

## Type of Change

- [x] New feature (non-breaking)
- [ ] Bug fix
- [ ] New feature (breaking change)
- [ ] Documentation update
- [ ] Test improvements

## Related Issues

Closes: #514

## Testing and linting

- `ruff check --fix --select I && ruff format` (passed)
- `pytest tests/ --ignore=tests/ui/` — 127 passed (UI Playwright tests were not run; they failed locally due to missing frontend build / timeouts unrelated to this change)


Made with [Cursor](https://cursor.com)