### PR TITLE
docs: add TRL integration guide

### DIFF
--- a/docs/source/_toctree.yml
+++ b/docs/source/_toctree.yml
@@ -36,9 +36,11 @@
   title: How-to guides
 - sections:
   - local: transformers_integration
-    title: Transformers Trainer
+    title: Running with Transformers
+  - local: trl_integration
+    title: Running with TRL
   - local: rapidfireai_integration
-    title: RapidFire AI
+    title: Running with RapidFire AI
   title: Integration
 - sections:
   - local: api

--- a/docs/source/trl_integration.md
+++ b/docs/source/trl_integration.md
@@ -35,8 +35,3 @@ args = SFTConfig(
 )
 ```
 
-<iframe 
-    src="https://trackio-documentation.hf.space/?project=trl-integration&sidebar=hidden" 
-    style="width: 100%; border:0;" 
-    height="1530">
-</iframe>

--- a/docs/source/trl_integration.md
+++ b/docs/source/trl_integration.md
@@ -1,0 +1,42 @@
+# TRL Integration
+
+Trackio integrates natively with [TRL](https://github.com/huggingface/trl) so you can log metrics from any TRL trainer (`SFTTrainer`, `DPOTrainer`, `GRPOTrainer`, etc.) with minimal setup. Ensure you have the latest version of `trl` installed (version 1.2.0 or higher).
+
+```python
+from datasets import Dataset
+from trl import SFTConfig, SFTTrainer
+
+# Create a small fake dataset
+prompts = ["What is the capital of France?", "Who wrote Hamlet?"] * 12
+completions = ["Paris.", "Shakespeare."] * 12
+dataset = Dataset.from_dict({"prompt": prompts, "completion": completions})
+
+# Train a model using the TRL SFTTrainer API
+trainer = SFTTrainer(
+    model="Qwen/Qwen3-0.6B",
+    args=SFTConfig(report_to="trackio", run_name="Qwen3-0.6B-sft"),
+    train_dataset=dataset,
+)
+trainer.train()
+```
+
+## Configuring Project and Space
+
+Set the project and space ID directly in your TRL config (e.g. [`~trl.SFTConfig`], [`~trl.DPOConfig`], [`~trl.GRPOConfig`]):
+
+```python
+from trl import SFTConfig
+
+args = SFTConfig(
+    report_to="trackio",
+    run_name="my-run",
+    project="my-project",
+    trackio_space_id="username/space_id",
+)
+```
+
+<iframe 
+    src="https://trackio-documentation.hf.space/?project=trl-integration&sidebar=hidden" 
+    style="width: 100%; border:0;" 
+    height="1530">
+</iframe>

--- a/docs/source/trl_integration.md
+++ b/docs/source/trl_integration.md
@@ -7,8 +7,8 @@ from datasets import Dataset
 from trl import SFTConfig, SFTTrainer
 
 # Create a small fake dataset
-prompts = ["What is the capital of France?", "Who wrote Hamlet?"] * 12
-completions = ["Paris.", "Shakespeare."] * 12
+prompts = ["The capital of France is", "Hamlet was written by"] * 12
+completions = [" Paris.", " Shakespeare."] * 12
 dataset = Dataset.from_dict({"prompt": prompts, "completion": completions})
 
 # Train a model using the TRL SFTTrainer API

--- a/examples/trl-integration.py
+++ b/examples/trl-integration.py
@@ -1,0 +1,53 @@
+# /// script
+# dependencies = [
+#   "trackio>=0.23.0",
+#   "trl>=1.2.0",
+#   "datasets>=4.4.0",
+#   "transformers[torch]>=5.0.0rc2",
+#   "huggingface_hub>=1.0.0",
+# ]
+# ///
+
+import random
+
+from datasets import Dataset
+from trl import SFTConfig, SFTTrainer
+
+suffix = random.randint(100000, 999999)
+project_name = f"trackio-trl-demo-{suffix}"
+
+prompts = [
+    "What is the capital of France?",
+    "Who wrote Hamlet?",
+    "What is 2 + 2?",
+    "What color is the sky?",
+    "Name a primary color.",
+    "What is the largest planet?",
+] * 4
+completions = [
+    "Paris.",
+    "Shakespeare.",
+    "4.",
+    "Blue.",
+    "Red.",
+    "Jupiter.",
+] * 4
+dataset = Dataset.from_dict({"prompt": prompts, "completion": completions})
+
+trainer = SFTTrainer(
+    model="trl-internal-testing/tiny-LlamaForCausalLM-3",
+    args=SFTConfig(
+        output_dir="./model_output",
+        num_train_epochs=1,
+        per_device_train_batch_size=4,
+        learning_rate=2e-5,
+        logging_steps=1,
+        report_to="trackio",
+        project=project_name,
+    ),
+    train_dataset=dataset,
+)
+
+trainer.train()
+
+print(f"Run complete. Open with: trackio show --project {project_name}")

--- a/examples/trl-integration.py
+++ b/examples/trl-integration.py
@@ -25,12 +25,12 @@ prompts = [
     {"role": "user", "content": "What is the largest planet?"},
 ] * 4
 completions = [
-    "Paris.",
-    "Shakespeare.",
-    "4.",
-    "Blue.",
-    "Red.",
-    "Jupiter.",
+    {"role": "assistant", "content": "Paris."},
+    {"role": "assistant", "content": "Shakespeare."},
+    {"role": "assistant", "content": "4."},
+    {"role": "assistant", "content": "Blue."},
+    {"role": "assistant", "content": "Red."},
+    {"role": "assistant", "content": "Jupiter."},
 ] * 4
 dataset = Dataset.from_dict({"prompt": prompts, "completion": completions})
 

--- a/examples/trl-integration.py
+++ b/examples/trl-integration.py
@@ -35,7 +35,7 @@ completions = [
 dataset = Dataset.from_dict({"prompt": prompts, "completion": completions})
 
 trainer = SFTTrainer(
-    model="trl-internal-testing/tiny-LlamaForCausalLM-3",
+    model="Qwen/Qwen3-0.6B",
     args=SFTConfig(
         output_dir="./model_output",
         num_train_epochs=1,

--- a/examples/trl-integration.py
+++ b/examples/trl-integration.py
@@ -17,12 +17,12 @@ suffix = random.randint(100000, 999999)
 project_name = f"trackio-trl-demo-{suffix}"
 
 prompts = [
-    "What is the capital of France?",
-    "Who wrote Hamlet?",
-    "What is 2 + 2?",
-    "What color is the sky?",
-    "Name a primary color.",
-    "What is the largest planet?",
+    {"role": "user", "content": "What is the capital of France?"},
+    {"role": "user", "content": "Who wrote Hamlet?"},
+    {"role": "user", "content": "What is 2 + 2?"},
+    {"role": "user", "content": "What color is the sky?"},
+    {"role": "user", "content": "Name a primary color."},
+    {"role": "user", "content": "What is the largest planet?"},
 ] * 4
 completions = [
     "Paris.",

--- a/examples/trl-integration.py
+++ b/examples/trl-integration.py
@@ -2,9 +2,6 @@
 # dependencies = [
 #   "trackio>=0.23.0",
 #   "trl>=1.2.0",
-#   "datasets>=4.4.0",
-#   "transformers[torch]>=5.0.0rc2",
-#   "huggingface_hub>=1.0.0",
 # ]
 # ///
 

--- a/examples/trl-integration.py
+++ b/examples/trl-integration.py
@@ -14,20 +14,20 @@ suffix = random.randint(100000, 999999)
 project_name = f"trackio-trl-demo-{suffix}"
 
 prompts = [
-    {"role": "user", "content": "What is the capital of France?"},
-    {"role": "user", "content": "Who wrote Hamlet?"},
-    {"role": "user", "content": "What is 2 + 2?"},
-    {"role": "user", "content": "What color is the sky?"},
-    {"role": "user", "content": "Name a primary color."},
-    {"role": "user", "content": "What is the largest planet?"},
+    [{"role": "user", "content": "What is the capital of France?"}],
+    [{"role": "user", "content": "Who wrote Hamlet?"}],
+    [{"role": "user", "content": "What is 2 + 2?"}],
+    [{"role": "user", "content": "What color is the sky?"}],
+    [{"role": "user", "content": "Name a primary color."}],
+    [{"role": "user", "content": "What is the largest planet?"}],
 ] * 4
 completions = [
-    {"role": "assistant", "content": "Paris."},
-    {"role": "assistant", "content": "Shakespeare."},
-    {"role": "assistant", "content": "4."},
-    {"role": "assistant", "content": "Blue."},
-    {"role": "assistant", "content": "Red."},
-    {"role": "assistant", "content": "Jupiter."},
+    [{"role": "assistant", "content": "Paris."}],
+    [{"role": "assistant", "content": "Shakespeare."}],
+    [{"role": "assistant", "content": "4."}],
+    [{"role": "assistant", "content": "Blue."}],
+    [{"role": "assistant", "content": "Red."}],
+    [{"role": "assistant", "content": "Jupiter."}],
 ] * 4
 dataset = Dataset.from_dict({"prompt": prompts, "completion": completions})
 


### PR DESCRIPTION
- Add a TRL integration page (`docs/source/trl_integration.md`) mirroring the Transformers guide, with a runnable `SFTTrainer` snippet and project/space configuration example.
- Add `examples/trl-integration.py`, a complete end-to-end SFT example using a tiny test model that runs in well under a minute. Verified locally.
- Rename the Integration section sidebar titles to "Running with Transformers", "Running with TRL", and "Running with RapidFire AI" so the docs are easier to find from the table of contents (per Aksel's suggestion).

For ML-Intern -- see internal context: https://huggingface.slack.com/archives/C08SW1X12C8/p1777305610753559?thread_ts=1777063926.876859&cid=C08SW1X12C8
