### PR TITLE
Add OTLP trace ingestion MVP

### DIFF
--- a/.changeset/thick-boats-win.md
+++ b/.changeset/thick-boats-win.md
@@ -1,0 +1,5 @@
+---
+"trackio": minor
+---
+
+feat:Add OTLP trace ingestion MVP

--- a/docs/source/_toctree.yml
+++ b/docs/source/_toctree.yml
@@ -29,6 +29,8 @@
     title: API and MCP Server
   - local: alerts
     title: Alerts
+  - local: otel_tracing
+    title: OpenTelemetry Traces
   - local: ml_agents
     title: ML Agents
   - local: environment_variables

--- a/docs/source/otel_tracing.md
+++ b/docs/source/otel_tracing.md
@@ -1,0 +1,93 @@
+# OpenTelemetry Traces
+
+Trackio can receive OpenTelemetry trace data over OTLP/HTTP and show it in the
+dashboard's **Traces** tab. This is useful for agent and LLM frameworks that
+already emit OpenTelemetry or OpenInference spans, such as smolagents through
+`openinference-instrumentation-smolagents`.
+
+This is a minimal v1 receiver:
+
+- supported endpoint: `POST /otel/v1/traces`
+- supported encoding: OTLP protobuf (`application/x-protobuf`)
+- supported signal: traces
+- storage: each incoming span is converted to a `trackio.Trace` log entry
+
+## Start Trackio
+
+Launch a writable Trackio dashboard:
+
+```bash
+trackio show
+```
+
+Use the write-access URL or token printed by the server. For a local server,
+OTLP requests must include the same write token as normal remote logging.
+
+## Configure an OTLP Exporter
+
+Point your OpenTelemetry exporter at Trackio:
+
+```bash
+export OTEL_EXPORTER_OTLP_TRACES_ENDPOINT="http://localhost:7860/otel/v1/traces"
+export OTEL_EXPORTER_OTLP_TRACES_PROTOCOL="http/protobuf"
+export OTEL_EXPORTER_OTLP_TRACES_HEADERS="x-trackio-write-token=<write-token>"
+```
+
+Set the Trackio project and run using OpenTelemetry resource attributes:
+
+```python
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+
+provider = TracerProvider(
+    resource=Resource(
+        {
+            "trackio.project": "my-project",
+            "trackio.run": "agent-run",
+            "service.name": "smolagents",
+        }
+    )
+)
+```
+
+If `trackio.project` is not set, Trackio uses the `project` query parameter if
+present, then falls back to `otel-traces`. If `trackio.run` is not set, Trackio
+uses `service.name`, then falls back to `otel`.
+
+## Example: smolagents with OpenInference
+
+```bash
+pip install smolagents opentelemetry-sdk opentelemetry-exporter-otlp-proto-http openinference-instrumentation-smolagents
+```
+
+```python
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from openinference.instrumentation.smolagents import SmolagentsInstrumentor
+
+provider = TracerProvider(
+    resource=Resource(
+        {
+            "trackio.project": "agent-debugging",
+            "trackio.run": "smolagents",
+            "service.name": "smolagents",
+        }
+    )
+)
+provider.add_span_processor(BatchSpanProcessor(OTLPSpanExporter()))
+SmolagentsInstrumentor().instrument(tracer_provider=provider)
+
+# Run your smolagents application normally. Spans will appear in Trackio.
+```
+
+## Notes
+
+Trackio preserves the raw span attributes in trace metadata and maps common
+OpenInference fields such as `input.value`, `output.value`, and indexed
+`llm.input_messages.*` / `llm.output_messages.*` attributes into conversational
+messages for the Traces tab.
+
+Runnable examples are available in `examples/otel-basic-mvp.py` and
+`examples/otel-smolagents-integration.py`.

--- a/examples/otel-basic-mvp.py
+++ b/examples/otel-basic-mvp.py
@@ -1,0 +1,61 @@
+"""Minimal OpenTelemetry -> Trackio example.
+
+Run a writable Trackio dashboard first:
+
+    trackio show
+
+Then set the write token printed by Trackio and run this example:
+
+    export TRACKIO_WRITE_TOKEN=<write-token>
+    python examples/otel-basic-mvp.py
+
+The span appears in the Trackio dashboard's Traces tab.
+"""
+
+import os
+
+from opentelemetry import trace
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+
+def main() -> None:
+    endpoint = os.getenv(
+        "TRACKIO_OTEL_ENDPOINT",
+        "http://localhost:7860/otel/v1/traces",
+    )
+    write_token = os.getenv("TRACKIO_WRITE_TOKEN")
+    headers = {"x-trackio-write-token": write_token} if write_token else {}
+
+    provider = TracerProvider(
+        resource=Resource(
+            {
+                "trackio.project": os.getenv("TRACKIO_PROJECT", "otel-basic-mvp"),
+                "trackio.run": os.getenv("TRACKIO_RUN", "manual-span"),
+                "service.name": "trackio-otel-basic-example",
+            }
+        )
+    )
+    provider.add_span_processor(
+        BatchSpanProcessor(OTLPSpanExporter(endpoint=endpoint, headers=headers))
+    )
+    trace.set_tracer_provider(provider)
+
+    tracer = trace.get_tracer("trackio.examples.otel-basic-mvp")
+    with tracer.start_as_current_span("manual llm call") as span:
+        span.set_attribute("openinference.span.kind", "llm")
+        span.set_attribute("input.value", "Say hello to Trackio.")
+        span.set_attribute("output.value", "Hello from OpenTelemetry.")
+        span.set_attribute("llm.model_name", "example-model")
+        span.set_attribute("llm.token_count.prompt", 5)
+        span.set_attribute("llm.token_count.completion", 4)
+
+    provider.force_flush()
+    provider.shutdown()
+    print(f"Sent one OTLP span to {endpoint}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/otel-smolagents-integration.py
+++ b/examples/otel-smolagents-integration.py
@@ -1,0 +1,80 @@
+"""smolagents + OpenInference + OpenTelemetry -> Trackio example.
+
+Run a writable Trackio dashboard first:
+
+    trackio show
+
+Then set the write token printed by Trackio and run this example:
+
+    pip install smolagents openinference-instrumentation-smolagents \
+        opentelemetry-sdk opentelemetry-exporter-otlp-proto-http
+    export TRACKIO_WRITE_TOKEN=<write-token>
+    python examples/otel-smolagents-integration.py
+
+This example uses a local dummy smolagents model, so it does not require an LLM
+API key. The agent run appears in the Trackio dashboard's Traces tab.
+
+Note: smolagents currently declares a narrower huggingface-hub dependency than
+Trackio. If installing smolagents downgrades huggingface-hub in a Trackio dev
+environment, reinstall Trackio's supported range with:
+
+    pip install "huggingface-hub>=1.10.0,<2"
+"""
+
+import os
+
+from openinference.instrumentation.smolagents import SmolagentsInstrumentor
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from smolagents import CodeAgent, Model
+from smolagents.models import ChatMessage, MessageRole
+
+
+class DemoModel(Model):
+    def generate(self, messages, **kwargs):
+        return ChatMessage(
+            role=MessageRole.ASSISTANT,
+            content="```python\nfinal_answer('Trackio received this smolagents trace')\n```",
+        )
+
+
+def main() -> None:
+    endpoint = os.getenv(
+        "TRACKIO_OTEL_ENDPOINT",
+        "http://localhost:7860/otel/v1/traces",
+    )
+    write_token = os.getenv("TRACKIO_WRITE_TOKEN")
+    headers = {"x-trackio-write-token": write_token} if write_token else {}
+
+    provider = TracerProvider(
+        resource=Resource(
+            {
+                "trackio.project": os.getenv("TRACKIO_PROJECT", "otel-smolagents"),
+                "trackio.run": os.getenv("TRACKIO_RUN", "dummy-agent"),
+                "service.name": "smolagents",
+            }
+        )
+    )
+    provider.add_span_processor(
+        BatchSpanProcessor(OTLPSpanExporter(endpoint=endpoint, headers=headers))
+    )
+
+    SmolagentsInstrumentor().instrument(tracer_provider=provider)
+
+    agent = CodeAgent(
+        tools=[],
+        model=DemoModel(model_id="trackio-demo-model"),
+        max_steps=1,
+    )
+    result = agent.run("Return a short confirmation that Trackio tracing works.")
+
+    provider.force_flush()
+    provider.shutdown()
+    print(f"Agent result: {result}")
+    print(f"Sent smolagents OpenInference spans to {endpoint}")
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "numpy<3.0.0",
     "pillow<13.0.0",
     "orjson>=3.0,<4.0.0",
+    "opentelemetry-proto>=1.25.0,<2.0.0",
     "tomli>=2.0.0; python_version < '3.11'",
 ]
 classifiers = [

--- a/tests/unit/test_otel_ingest.py
+++ b/tests/unit/test_otel_ingest.py
@@ -1,0 +1,182 @@
+import json
+
+from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import (
+    ExportTraceServiceRequest,
+)
+from opentelemetry.proto.common.v1.common_pb2 import AnyValue, KeyValue
+from opentelemetry.proto.resource.v1.resource_pb2 import Resource
+from opentelemetry.proto.trace.v1.trace_pb2 import ResourceSpans, ScopeSpans, Span
+from starlette.testclient import TestClient
+
+from trackio.otel import ingest_otlp_trace_bytes
+from trackio.server import build_starlette_app_only
+from trackio.sqlite_storage import SQLiteStorage
+
+
+def _kv(key, value):
+    any_value = AnyValue()
+    if isinstance(value, bool):
+        any_value.bool_value = value
+    elif isinstance(value, int):
+        any_value.int_value = value
+    elif isinstance(value, float):
+        any_value.double_value = value
+    else:
+        any_value.string_value = value
+    return KeyValue(key=key, value=any_value)
+
+
+def _request_bytes():
+    span = Span(
+        trace_id=bytes.fromhex("0" * 31 + "1"),
+        span_id=bytes.fromhex("0" * 15 + "2"),
+        name="agent run",
+        kind=Span.SPAN_KIND_INTERNAL,
+        start_time_unix_nano=1_700_000_000_000_000_000,
+        end_time_unix_nano=1_700_000_001_000_000_000,
+        attributes=[
+            _kv("input.value", "hello"),
+            _kv("output.value", "world"),
+            _kv("openinference.span.kind", "agent"),
+        ],
+    )
+    resource_spans = ResourceSpans(
+        resource=Resource(
+            attributes=[
+                _kv("trackio.project", "otel-project"),
+                _kv("service.name", "smolagents"),
+                _kv("service.instance.id", "service-1"),
+            ]
+        ),
+        scope_spans=[ScopeSpans(spans=[span])],
+    )
+    return ExportTraceServiceRequest(
+        resource_spans=[resource_spans]
+    ).SerializeToString()
+
+
+def _smolagents_request_bytes():
+    spans = [
+        Span(
+            trace_id=bytes.fromhex("0" * 31 + "3"),
+            span_id=bytes.fromhex("0" * 15 + "4"),
+            name="FinalAnswerTool",
+            start_time_unix_nano=1_700_000_000_000_000_000,
+            attributes=[
+                _kv(
+                    "input.value",
+                    json.dumps(
+                        {
+                            "args": ["Trackio received this smolagents trace"],
+                            "sanitize_inputs_outputs": False,
+                            "kwargs": {},
+                        }
+                    ),
+                ),
+                _kv("output.value", "Trackio received this smolagents trace"),
+            ],
+        ),
+        Span(
+            trace_id=bytes.fromhex("0" * 31 + "3"),
+            span_id=bytes.fromhex("0" * 15 + "5"),
+            name="Step 1",
+            start_time_unix_nano=1_700_000_001_000_000_000,
+            attributes=[
+                _kv(
+                    "input.value",
+                    json.dumps({"memory_step": "ActionStep(...lots of state...)"}),
+                ),
+                _kv("output.value", "Execution logs: Last output from code snippet"),
+            ],
+        ),
+        Span(
+            trace_id=bytes.fromhex("0" * 31 + "3"),
+            span_id=bytes.fromhex("0" * 15 + "6"),
+            name="CodeAgent.run",
+            start_time_unix_nano=1_700_000_002_000_000_000,
+            attributes=[
+                _kv(
+                    "input.value",
+                    json.dumps(
+                        {
+                            "task": "Return a short confirmation that Trackio tracing works.",
+                            "stream": False,
+                        }
+                    ),
+                ),
+                _kv("output.value", "Trackio received this smolagents trace"),
+            ],
+        ),
+    ]
+    resource_spans = ResourceSpans(
+        resource=Resource(
+            attributes=[
+                _kv("trackio.project", "otel-smolagents"),
+                _kv("trackio.run", "dummy-agent"),
+            ]
+        ),
+        scope_spans=[ScopeSpans(spans=spans)],
+    )
+    return ExportTraceServiceRequest(
+        resource_spans=[resource_spans]
+    ).SerializeToString()
+
+
+def test_ingest_otlp_trace_bytes_logs_trackio_trace(temp_dir):
+    result = ingest_otlp_trace_bytes(_request_bytes())
+
+    assert result["accepted_spans"] == 1
+    traces = SQLiteStorage.get_traces(
+        "otel-project", run="smolagents", run_id="service-1"
+    )
+    assert len(traces) == 1
+    assert traces[0]["run"] == "smolagents"
+    assert traces[0]["messages"] == [
+        {"role": "user", "content": "hello"},
+        {"role": "assistant", "content": "world"},
+    ]
+    assert traces[0]["metadata"]["source"] == "opentelemetry"
+    assert traces[0]["metadata"]["attributes"]["openinference.span.kind"] == "agent"
+
+
+def test_otel_route_requires_write_token_and_accepts_protobuf(temp_dir):
+    app, write_token = build_starlette_app_only()
+    client = TestClient(app)
+
+    unauthorized = client.post("/otel/v1/traces", content=_request_bytes())
+    assert unauthorized.status_code == 400
+
+    response = client.post(
+        "/otel/v1/traces",
+        content=_request_bytes(),
+        headers={
+            "content-type": "application/x-protobuf",
+            "x-trackio-write-token": write_token,
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("application/x-protobuf")
+    assert (
+        len(
+            SQLiteStorage.get_traces(
+                "otel-project", run="smolagents", run_id="service-1"
+            )
+        )
+        == 1
+    )
+
+
+def test_smolagents_json_inputs_render_as_readable_requests(temp_dir):
+    ingest_otlp_trace_bytes(_smolagents_request_bytes())
+
+    traces = SQLiteStorage.get_traces(
+        "otel-smolagents", run="dummy-agent", sort="step_asc"
+    )
+    requests = [trace["messages"][0]["content"] for trace in traces]
+
+    assert requests == [
+        "Trackio received this smolagents trace",
+        "Step 1",
+        "Return a short confirmation that Trackio tracing works.",
+    ]

--- a/trackio/otel.py
+++ b/trackio/otel.py
@@ -1,0 +1,317 @@
+from __future__ import annotations
+
+import json
+import re
+from datetime import datetime, timezone
+from typing import Any
+
+from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import (
+    ExportTraceServiceRequest,
+)
+from opentelemetry.proto.trace.v1.trace_pb2 import Span
+
+from trackio.sqlite_storage import SQLiteStorage
+
+DEFAULT_OTEL_PROJECT = "otel-traces"
+DEFAULT_OTEL_RUN = "otel"
+
+_INPUT_MESSAGE_RE = re.compile(r"^llm\.input_messages\.(\d+)\.message\.(role|content)$")
+_OUTPUT_MESSAGE_RE = re.compile(
+    r"^llm\.output_messages\.(\d+)\.message\.(role|content)$"
+)
+
+
+def _bytes_to_hex(value: bytes) -> str:
+    return value.hex()
+
+
+def _timestamp_from_unix_nano(value: int) -> str:
+    if not value:
+        return datetime.now(timezone.utc).isoformat()
+    return datetime.fromtimestamp(value / 1_000_000_000, timezone.utc).isoformat()
+
+
+def _value_to_python(value: Any) -> Any:
+    field = value.WhichOneof("value")
+    if field is None:
+        return None
+    raw = getattr(value, field)
+    if field == "array_value":
+        return [_value_to_python(item) for item in raw.values]
+    if field == "kvlist_value":
+        return {item.key: _value_to_python(item.value) for item in raw.values}
+    if field == "bytes_value":
+        return _bytes_to_hex(raw)
+    return raw
+
+
+def _attributes_to_dict(attributes: Any) -> dict[str, Any]:
+    return {attr.key: _value_to_python(attr.value) for attr in attributes}
+
+
+def _jsonish(value: Any) -> Any:
+    if not isinstance(value, str):
+        return value
+    stripped = value.strip()
+    if not stripped:
+        return value
+    if stripped[0] not in '[{"':
+        return value
+    try:
+        return json.loads(stripped)
+    except Exception:
+        return value
+
+
+def _content_from_value(value: Any) -> str:
+    parsed = _jsonish(value)
+    if isinstance(parsed, str):
+        return parsed
+    return json.dumps(parsed, ensure_ascii=False, default=str)
+
+
+def _messages_from_indexed_attrs(
+    attrs: dict[str, Any],
+    pattern: re.Pattern[str],
+    default_role: str,
+) -> list[dict[str, Any]]:
+    grouped: dict[int, dict[str, Any]] = {}
+    for key, value in attrs.items():
+        match = pattern.match(key)
+        if not match:
+            continue
+        index = int(match.group(1))
+        field = match.group(2)
+        grouped.setdefault(index, {})[field] = value
+    return [
+        {
+            "role": str(parts.get("role") or default_role),
+            "content": _content_from_value(parts.get("content", "")),
+        }
+        for _, parts in sorted(grouped.items())
+        if "content" in parts
+    ]
+
+
+def _message_content_from_mapping(value: dict[str, Any], fallback: str | None) -> str:
+    if isinstance(value.get("task"), str):
+        return value["task"]
+    if isinstance(value.get("query"), str):
+        return value["query"]
+    if isinstance(value.get("prompt"), str):
+        return value["prompt"]
+    if isinstance(value.get("input"), str):
+        return value["input"]
+    if isinstance(value.get("args"), list) and value["args"]:
+        return "\n".join(_content_from_value(item) for item in value["args"])
+    if isinstance(value.get("kwargs"), dict) and value["kwargs"]:
+        return json.dumps(value["kwargs"], ensure_ascii=False, default=str)
+    if "memory_step" in value and fallback:
+        return fallback
+    return json.dumps(value, ensure_ascii=False, default=str)
+
+
+def _messages_from_value(
+    value: Any,
+    role: str,
+    fallback: str | None = None,
+) -> list[dict[str, Any]]:
+    parsed = _jsonish(value)
+    if isinstance(parsed, list) and all(isinstance(item, dict) for item in parsed):
+        messages = []
+        for item in parsed:
+            if "content" not in item and "message" not in item:
+                continue
+            messages.append(
+                {
+                    "role": str(item.get("role") or role),
+                    "content": _content_from_value(
+                        item.get("content", item.get("message", ""))
+                    ),
+                }
+            )
+        if messages:
+            return messages
+    if isinstance(parsed, dict):
+        if "messages" in parsed:
+            return _messages_from_value(parsed["messages"], role, fallback=fallback)
+        return [
+            {
+                "role": role,
+                "content": _message_content_from_mapping(parsed, fallback),
+            }
+        ]
+    return [{"role": role, "content": _content_from_value(value)}]
+
+
+def _span_messages(
+    attrs: dict[str, Any], span_name: str | None = None
+) -> list[dict[str, Any]]:
+    messages = []
+    messages.extend(_messages_from_indexed_attrs(attrs, _INPUT_MESSAGE_RE, "user"))
+    if not messages and "input.value" in attrs:
+        messages.extend(
+            _messages_from_value(attrs["input.value"], "user", fallback=span_name)
+        )
+    messages.extend(
+        _messages_from_indexed_attrs(attrs, _OUTPUT_MESSAGE_RE, "assistant")
+    )
+    if not any(message.get("role") == "assistant" for message in messages):
+        if "output.value" in attrs:
+            messages.extend(
+                _messages_from_value(
+                    attrs["output.value"],
+                    "assistant",
+                    fallback=span_name,
+                )
+            )
+    return messages
+
+
+def _span_kind_name(kind: int) -> str:
+    try:
+        return Span.SpanKind.Name(kind).replace("SPAN_KIND_", "").lower()
+    except Exception:
+        return str(kind)
+
+
+def _span_status(span: Span) -> dict[str, Any]:
+    status = {
+        "code": span.status.code,
+        "message": span.status.message,
+    }
+    try:
+        status["name"] = span.status.StatusCode.Name(span.status.code)
+    except Exception:
+        pass
+    return status
+
+
+def _span_to_trace_payload(
+    span: Span,
+    resource_attrs: dict[str, Any],
+    scope_attrs: dict[str, Any],
+) -> tuple[str, dict[str, Any], str]:
+    attrs = _attributes_to_dict(span.attributes)
+    trace_id = _bytes_to_hex(span.trace_id)
+    span_id = _bytes_to_hex(span.span_id)
+    messages = _span_messages(attrs, span_name=span.name)
+    if not messages:
+        messages = [{"role": "system", "content": span.name or "OpenTelemetry span"}]
+
+    metadata = {
+        "source": "opentelemetry",
+        "trace_id": trace_id,
+        "span_id": span_id,
+        "parent_span_id": _bytes_to_hex(span.parent_span_id)
+        if span.parent_span_id
+        else None,
+        "name": span.name,
+        "kind": _span_kind_name(span.kind),
+        "status": _span_status(span),
+        "start_time": _timestamp_from_unix_nano(span.start_time_unix_nano),
+        "end_time": _timestamp_from_unix_nano(span.end_time_unix_nano),
+        "attributes": attrs,
+        "resource": resource_attrs,
+        "scope": scope_attrs,
+        "events": [
+            {
+                "name": event.name,
+                "timestamp": _timestamp_from_unix_nano(event.time_unix_nano),
+                "attributes": _attributes_to_dict(event.attributes),
+            }
+            for event in span.events
+        ],
+    }
+    payload = {
+        "_type": "trackio.trace",
+        "messages": messages,
+        "metadata": metadata,
+    }
+    return trace_id, payload, _timestamp_from_unix_nano(span.start_time_unix_nano)
+
+
+def ingest_otlp_trace_bytes(
+    body: bytes,
+    *,
+    project: str | None = None,
+    run: str | None = None,
+    run_id: str | None = None,
+) -> dict[str, Any]:
+    request = ExportTraceServiceRequest()
+    request.ParseFromString(body)
+
+    logs_by_run: dict[tuple[str, str, str | None], dict[str, list[Any]]] = {}
+    span_count = 0
+
+    for resource_spans in request.resource_spans:
+        resource_attrs = _attributes_to_dict(resource_spans.resource.attributes)
+        resolved_project = (
+            project
+            or resource_attrs.get("trackio.project")
+            or resource_attrs.get("project.name")
+            or DEFAULT_OTEL_PROJECT
+        )
+        resolved_run = (
+            run
+            or resource_attrs.get("trackio.run")
+            or resource_attrs.get("service.name")
+            or DEFAULT_OTEL_RUN
+        )
+        resolved_run_id = (
+            run_id
+            or resource_attrs.get("trackio.run_id")
+            or resource_attrs.get("service.instance.id")
+        )
+
+        for scope_spans in resource_spans.scope_spans:
+            scope_attrs = {
+                "name": scope_spans.scope.name,
+                "version": scope_spans.scope.version,
+                "attributes": _attributes_to_dict(scope_spans.scope.attributes),
+            }
+            for span in scope_spans.spans:
+                trace_id, payload, timestamp = _span_to_trace_payload(
+                    span,
+                    resource_attrs=resource_attrs,
+                    scope_attrs=scope_attrs,
+                )
+                key = (
+                    str(resolved_project),
+                    str(resolved_run),
+                    str(resolved_run_id) if resolved_run_id is not None else None,
+                )
+                if key not in logs_by_run:
+                    logs_by_run[key] = {
+                        "metrics": [],
+                        "steps": [],
+                        "timestamps": [],
+                        "log_ids": [],
+                    }
+                group = logs_by_run[key]
+                step = len(group["metrics"])
+                group["metrics"].append({"otel/span": payload})
+                group["steps"].append(step)
+                group["timestamps"].append(timestamp)
+                group["log_ids"].append(
+                    f"otel:{trace_id}:{_bytes_to_hex(span.span_id)}"
+                )
+                span_count += 1
+
+    for (project_name, run_name, run_id_value), group in logs_by_run.items():
+        SQLiteStorage.bulk_log(
+            project=project_name,
+            run=run_name,
+            run_id=run_id_value,
+            metrics_list=group["metrics"],
+            steps=group["steps"],
+            timestamps=group["timestamps"],
+            log_ids=group["log_ids"],
+            config={"_Source": "opentelemetry"},
+        )
+
+    return {
+        "accepted_spans": span_count,
+        "projects": sorted({key[0] for key in logs_by_run}),
+        "runs": sorted({key[1] for key in logs_by_run}),
+    }

--- a/trackio/server.py
+++ b/trackio/server.py
@@ -18,7 +18,7 @@ from urllib.parse import urlencode
 import httpx
 import huggingface_hub as hf
 from starlette.requests import Request
-from starlette.responses import RedirectResponse
+from starlette.responses import JSONResponse, RedirectResponse, Response
 from starlette.routing import Route
 
 import trackio.utils as utils
@@ -933,6 +933,39 @@ def force_sync() -> bool:
     return True
 
 
+async def otel_traces_handler(request: Request) -> Response:
+    hf_token = _authorization_bearer_token(request) if on_spaces() else None
+    try:
+        assert_can_write_metrics(request, hf_token)
+        from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import (  # noqa: PLC0415
+            ExportTraceServiceResponse,
+        )
+
+        from trackio.otel import ingest_otlp_trace_bytes  # noqa: PLC0415
+
+        result = ingest_otlp_trace_bytes(
+            await request.body(),
+            project=request.query_params.get("project"),
+            run=request.query_params.get("run"),
+            run_id=request.query_params.get("run_id"),
+        )
+        logger.info(
+            "otel: accepted %d spans into projects=%s runs=%s",
+            result["accepted_spans"],
+            result["projects"],
+            result["runs"],
+        )
+        return Response(
+            ExportTraceServiceResponse().SerializeToString(),
+            media_type="application/x-protobuf",
+        )
+    except TrackioAPIError as e:
+        return JSONResponse({"error": str(e)}, status_code=400)
+    except Exception as e:
+        logger.exception("otel: failed to ingest traces")
+        return JSONResponse({"error": str(e)}, status_code=400)
+
+
 CSS = ""
 HEAD = ""
 
@@ -1005,6 +1038,7 @@ def build_starlette_app_only(
                 UserWarning,
                 stacklevel=2,
             )
+    mcp_routes.append(Route("/otel/v1/traces", otel_traces_handler, methods=["POST"]))
     starlette_app = create_trackio_starlette_app(
         oauth_routes,
         _api_registry(),


### PR DESCRIPTION

<img width="1512" height="631" alt="image" src="https://github.com/user-attachments/assets/24ef70f0-40c8-4d51-a089-6baf09bee228" />


- add a minimal OTLP/HTTP protobuf receiver at /otel/v1/traces
- route spans into Trackio projects/runs using trackio.project, trackio.run, service.name, or query params
- convert incoming OTel/OpenInference spans into existing trackio.Trace log entries so the current Traces tab can display them
- document exporter setup, including smolagents + OpenInference
- add runnable examples for a manual OTLP span and a smolagents/OpenInference agent run

## V1 scope
This follows the MLflow/Weave pattern of supporting standard OTel ingestion instead of framework-specific integrations. V1 is traces-only, protobuf-only, and stores converted spans through the existing metrics/logs path. A dedicated spans table, gRPC receiver, richer trace tree UI, and additional semantic convention mappings can follow separately.

## Tests
- python -m ruff check examples/otel-basic-mvp.py examples/otel-smolagents-integration.py trackio/otel.py trackio/server.py tests/unit/test_otel_ingest.py
- python -m pytest tests/unit/test_otel_ingest.py
- python -m pytest tests/unit/test_otel_ingest.py tests/unit/test_gradio_api_spaces.py tests/unit/test_sqlite_storage.py
- started a local Trackio Starlette/uvicorn server, ran examples/otel-basic-mvp.py and examples/otel-smolagents-integration.py against /otel/v1/traces, and confirmed SQLite stored 1 basic trace plus 3 smolagents spans (FinalAnswerTool, Step 1, CodeAgent.run)