### PR TITLE
Update MCP docs to fix server URL, tool list, and other small fixes

### DIFF
--- a/docs/source/api_mcp_server.md
+++ b/docs/source/api_mcp_server.md
@@ -1,10 +1,14 @@
 # Trackio as an API and MCP Server
 
-The Trackio dashboard can be configured to run as both an API server and an MCP (Model Context Protocol) server, allowing external tools and applications to programmatically interact with your experiment tracking data, or for you to be able to "chat with your experiment data" in natural language using ChatGPT, Claude, Deepseek, or various LLMs that support MCPs. This makes Trackio an ideal choice for LLM agents running autonomous ML experiments, as they can seamlessly log metrics and query experiment results.
+The Trackio dashboard can be configured to run as both an HTTP API server and an MCP (Model Context Protocol) server, allowing external tools and applications to programmatically interact with your experiment tracking data, or for you to be able to "chat with your experiment data" in natural language using ChatGPT, Claude, Deepseek, or various LLMs that support MCPs. This makes Trackio an ideal choice for LLM agents running autonomous ML experiments, as they can seamlessly log metrics and query experiment results.
 
 ## Setup
 
-To enable API/MCP usage, start the MCP server when you launch the Trackio dashboard. You can do this a few different ways:
+Install the optional MCP dependency, then enable the MCP server when launching the Trackio dashboard. You can do this a few different ways:
+
+```bash
+pip install "trackio[mcp]"
+```
 
 ### Option 1: CLI Command
 ```bash
@@ -23,168 +27,80 @@ export GRADIO_MCP_SERVER=True
 trackio show
 ```
 
-When MCP server mode is enabled, Trackio will:
-- Enable the Gradio API endpoints
-- Start an MCP server alongside the web dashboard
-- Allow programmatic access to writing and reading experiment data 
+When MCP server mode is enabled, Trackio:
+- Mounts a streamable-HTTP MCP server alongside the dashboard
+- Exposes read-only project/run/metric inspection tools to MCP clients
+- Exposes a small set of mutation tools (delete/rename/sync) gated by a write token
 
 ## API Usage
 
-Once your Trackio server is running in MCP mode, click on the **"Use via API or MCP"** link in the footer of the dashboard to see the complete API documentation with exact usage examples for all endpoints.
-
-Here is example usage in Python, JS, Bash, and via MCP.
+Trackio exposes each MCP tool as a plain HTTP endpoint at `POST /api/{tool_name}`. The body is JSON; pass arguments as `{"kwargs": {...}}`, `{"args": [...]}`, or simply as a flat `{"name": value}` object.
 
 <hfoptions id="api-mcp-server">
 <hfoption id="Python">
 
-Using the [Gradio Python Client](https://www.gradio.app/guides/getting-started-with-the-python-client).
-
 ```python
-from gradio_client import Client
+import httpx
 
-# Connect to your Trackio instance
-client = Client("http://127.0.0.1:7860/")
+base = "http://127.0.0.1:7860"
 
-# Get all projects
-result = client.predict(api_name="/get_all_projects")
-print("Projects:", result)
+projects = httpx.post(f"{base}/api/get_all_projects").json()["data"]
+print("Projects:", projects)
 
-# Get runs for a specific project
-result = client.predict(
-    project="my-project",
-    api_name="/get_runs_for_project"
-)
-print("Runs:", result)
+runs = httpx.post(
+    f"{base}/api/get_runs_for_project",
+    json={"project": "my-project"},
+).json()["data"]
+print("Runs:", runs)
 
-# Get metrics for a specific run
-result = client.predict(
-    project="my-project",
-    run="run-1",
-    api_name="/get_metrics_for_run"
-)
-print("Metrics:", result)
-
-# Get metric values over time
-result = client.predict(
-    project="my-project",
-    run="run-1",
-    metric_name="loss",
-    api_name="/get_metric_values"
-)
-print("Loss values:", result)
-
-# Get project summary
-result = client.predict(
-    project="my-project",
-    api_name="/get_project_summary"
-)
-print("Project summary:", result)
-
-# Get run summary
-result = client.predict(
-    project="my-project",
-    run="run-1",
-    api_name="/get_run_summary"
-)
-print("Run summary:", result)
+values = httpx.post(
+    f"{base}/api/get_metric_values",
+    json={"project": "my-project", "run": "run-1", "metric_name": "loss"},
+).json()["data"]
+print("Loss values:", values)
 ```
 
 </hfoption>
 <hfoption id="JavaScript">
 
-Using the [Gradio JS Client](https://www.gradio.app/guides/getting-started-with-the-js-client).
-
 ```javascript
-import { Client } from "@gradio/client";
+const base = "http://127.0.0.1:7860";
 
-const client = await Client.connect("http://127.0.0.1:7860/");
+async function call(name, payload = {}) {
+  const res = await fetch(`${base}/api/${name}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+  return (await res.json()).data;
+}
 
-// Get all projects
-const result = await client.predict("/get_all_projects", {});
-console.log("Projects:", result.data);
-
-// Get runs for a project
-const result = await client.predict("/get_runs_for_project", {
-    project: "my-project"
-});
-console.log("Runs:", result.data);
-
-// Get metrics for a run
-const result = await client.predict("/get_metrics_for_run", {
-    project: "my-project",
-    run: "run-1"
-});
-console.log("Metrics:", result.data);
-
-// Get metric values
-const result = await client.predict("/get_metric_values", {
-    project: "my-project",
-    run: "run-1",
-    metric_name: "loss"
-});
-console.log("Values:", result.data);
-
-// Get project summary
-const result = await client.predict("/get_project_summary", {
-    project: "my-project"
-});
-console.log("Project summary:", result.data);
-
-// Get run summary
-const result = await client.predict("/get_run_summary", {
-    project: "my-project",
-    run: "run-1"
-});
-console.log("Run summary:", result.data);
+console.log("Projects:", await call("get_all_projects"));
+console.log("Runs:", await call("get_runs_for_project", { project: "my-project" }));
+console.log("Loss:", await call("get_metric_values", {
+  project: "my-project",
+  run: "run-1",
+  metric_name: "loss",
+}));
 ```
 
 </hfoption>
 <hfoption id="Bash">
 
-Using standard `curl` commands.
-
 ```bash
 # Get all projects
-curl -X POST http://127.0.0.1:7860/gradio_api/call/get_all_projects -s -H "Content-Type: application/json" -d '{
-    "data": []
-}' \
-| awk -F'"' '{ print $4}' \
-| read EVENT_ID; curl -N http://127.0.0.1:7860/gradio_api/call/get_all_projects/$EVENT_ID
+curl -s -X POST http://127.0.0.1:7860/api/get_all_projects \
+  -H "Content-Type: application/json" -d '{}'
 
 # Get runs for a project
-curl -X POST http://127.0.0.1:7860/gradio_api/call/get_runs_for_project -s -H "Content-Type: application/json" -d '{
-    "data": ["my-project"]
-}' \
-| awk -F'"' '{ print $4}' \
-| read EVENT_ID; curl -N http://127.0.0.1:7860/gradio_api/call/get_runs_for_project/$EVENT_ID
+curl -s -X POST http://127.0.0.1:7860/api/get_runs_for_project \
+  -H "Content-Type: application/json" \
+  -d '{"project": "my-project"}'
 
-# Get metrics for a run
-curl -X POST http://127.0.0.1:7860/gradio_api/call/get_metrics_for_run -s -H "Content-Type: application/json" -d '{
-    "data": ["my-project", "run-1"]
-}' \
-| awk -F'"' '{ print $4}' \
-| read EVENT_ID; curl -N http://127.0.0.1:7860/gradio_api/call/get_metrics_for_run/$EVENT_ID
-
-# Get metric values
-curl -X POST http://127.0.0.1:7860/gradio_api/call/get_metric_values -s -H "Content-Type: application/json" -d '{
-    "data": ["my-project", "run-1", "loss"]
-}' \
-| awk -F'"' '{ print $4}' \
-| read EVENT_ID; curl -N http://127.0.0.1:7860/gradio_api/call/get_metric_values/$EVENT_ID
-
-# Get project summary
-curl -X POST http://127.0.0.1:7860/gradio_api/call/get_project_summary -s -H "Content-Type: application/json" -d '{
-    "data": ["my-project"]
-}' \
-| awk -F'"' '{ print $4}' \
-| read EVENT_ID; curl -N http://127.0.0.1:7860/gradio_api/call/get_project_summary/$EVENT_ID
-
-# Get run summary
-curl -X POST http://127.0.0.1:7860/gradio_api/call/get_run_summary -s -H "Content-Type: application/json" -d '{
-    "data": ["my-project", "run-1"]
-}' \
-| awk -F'"' '{ print $4}' \
-| read EVENT_ID; curl -N http://127.0.0.1:7860/gradio_api/call/get_run_summary/$EVENT_ID
+# Get values for a metric
+curl -s -X POST http://127.0.0.1:7860/api/get_metric_values \
+  -H "Content-Type: application/json" \
+  -d '{"project": "my-project", "run": "run-1", "metric_name": "loss"}'
 ```
 
 </hfoption>
@@ -192,55 +108,62 @@ curl -X POST http://127.0.0.1:7860/gradio_api/call/get_run_summary -s -H "Conten
 
 ## MCP Usage
 
-When running as an MCP server, Trackio exposes its API endpoints as MCP tools that can be used by MCP-compatible clients like Claude Code.
+When running as an MCP server, Trackio exposes its tools at a single streamable-HTTP endpoint that MCP-compatible clients (Claude Desktop, Claude Code, etc.) can connect to.
 
 ### MCP Server URL
 
-The MCP server, using Streamble HTTP, is available (by default) at:
+The MCP server is available at:
 ```txt
-http://127.0.0.1:7860/gradio_api/mcp/
+http://127.0.0.1:7860/mcp/
 ```
+
+When deployed to a Hugging Face Space, the URL is `https://<your-space>.hf.space/mcp/`.
 
 ### Available MCP Tools
 
-The main tools that are available when Trackio is running in MCP server mode are:
+Read tools:
 
-1. **get_all_projects** - Get all project names. Returns a list of project names.
-2. **get_runs_for_project** - Get all runs for a given project. Returns a list of run names.
-3. **get_metrics_for_run** - Get all metrics for a given project and run. Returns a list of metric names.
-4. **get_metric_values** - Get all values for a specific metric in a project/run. Returns a list of dictionaries with timestamp, step, and value.
-5. **get_project_summary** - Get a summary of a project including number of runs and recent activity. Returns: Dictionary with project summary information.
-6. **get_run_summary** - Get a summary of a specific run including metrics and configuration. Returns: Dictionary with run summary information.
-7. **bulk_log** - Log metrics data to Trackio. Each entry is a dictionary with project, run, metrics, and optionally step and config.
-8. **upload_db_to_space** - Upload database file to Hugging Face Space. Requires file upload capability.
-9. **bulk_upload_media** - Upload media files for experiments. Requires file upload capability.
+1. **get_all_projects** – List all Trackio projects on this server.
+2. **get_runs_for_project** – List runs for a given project.
+3. **get_metrics_for_run** – List metric names recorded for a run.
+4. **get_metric_values** – Fetch metric values for a run, optionally around a step or time.
+5. **get_project_summary** – Summary metadata for a project.
+6. **get_run_summary** – Summary metadata for a run.
+7. **get_system_metrics_for_run** – List system metric names recorded for a run.
+8. **get_system_logs** – Fetch system metric logs for a run.
+9. **get_snapshot** – Fetch a single snapshot around a step or timestamp.
+10. **get_logs** – Fetch metric logs for a run.
+11. **get_alerts** – Fetch alerts for a project, optionally filtered by run or level.
+12. **get_settings** – Return dashboard settings and asset configuration.
+
+Mutation tools (require write access — see below):
+
+13. **delete_run** – Delete a run.
+14. **rename_run** – Rename a run.
+15. **trigger_sync** – Trigger an export/sync pass to Hugging Face.
+
+### Write Access for Mutation Tools
+
+Mutation tools are gated:
+
+- **Local dashboard:** pass the `write_token` argument. The token is printed in the terminal when you run `trackio show` (it's also embedded as `?write_token=...` in the dashboard URL printed at startup). For example:
+  ```json
+  {"project": "my-project", "run": "run-1", "write_token": "<token from startup output>"}
+  ```
+- **Hugging Face Spaces:** pass an `hf_token` argument with write access to the Space's repo. The local `write_token` is not used in this case.
+
+Read tools never require a token.
 
 ### MCP Client Configuration
 
-To add this MCP server to clients that support Streamable HTTP, add the following configuration to your MCP config:
+To add Trackio to clients that support streamable-HTTP MCP servers, use a config like:
 
 ```json
 {
   "mcpServers": {
-    "gradio": {
-      "url": "http://127.0.0.1:7860/gradio_api/mcp/"
-    },
-    "upload_files_to_gradio": {
-      "command": "uvx",
-      "args": [
-        "--from",
-        "gradio[mcp]",
-        "gradio",
-        "upload-mcp",
-        "http://127.0.0.1:7860/gradio_api/mcp/",
-        "<UPLOAD_DIRECTORY>"
-      ]
+    "trackio": {
+      "url": "http://127.0.0.1:7860/mcp/"
     }
   }
 }
 ```
-
-The `upload_files_to_gradio` tool uploads files from your local UPLOAD_DIRECTORY to the Gradio app, which is needed for file-based operations. This tool requires `uv` to be installed. You can omit this tool if you are not planning on using the file-based tools.
-
-
-


### PR DESCRIPTION
Fixes #542.

The Gradio backend was removed, but the MCP docs still pointed users at the old `/gradio_api/mcp/` mount (which 404s) and listed tools that no longer exist. The MCP server itself is fine — it's mounted at `/mcp/` via `trackio/mcp_setup.py` and responds correctly to `initialize` / `tools/list`.

## Summary

- Change the documented MCP URL from `http://127.0.0.1:7860/gradio_api/mcp/` to `http://127.0.0.1:7860/mcp/`.
- Replace the stale tool list (`bulk_log`, `upload_db_to_space`, `bulk_upload_media`) with the actual tools registered in `mcp_setup.py` (the `get_*` read tools plus `delete_run`, `rename_run`, `trigger_sync`).
- Document the `write_token` (local) / `hf_token` (Spaces) requirement for mutation tools — this was the specific confusion in #542.
- Replace the dead `gradio_client` / `/gradio_api/call/...` examples with `POST /api/{name}` examples (Python via `httpx`, JS via `fetch`, and `curl`).
- Drop the `upload_files_to_gradio` uvx snippet — no file-upload MCP tools exist anymore.
- Add the `pip install "trackio[mcp]"` step.
