### PR TITLE
fix: keep sparse metrics sparse through smoothing

### DIFF
--- a/.changeset/free-jeans-make.md
+++ b/.changeset/free-jeans-make.md
@@ -1,0 +1,5 @@
+---
+"trackio": minor
+---
+
+feat:fix: keep sparse metrics sparse through smoothing

--- a/trackio/frontend/src/lib/dataProcessing.js
+++ b/trackio/frontend/src/lib/dataProcessing.js
@@ -100,6 +100,7 @@ function smoothData(rows, cols, windowSize) {
   return rows.map((row, i) => {
     const smoothed = { ...row };
     cols.forEach((col) => {
+      if (row[col] == null || typeof row[col] !== "number") return;
       const start = Math.max(0, i - half);
       const end = Math.min(rows.length, i + half + 1);
       let sum = 0;

--- a/trackio/frontend/src/lib/dataProcessing.test.js
+++ b/trackio/frontend/src/lib/dataProcessing.test.js
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "vitest";
+import { computeMetricPlotData, processRunData } from "./dataProcessing.js";
+
+describe("processRunData smoothing", () => {
+  test("does not fabricate values for rows that did not log the metric", () => {
+    const logs = [
+      { step: 0, "train/loss": 1.0 },
+      { step: 0, "train/loss": 1.1 },
+      { step: 0, "train/loss": 0.9 },
+      { step: 0, epoch: 0, "train/avg_loss": 1.0 },
+      { step: 1, "train/loss": 0.8 },
+      { step: 1, "train/loss": 0.7 },
+      { step: 1, "train/loss": 0.75 },
+      { step: 1, epoch: 1, "train/avg_loss": 0.75 },
+    ];
+
+    const { rows } = processRunData(logs, "run-1", 10, "step", false, false);
+
+    const epochSmoothed = rows.filter(
+      (r) => r.data_type === "smoothed" && r.epoch != null,
+    );
+    expect(epochSmoothed.length).toBe(2);
+    expect(epochSmoothed.map((r) => r.step).sort()).toEqual([0, 1]);
+  });
+
+  test("computeMetricPlotData returns one point per logged epoch", () => {
+    const logs = [
+      { step: 0, "train/loss": 1.0 },
+      { step: 0, "train/loss": 1.1 },
+      { step: 0, epoch: 0 },
+      { step: 1, "train/loss": 0.8 },
+      { step: 1, "train/loss": 0.7 },
+      { step: 1, epoch: 1 },
+      { step: 2, "train/loss": 0.6 },
+      { step: 2, epoch: 2 },
+    ];
+    const { rows } = processRunData(logs, "run-1", 10, "step", false, false);
+    const { data } = computeMetricPlotData(rows, "step", "epoch", null);
+    const originals = data.filter((r) => r.data_type === "original");
+    const smoothed = data.filter((r) => r.data_type === "smoothed");
+    expect(originals.length).toBe(3);
+    expect(smoothed.length).toBe(3);
+  });
+
+  test("dense metrics are still smoothed across all rows", () => {
+    const logs = [
+      { step: 0, loss: 1.0 },
+      { step: 1, loss: 0.9 },
+      { step: 2, loss: 0.8 },
+      { step: 3, loss: 0.7 },
+      { step: 4, loss: 0.6 },
+    ];
+    const { rows } = processRunData(logs, "run-1", 3, "step", false, false);
+    const smoothed = rows.filter((r) => r.data_type === "smoothed");
+    expect(smoothed.length).toBe(5);
+    expect(smoothed.every((r) => typeof r.loss === "number")).toBe(true);
+  });
+});


### PR DESCRIPTION
Fixes #543.

`smoothData` ran a centered moving-window average over *every* row of a run for *every* numeric metric, and wrote the result back unconditionally. For metrics that are logged only on some rows (e.g. an `epoch` counter logged once per epoch alongside many per-batch `train/loss` rows), this densified the column to one value per log row.

Downstream, `computeMetricPlotData` filters by `r[metric] != null` to pick the points for a metric's chart. With smoothing densifying the column, every row passed the filter — so the chart got many duplicate-x points per step, which Vega renders as a vertical zig-zag that visually reads as a filled rectangle.

The fix: in `smoothData`, skip rows that didn't originally have a numeric value for the metric being smoothed. Sparsity survives, the null-filter still works, and dense metrics behave identically to before.

## Summary

- `trackio/frontend/src/lib/dataProcessing.js`: guard the per-metric smoothing assignment on the original row having a numeric value for that metric.
- `trackio/frontend/src/lib/dataProcessing.test.js`: new tests covering the sparse-metric case from #543 and a dense-metric regression check.

## Test plan

- [x] `npm test` in `trackio/frontend/` — all 16 tests pass, including the 3 new ones.
- [x] `npm run build` — production build succeeds.
- [ ] Reproduce #543's loop locally and confirm the `epoch` chart renders as a line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)