### PR TITLE
feature: add "group by" dropdown to sidebar

### DIFF
--- a/.changeset/loose-loops-obey.md
+++ b/.changeset/loose-loops-obey.md
@@ -2,4 +2,4 @@
 "trackio": minor
 ---
 
-feat:feature: add "group by" dropdown to sidebar
+feat: add "group by" dropdown to sidebar

--- a/.changeset/loose-loops-obey.md
+++ b/.changeset/loose-loops-obey.md
@@ -2,4 +2,4 @@
 "trackio": minor
 ---
 
-feat:Feature/run grouping
+feat:add "group by" dropdown to sidebar

--- a/.changeset/loose-loops-obey.md
+++ b/.changeset/loose-loops-obey.md
@@ -1,0 +1,5 @@
+---
+"trackio": minor
+---
+
+feat:Feature/run grouping

--- a/.changeset/loose-loops-obey.md
+++ b/.changeset/loose-loops-obey.md
@@ -2,4 +2,4 @@
 "trackio": minor
 ---
 
-feat:add "group by" dropdown to sidebar
+feat:feature: add "group by" dropdown to sidebar

--- a/tests/unit/test_local_server_api.py
+++ b/tests/unit/test_local_server_api.py
@@ -100,6 +100,54 @@ def test_local_dashboard_supports_remote_client(temp_dir):
         app.close()
 
 
+def test_get_run_configs_returns_config_per_run(temp_dir):
+    project = "test_run_configs"
+
+    trackio.init(
+        project=project,
+        name="run-a",
+        config={"lr": 0.01, "model": "resnet"},
+        group="exp-1",
+    )
+    trackio.log(metrics={"loss": 0.1})
+    trackio.finish()
+
+    trackio.init(
+        project=project,
+        name="run-b",
+        config={"lr": 0.02, "model": "vit"},
+    )
+    trackio.log(metrics={"loss": 0.2})
+    trackio.finish()
+
+    app, url, _, _ = trackio.show(block_thread=False, open_browser=False)
+
+    try:
+        client = Client(url, verbose=False)
+        configs = client.predict(project, api_name="/get_run_configs")
+
+        assert set(configs.keys()) == {"run-a", "run-b"}
+        assert configs["run-a"]["lr"] == 0.01
+        assert configs["run-a"]["model"] == "resnet"
+        assert configs["run-a"]["_Group"] == "exp-1"
+        assert configs["run-b"]["lr"] == 0.02
+        assert configs["run-b"]["model"] == "vit"
+    finally:
+        trackio.delete_project(project, force=True)
+        app.close()
+
+
+def test_get_run_configs_returns_empty_for_unknown_project(temp_dir):
+    app, url, _, _ = trackio.show(block_thread=False, open_browser=False)
+
+    try:
+        client = Client(url, verbose=False)
+        configs = client.predict("no_such_project", api_name="/get_run_configs")
+        assert configs == {}
+    finally:
+        app.close()
+
+
 def test_server_url_logs_to_self_hosted_server(temp_dir):
     project = "test_self_hosted"
     run_name = "self-hosted-run"

--- a/tests/unit/test_local_server_api.py
+++ b/tests/unit/test_local_server_api.py
@@ -103,20 +103,22 @@ def test_local_dashboard_supports_remote_client(temp_dir):
 def test_get_run_configs_returns_config_per_run(temp_dir):
     project = "test_run_configs"
 
-    trackio.init(
+    run_a = trackio.init(
         project=project,
         name="run-a",
         config={"lr": 0.01, "model": "resnet"},
         group="exp-1",
     )
+    run_a_id = run_a.id
     trackio.log(metrics={"loss": 0.1})
     trackio.finish()
 
-    trackio.init(
+    run_b = trackio.init(
         project=project,
         name="run-b",
         config={"lr": 0.02, "model": "vit"},
     )
+    run_b_id = run_b.id
     trackio.log(metrics={"loss": 0.2})
     trackio.finish()
 
@@ -126,12 +128,12 @@ def test_get_run_configs_returns_config_per_run(temp_dir):
         client = Client(url, verbose=False)
         configs = client.predict(project, api_name="/get_run_configs")
 
-        assert set(configs.keys()) == {"run-a", "run-b"}
-        assert configs["run-a"]["lr"] == 0.01
-        assert configs["run-a"]["model"] == "resnet"
-        assert configs["run-a"]["_Group"] == "exp-1"
-        assert configs["run-b"]["lr"] == 0.02
-        assert configs["run-b"]["model"] == "vit"
+        assert set(configs.keys()) == {run_a_id, run_b_id}
+        assert configs[run_a_id]["lr"] == 0.01
+        assert configs[run_a_id]["model"] == "resnet"
+        assert configs[run_a_id]["_Group"] == "exp-1"
+        assert configs[run_b_id]["lr"] == 0.02
+        assert configs[run_b_id]["model"] == "vit"
     finally:
         trackio.delete_project(project, force=True)
         app.close()

--- a/trackio/frontend/src/App.svelte
+++ b/trackio/frontend/src/App.svelte
@@ -14,6 +14,7 @@
   import {
     getAllProjects,
     getRunsForProject,
+    getRunConfigs,
     getAlerts,
     getRunMutationStatus,
     getSettings,
@@ -88,6 +89,7 @@
   let spaceId = $state(null);
   let availableSystemDevices = $state([]);
   let selectedSystemDevices = $state([]);
+  let runConfigs = $state({});
 
   function runKey(run) {
     return run?.id ?? run?.name;
@@ -140,10 +142,14 @@
       selectedRuns = [];
       availableSystemDevices = [];
       selectedSystemDevices = [];
+      runConfigs = {};
       return;
     }
     try {
-      const data = await getRunsForProject(selectedProject);
+      const [data, configs] = await Promise.all([
+        getRunsForProject(selectedProject),
+        getRunConfigs(selectedProject).catch(() => ({})),
+      ]);
       const newRuns = [...(data || [])].reverse();
 
       if (JSON.stringify(runs) !== JSON.stringify(newRuns)) {
@@ -156,6 +162,7 @@
           prevOrdered,
         );
       }
+      runConfigs = configs || {};
     } catch (e) {
       console.error("Failed to load runs:", e);
     }
@@ -401,6 +408,7 @@
       projectLocked={projectLocked}
       bind:selectedProject
       {runs}
+      {runConfigs}
       bind:selectedRuns
       bind:smoothing
       bind:xAxis

--- a/trackio/frontend/src/App.svelte
+++ b/trackio/frontend/src/App.svelte
@@ -138,7 +138,8 @@
   }
 
   async function refreshRuns() {
-    if (!selectedProject) {
+    const project = selectedProject;
+    if (!project) {
       runs = [];
       selectedRuns = [];
       availableSystemDevices = [];
@@ -147,14 +148,15 @@
       runConfigsProject = null;
       return;
     }
-    if (selectedProject !== runConfigsProject) {
+    if (project !== runConfigsProject) {
       runConfigs = {};
     }
     try {
       const [data, configs] = await Promise.all([
-        getRunsForProject(selectedProject),
-        getRunConfigs(selectedProject).catch(() => null),
+        getRunsForProject(project),
+        getRunConfigs(project).catch(() => null),
       ]);
+      if (selectedProject !== project) return;
       const newRuns = [...(data || [])].reverse();
 
       if (JSON.stringify(runs) !== JSON.stringify(newRuns)) {
@@ -169,7 +171,7 @@
       }
       if (configs != null) {
         runConfigs = configs;
-        runConfigsProject = selectedProject;
+        runConfigsProject = project;
       }
     } catch (e) {
       console.error("Failed to load runs:", e);

--- a/trackio/frontend/src/App.svelte
+++ b/trackio/frontend/src/App.svelte
@@ -148,7 +148,7 @@
     try {
       const [data, configs] = await Promise.all([
         getRunsForProject(selectedProject),
-        getRunConfigs(selectedProject).catch(() => ({})),
+        getRunConfigs(selectedProject).catch(() => null),
       ]);
       const newRuns = [...(data || [])].reverse();
 
@@ -162,7 +162,7 @@
           prevOrdered,
         );
       }
-      runConfigs = configs || {};
+      if (configs != null) runConfigs = configs;
     } catch (e) {
       console.error("Failed to load runs:", e);
     }

--- a/trackio/frontend/src/App.svelte
+++ b/trackio/frontend/src/App.svelte
@@ -90,6 +90,7 @@
   let availableSystemDevices = $state([]);
   let selectedSystemDevices = $state([]);
   let runConfigs = $state({});
+  let runConfigsProject = $state(null);
 
   function runKey(run) {
     return run?.id ?? run?.name;
@@ -143,7 +144,11 @@
       availableSystemDevices = [];
       selectedSystemDevices = [];
       runConfigs = {};
+      runConfigsProject = null;
       return;
+    }
+    if (selectedProject !== runConfigsProject) {
+      runConfigs = {};
     }
     try {
       const [data, configs] = await Promise.all([
@@ -162,7 +167,10 @@
           prevOrdered,
         );
       }
-      if (configs != null) runConfigs = configs;
+      if (configs != null) {
+        runConfigs = configs;
+        runConfigsProject = selectedProject;
+      }
     } catch (e) {
       console.error("Failed to load runs:", e);
     }

--- a/trackio/frontend/src/components/Dropdown.svelte
+++ b/trackio/frontend/src/components/Dropdown.svelte
@@ -20,34 +20,41 @@
   let bottom = $state(null);
   let maxHeight = $state(300);
 
+  let normalizedChoices = $derived(
+    choices.map((c) =>
+      typeof c === "object" && c !== null ? c : { label: String(c), value: c },
+    ),
+  );
+
   let selectedIndex = $derived(
-    value !== null ? choices.indexOf(value) : -1,
+    value !== null ? normalizedChoices.findIndex((c) => c.value === value) : -1,
   );
 
   $effect(() => {
     if (showOptions) return;
-    if (value !== null && choices.includes(value)) {
-      inputText = value;
+    const idx = normalizedChoices.findIndex((c) => c.value === value);
+    if (value !== null && idx >= 0) {
+      inputText = normalizedChoices[idx].label;
     } else {
       inputText = "";
     }
   });
 
   $effect(() => {
-    filteredIndices = showOptions ? filterChoices(inputText) : choices.map((_, i) => i);
+    filteredIndices = showOptions ? filterChoices(inputText) : normalizedChoices.map((_, i) => i);
   });
 
   function filterChoices(text) {
-    if (!text) return choices.map((_, i) => i);
+    if (!text) return normalizedChoices.map((_, i) => i);
     const lower = text.toLowerCase();
-    return choices
-      .map((c, i) => (c.toLowerCase().includes(lower) ? i : -1))
+    return normalizedChoices
+      .map((c, i) => (c.label.toLowerCase().includes(lower) ? i : -1))
       .filter((i) => i >= 0);
   }
 
   function handleFocus() {
     inputText = "";
-    filteredIndices = choices.map((_, i) => i);
+    filteredIndices = normalizedChoices.map((_, i) => i);
     showOptions = true;
     if (filterInput) {
       const rect = filterInput.closest(".wrap")?.getBoundingClientRect();
@@ -69,23 +76,25 @@
   }
 
   function handleBlur() {
-    if (choices.includes(inputText)) {
-      value = inputText;
+    const matchIdx = normalizedChoices.findIndex((c) => c.label === inputText);
+    if (matchIdx >= 0) {
+      value = normalizedChoices[matchIdx].value;
     } else if (value !== null) {
-      inputText = value;
+      const currentIdx = normalizedChoices.findIndex((c) => c.value === value);
+      inputText = currentIdx >= 0 ? normalizedChoices[currentIdx].label : "";
     } else {
       inputText = "";
     }
     showOptions = false;
     activeIndex = null;
-    filteredIndices = choices.map((_, i) => i);
+    filteredIndices = normalizedChoices.map((_, i) => i);
   }
 
   function handleOptionSelected(index) {
     const idx = parseInt(index);
     if (isNaN(idx)) return;
-    value = choices[idx];
-    inputText = choices[idx];
+    value = normalizedChoices[idx].value;
+    inputText = normalizedChoices[idx].label;
     showOptions = false;
     activeIndex = null;
     filterInput?.blur();
@@ -183,7 +192,7 @@
             aria-selected={index === selectedIndex}
           >
             <span class="check-mark" class:hide={index !== selectedIndex}>✓</span>
-            {choices[index]}
+            {normalizedChoices[index].label}
           </li>
         {/each}
       </ul>

--- a/trackio/frontend/src/components/Sidebar.svelte
+++ b/trackio/frontend/src/components/Sidebar.svelte
@@ -98,6 +98,12 @@
     groupByRaw = "None";
   });
 
+  $effect(() => {
+    if (!groupByOptions.includes(groupByRaw)) {
+      groupByRaw = "None";
+    }
+  });
+
 
   let groupByOptions = $derived(computeGroupByOptions(runConfigs));
   let groupedRuns = $derived(computeGroupedRuns(filteredRuns, runConfigs, groupByField));

--- a/trackio/frontend/src/components/Sidebar.svelte
+++ b/trackio/frontend/src/components/Sidebar.svelte
@@ -400,16 +400,14 @@
             placeholder="Type to filter..."
             showLabel={false}
           />
-          {#if groupByOptions.length > 1}
-            <div class="group-by-row">
-              <Dropdown
-                label="Group by"
-                choices={groupByOptions}
-                bind:value={groupByRaw}
-                filterable={false}
-              />
-            </div>
-          {/if}
+          <div class="group-by-row">
+            <Dropdown
+              label="Group by"
+              choices={groupByOptions}
+              bind:value={groupByRaw}
+              filterable={false}
+            />
+          </div>
           {#if groupedRuns}
             <div class="grouped-runs">
               {#each [...groupedRuns.entries()] as [groupLabel, groupRunList]}

--- a/trackio/frontend/src/components/Sidebar.svelte
+++ b/trackio/frontend/src/components/Sidebar.svelte
@@ -8,6 +8,7 @@
   import { buildColorMap, getColorForIndex } from "../lib/stores.js";
   import { latestOnlySelection } from "../lib/selection.js";
   import { filterMetricsByRegex } from "../lib/dataProcessing.js";
+  import Accordion from "./Accordion.svelte";
 
   let {
     open = $bindable(true),
@@ -27,6 +28,7 @@
     realtimeEnabled = $bindable(true),
     showHeaders = $bindable(true),
     filterText = $bindable(""),
+    runConfigs = {},
     metricColumns = [],
     spacesMode = false,
     runMutationAllowed = true,
@@ -87,6 +89,40 @@
 
   let runColorMap = $derived(buildColorMap(runs));
   let filteredRunIds = $derived(filteredRuns.map((r) => r.id ?? r.name));
+
+  let groupByRaw = $state("None");
+  let groupByField = $derived(groupByRaw === "None" ? null : groupByRaw);
+
+  $effect(() => {
+    selectedProject;
+    groupByRaw = "None";
+  });
+
+
+  let groupByOptions = $derived.by(() => {
+    const keys = new Set();
+    for (const cfg of Object.values(runConfigs)) {
+      if (cfg && typeof cfg === "object") {
+        for (const key of Object.keys(cfg)) {
+          if (cfg[key] !== null && cfg[key] !== undefined) keys.add(key);
+        }
+      }
+    }
+    return ["None", ...Array.from(keys).sort()];
+  });
+
+  let groupedRuns = $derived.by(() => {
+    if (!groupByField) return null;
+    const groups = new Map();
+    for (const run of filteredRuns) {
+      const cfg = runConfigs[run.name] ?? {};
+      const raw = cfg[groupByField];
+      const label = raw === null || raw === undefined ? "(unset)" : String(raw);
+      if (!groups.has(label)) groups.set(label, []);
+      groups.get(label).push(run);
+    }
+    return groups;
+  });
 
   let latestOnly = $state(false);
   let shareTab = $state("share");
@@ -380,18 +416,72 @@
             placeholder="Type to filter..."
             showLabel={false}
           />
-          <div class="checkbox-list">
-            <ColoredCheckbox
-              choices={filteredRuns}
-              bind:selected={selectedRuns}
-              getKey={(run) => run.id ?? run.name}
-              getLabel={(run) => run.name}
-              colors={filteredRuns.map(
-              (r) => runColorMap[r.id ?? r.name] ?? getColorForIndex(Math.max(0, runs.indexOf(r))),
-            )}
-              ontoggle={() => { latestOnly = false; }}
-            />
-          </div>
+          {#if groupByOptions.length > 1}
+            <div class="group-by-row">
+              <Dropdown
+                label="Group by"
+                choices={groupByOptions}
+                bind:value={groupByRaw}
+                filterable={false}
+              />
+            </div>
+          {/if}
+          {#if groupedRuns}
+            <div class="grouped-runs">
+              {#each [...groupedRuns.entries()] as [groupLabel, groupRunList]}
+                {@const groupIds = groupRunList.map((r) => r.id ?? r.name)}
+                {@const groupSelected = groupIds.filter((id) => selectedRuns.includes(id))}
+                <div class="run-group-section">
+                  <div class="run-group-header">
+                    <label class="select-all-label">
+                      <input
+                        type="checkbox"
+                        class="select-all-cb"
+                        checked={groupSelected.length === groupIds.length && groupIds.length > 0}
+                        use:setIndeterminate={groupSelected.length > 0 && groupSelected.length < groupIds.length}
+                        onchange={() => {
+                          if (groupSelected.length === groupIds.length) {
+                            selectedRuns = selectedRuns.filter((id) => !groupIds.includes(id));
+                          } else {
+                            const toAdd = groupIds.filter((id) => !selectedRuns.includes(id));
+                            selectedRuns = [...selectedRuns, ...toAdd];
+                          }
+                          latestOnly = false;
+                        }}
+                      />
+                      <span class="run-group-label" title={groupLabel}>{groupLabel}</span>
+                      <span class="run-group-count">({groupRunList.length})</span>
+                    </label>
+                  </div>
+                  <div class="checkbox-list group-checkbox-list">
+                    <ColoredCheckbox
+                      choices={groupRunList}
+                      bind:selected={selectedRuns}
+                      getKey={(run) => run.id ?? run.name}
+                      getLabel={(run) => run.name}
+                      colors={groupRunList.map(
+                        (r) => runColorMap[r.id ?? r.name] ?? getColorForIndex(Math.max(0, runs.indexOf(r))),
+                      )}
+                      ontoggle={() => { latestOnly = false; }}
+                    />
+                  </div>
+                </div>
+              {/each}
+            </div>
+          {:else}
+            <div class="checkbox-list">
+              <ColoredCheckbox
+                choices={filteredRuns}
+                bind:selected={selectedRuns}
+                getKey={(run) => run.id ?? run.name}
+                getLabel={(run) => run.name}
+                colors={filteredRuns.map(
+                (r) => runColorMap[r.id ?? r.name] ?? getColorForIndex(Math.max(0, runs.indexOf(r))),
+              )}
+                ontoggle={() => { latestOnly = false; }}
+              />
+            </div>
+          {/if}
           {#if currentPage === "system" && availableSystemDevices.length > 0}
             <div class="device-group">
               <label class="select-all-label">
@@ -867,5 +957,45 @@
     text-overflow: ellipsis;
     white-space: nowrap;
     color: var(--body-text-color, #1f2937);
+  }
+  .group-by-row {
+    margin-top: 8px;
+  }
+  .grouped-runs {
+    margin-top: 8px;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+  .run-group-section {
+    border: 1px solid var(--border-color-primary, #e5e7eb);
+    border-radius: var(--radius-md, 6px);
+    overflow: hidden;
+  }
+  .run-group-header {
+    display: flex;
+    align-items: center;
+    padding: 6px 10px;
+    background: var(--background-fill-secondary, #f9fafb);
+    border-bottom: 1px solid var(--border-color-primary, #e5e7eb);
+  }
+  .run-group-label {
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--body-text-color, #1f2937);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    max-width: 160px;
+  }
+  .run-group-count {
+    font-size: 11px;
+    color: var(--body-text-color-subdued, #9ca3af);
+    margin-left: 4px;
+    flex-shrink: 0;
+  }
+  .group-checkbox-list {
+    padding: 4px 10px;
+    max-height: none;
   }
 </style>

--- a/trackio/frontend/src/components/Sidebar.svelte
+++ b/trackio/frontend/src/components/Sidebar.svelte
@@ -8,7 +8,7 @@
   import { buildColorMap, getColorForIndex } from "../lib/stores.js";
   import { latestOnlySelection } from "../lib/selection.js";
   import { filterMetricsByRegex } from "../lib/dataProcessing.js";
-  import Accordion from "./Accordion.svelte";
+  import { computeGroupByOptions, computeGroupedRuns } from "../lib/grouping.js";
 
   let {
     open = $bindable(true),
@@ -99,30 +99,8 @@
   });
 
 
-  let groupByOptions = $derived.by(() => {
-    const keys = new Set();
-    for (const cfg of Object.values(runConfigs)) {
-      if (cfg && typeof cfg === "object") {
-        for (const key of Object.keys(cfg)) {
-          if (cfg[key] !== null && cfg[key] !== undefined) keys.add(key);
-        }
-      }
-    }
-    return ["None", ...Array.from(keys).sort()];
-  });
-
-  let groupedRuns = $derived.by(() => {
-    if (!groupByField) return null;
-    const groups = new Map();
-    for (const run of filteredRuns) {
-      const cfg = runConfigs[run.name] ?? {};
-      const raw = cfg[groupByField];
-      const label = raw === null || raw === undefined ? "(unset)" : String(raw);
-      if (!groups.has(label)) groups.set(label, []);
-      groups.get(label).push(run);
-    }
-    return groups;
-  });
+  let groupByOptions = $derived(computeGroupByOptions(runConfigs));
+  let groupedRuns = $derived(computeGroupedRuns(filteredRuns, runConfigs, groupByField));
 
   let latestOnly = $state(false);
   let shareTab = $state("share");

--- a/trackio/frontend/src/components/Sidebar.svelte
+++ b/trackio/frontend/src/components/Sidebar.svelte
@@ -90,23 +90,21 @@
   let runColorMap = $derived(buildColorMap(runs));
   let filteredRunIds = $derived(filteredRuns.map((r) => r.id ?? r.name));
 
-  let groupByRaw = $state("None");
-  let groupByField = $derived(groupByRaw === "None" ? null : groupByRaw);
+  let groupByRaw = $state(null);
 
   $effect(() => {
     selectedProject;
-    groupByRaw = "None";
+    groupByRaw = null;
   });
 
   $effect(() => {
-    if (!groupByOptions.includes(groupByRaw)) {
-      groupByRaw = "None";
+    if (!groupByOptions.some((o) => o.value === groupByRaw)) {
+      groupByRaw = null;
     }
   });
 
-
   let groupByOptions = $derived(computeGroupByOptions(runConfigs));
-  let groupedRuns = $derived(computeGroupedRuns(filteredRuns, runConfigs, groupByField));
+  let groupedRuns = $derived(computeGroupedRuns(filteredRuns, runConfigs, groupByRaw));
 
   let latestOnly = $state(false);
   let shareTab = $state("share");

--- a/trackio/frontend/src/lib/api.js
+++ b/trackio/frontend/src/lib/api.js
@@ -71,6 +71,11 @@ export async function getRunsForProject(project) {
   return await callApi("/get_runs_for_project", { project });
 }
 
+export async function getRunConfigs(project) {
+  if (await isStaticMode()) return staticApi.getRunConfigs(project);
+  return await callApi("/get_run_configs", { project });
+}
+
 function normalizeRun(run) {
   if (run == null) return { run: null, run_id: null };
   if (typeof run === "string") return { run, run_id: null };

--- a/trackio/frontend/src/lib/grouping.js
+++ b/trackio/frontend/src/lib/grouping.js
@@ -1,4 +1,7 @@
-export const PROMOTED_RESERVED_KEYS = Object.freeze({ _Group: "Group" });
+export const PROMOTED_RESERVED_KEYS = Object.freeze({
+  _Group: "Group",
+  _Username: "Username",
+});
 
 const PROMOTED_LABELS = new Set(Object.values(PROMOTED_RESERVED_KEYS));
 
@@ -18,23 +21,32 @@ export function resolveGroupByKey(displayLabel) {
   return displayLabel;
 }
 
+function promotedKeyHasVariance(runConfigs, key) {
+  const seen = new Set();
+  for (const cfg of Object.values(runConfigs ?? {})) {
+    if (!cfg || typeof cfg !== "object") continue;
+    const raw = cfg[key];
+    const label = raw === null || raw === undefined ? "(unset)" : String(raw);
+    seen.add(label);
+    if (seen.size >= 2) return true;
+  }
+  return false;
+}
+
 export function computeGroupByOptions(runConfigs) {
-  const promotedFound = new Set();
   const regularKeys = new Set();
   for (const cfg of Object.values(runConfigs ?? {})) {
     if (!cfg || typeof cfg !== "object") continue;
     for (const key of Object.keys(cfg)) {
       if (cfg[key] === null || cfg[key] === undefined) continue;
       if (shouldHideKey(key)) continue;
-      if (key in PROMOTED_RESERVED_KEYS) {
-        promotedFound.add(key);
-      } else if (!PROMOTED_LABELS.has(key)) {
-        regularKeys.add(key);
-      }
+      if (key in PROMOTED_RESERVED_KEYS) continue;
+      if (PROMOTED_LABELS.has(key)) continue;
+      regularKeys.add(key);
     }
   }
   const promoted = Object.keys(PROMOTED_RESERVED_KEYS)
-    .filter((k) => promotedFound.has(k))
+    .filter((k) => promotedKeyHasVariance(runConfigs, k))
     .map(displayLabelForKey);
   const regular = [...regularKeys].sort();
   return ["None", ...promoted, ...regular];

--- a/trackio/frontend/src/lib/grouping.js
+++ b/trackio/frontend/src/lib/grouping.js
@@ -3,8 +3,6 @@ export const PROMOTED_RESERVED_KEYS = Object.freeze({
   _Username: "Username",
 });
 
-const PROMOTED_LABELS = new Set(Object.values(PROMOTED_RESERVED_KEYS));
-
 function shouldHideKey(key) {
   return key.startsWith("_") && !(key in PROMOTED_RESERVED_KEYS);
 }
@@ -13,10 +11,10 @@ function displayLabelForKey(key) {
   return PROMOTED_RESERVED_KEYS[key] ?? key;
 }
 
-export function resolveGroupByKey(displayLabel) {
+export function resolveGroupByKey(displayLabel, runConfigs) {
   if (!displayLabel) return null;
   for (const [key, label] of Object.entries(PROMOTED_RESERVED_KEYS)) {
-    if (label === displayLabel) return key;
+    if (label === displayLabel && promotedKeyHasVariance(runConfigs, key)) return key;
   }
   return displayLabel;
 }
@@ -34,6 +32,11 @@ function promotedKeyHasVariance(runConfigs, key) {
 }
 
 export function computeGroupByOptions(runConfigs) {
+  const promoted = Object.keys(PROMOTED_RESERVED_KEYS)
+    .filter((k) => promotedKeyHasVariance(runConfigs, k))
+    .map(displayLabelForKey);
+  const surfacedPromotedLabels = new Set(promoted);
+
   const regularKeys = new Set();
   for (const cfg of Object.values(runConfigs ?? {})) {
     if (!cfg || typeof cfg !== "object") continue;
@@ -41,19 +44,16 @@ export function computeGroupByOptions(runConfigs) {
       if (cfg[key] === null || cfg[key] === undefined) continue;
       if (shouldHideKey(key)) continue;
       if (key in PROMOTED_RESERVED_KEYS) continue;
-      if (PROMOTED_LABELS.has(key)) continue;
+      if (surfacedPromotedLabels.has(key)) continue;
       regularKeys.add(key);
     }
   }
-  const promoted = Object.keys(PROMOTED_RESERVED_KEYS)
-    .filter((k) => promotedKeyHasVariance(runConfigs, k))
-    .map(displayLabelForKey);
   const regular = [...regularKeys].sort();
   return ["None", ...promoted, ...regular];
 }
 
 export function computeGroupedRuns(filteredRuns, runConfigs, groupBy) {
-  const realKey = resolveGroupByKey(groupBy);
+  const realKey = resolveGroupByKey(groupBy, runConfigs);
   if (!realKey) return null;
   const groups = new Map();
   for (const run of filteredRuns) {

--- a/trackio/frontend/src/lib/grouping.js
+++ b/trackio/frontend/src/lib/grouping.js
@@ -1,0 +1,55 @@
+export const PROMOTED_RESERVED_KEYS = Object.freeze({ _Group: "Group" });
+
+const PROMOTED_LABELS = new Set(Object.values(PROMOTED_RESERVED_KEYS));
+
+function shouldHideKey(key) {
+  return key.startsWith("_") && !(key in PROMOTED_RESERVED_KEYS);
+}
+
+function displayLabelForKey(key) {
+  return PROMOTED_RESERVED_KEYS[key] ?? key;
+}
+
+export function resolveGroupByKey(displayLabel) {
+  if (!displayLabel) return null;
+  for (const [key, label] of Object.entries(PROMOTED_RESERVED_KEYS)) {
+    if (label === displayLabel) return key;
+  }
+  return displayLabel;
+}
+
+export function computeGroupByOptions(runConfigs) {
+  const promotedFound = new Set();
+  const regularKeys = new Set();
+  for (const cfg of Object.values(runConfigs ?? {})) {
+    if (!cfg || typeof cfg !== "object") continue;
+    for (const key of Object.keys(cfg)) {
+      if (cfg[key] === null || cfg[key] === undefined) continue;
+      if (shouldHideKey(key)) continue;
+      if (key in PROMOTED_RESERVED_KEYS) {
+        promotedFound.add(key);
+      } else if (!PROMOTED_LABELS.has(key)) {
+        regularKeys.add(key);
+      }
+    }
+  }
+  const promoted = Object.keys(PROMOTED_RESERVED_KEYS)
+    .filter((k) => promotedFound.has(k))
+    .map(displayLabelForKey);
+  const regular = [...regularKeys].sort();
+  return ["None", ...promoted, ...regular];
+}
+
+export function computeGroupedRuns(filteredRuns, runConfigs, groupBy) {
+  const realKey = resolveGroupByKey(groupBy);
+  if (!realKey) return null;
+  const groups = new Map();
+  for (const run of filteredRuns) {
+    const cfg = (runConfigs ?? {})[run.name] ?? {};
+    const raw = cfg[realKey];
+    const label = raw === null || raw === undefined ? "(unset)" : String(raw);
+    if (!groups.has(label)) groups.set(label, []);
+    groups.get(label).push(run);
+  }
+  return groups;
+}

--- a/trackio/frontend/src/lib/grouping.js
+++ b/trackio/frontend/src/lib/grouping.js
@@ -57,7 +57,7 @@ export function computeGroupedRuns(filteredRuns, runConfigs, groupBy) {
   if (!realKey) return null;
   const groups = new Map();
   for (const run of filteredRuns) {
-    const cfg = (runConfigs ?? {})[run.name] ?? {};
+    const cfg = (runConfigs ?? {})[run.id] ?? (runConfigs ?? {})[run.name] ?? {};
     const raw = cfg[realKey];
     const label = raw === null || raw === undefined ? "(unset)" : String(raw);
     if (!groups.has(label)) groups.set(label, []);

--- a/trackio/frontend/src/lib/grouping.js
+++ b/trackio/frontend/src/lib/grouping.js
@@ -11,14 +11,6 @@ function displayLabelForKey(key) {
   return PROMOTED_RESERVED_KEYS[key] ?? key;
 }
 
-export function resolveGroupByKey(displayLabel, runConfigs) {
-  if (!displayLabel) return null;
-  for (const [key, label] of Object.entries(PROMOTED_RESERVED_KEYS)) {
-    if (label === displayLabel && promotedKeyHasVariance(runConfigs, key)) return key;
-  }
-  return displayLabel;
-}
-
 function promotedKeyHasVariance(runConfigs, key) {
   const seen = new Set();
   for (const cfg of Object.values(runConfigs ?? {})) {
@@ -34,8 +26,8 @@ function promotedKeyHasVariance(runConfigs, key) {
 export function computeGroupByOptions(runConfigs) {
   const promoted = Object.keys(PROMOTED_RESERVED_KEYS)
     .filter((k) => promotedKeyHasVariance(runConfigs, k))
-    .map(displayLabelForKey);
-  const surfacedPromotedLabels = new Set(promoted);
+    .map((k) => ({ label: displayLabelForKey(k), value: k }));
+  const surfacedPromotedLabels = new Set(promoted.map((o) => o.label));
 
   const regularKeys = new Set();
   for (const cfg of Object.values(runConfigs ?? {})) {
@@ -48,17 +40,16 @@ export function computeGroupByOptions(runConfigs) {
       regularKeys.add(key);
     }
   }
-  const regular = [...regularKeys].sort();
-  return ["None", ...promoted, ...regular];
+  const regular = [...regularKeys].sort().map((k) => ({ label: k, value: k }));
+  return [{ label: "None", value: null }, ...promoted, ...regular];
 }
 
 export function computeGroupedRuns(filteredRuns, runConfigs, groupBy) {
-  const realKey = resolveGroupByKey(groupBy, runConfigs);
-  if (!realKey) return null;
+  if (!groupBy) return null;
   const groups = new Map();
   for (const run of filteredRuns) {
     const cfg = (runConfigs ?? {})[run.id] ?? (runConfigs ?? {})[run.name] ?? {};
-    const raw = cfg[realKey];
+    const raw = cfg[groupBy];
     const label = raw === null || raw === undefined ? "(unset)" : String(raw);
     if (!groups.has(label)) groups.set(label, []);
     groups.get(label).push(run);

--- a/trackio/frontend/src/lib/grouping.js
+++ b/trackio/frontend/src/lib/grouping.js
@@ -34,6 +34,7 @@ export function computeGroupByOptions(runConfigs) {
     if (!cfg || typeof cfg !== "object") continue;
     for (const key of Object.keys(cfg)) {
       if (cfg[key] === null || cfg[key] === undefined) continue;
+      if (typeof cfg[key] === "object") continue;
       if (shouldHideKey(key)) continue;
       if (key in PROMOTED_RESERVED_KEYS) continue;
       if (surfacedPromotedLabels.has(key)) continue;

--- a/trackio/frontend/src/lib/grouping.js
+++ b/trackio/frontend/src/lib/grouping.js
@@ -4,7 +4,7 @@ export const PROMOTED_RESERVED_KEYS = Object.freeze({
 });
 
 function shouldHideKey(key) {
-  return key.startsWith("_") && !(key in PROMOTED_RESERVED_KEYS);
+  return key.startsWith("_") && !Object.hasOwn(PROMOTED_RESERVED_KEYS, key);
 }
 
 function displayLabelForKey(key) {
@@ -30,17 +30,22 @@ export function computeGroupByOptions(runConfigs) {
   const surfacedPromotedLabels = new Set(promoted.map((o) => o.label));
 
   const regularKeys = new Set();
+  const nonScalarKeys = new Set();
   for (const cfg of Object.values(runConfigs ?? {})) {
     if (!cfg || typeof cfg !== "object") continue;
     for (const key of Object.keys(cfg)) {
       if (cfg[key] === null || cfg[key] === undefined) continue;
-      if (typeof cfg[key] === "object") continue;
       if (shouldHideKey(key)) continue;
-      if (key in PROMOTED_RESERVED_KEYS) continue;
+      if (Object.hasOwn(PROMOTED_RESERVED_KEYS, key)) continue;
       if (surfacedPromotedLabels.has(key)) continue;
-      regularKeys.add(key);
+      if (typeof cfg[key] === "object") {
+        nonScalarKeys.add(key);
+      } else {
+        regularKeys.add(key);
+      }
     }
   }
+  for (const key of nonScalarKeys) regularKeys.delete(key);
   const regular = [...regularKeys].sort().map((k) => ({ label: k, value: k }));
   return [{ label: "None", value: null }, ...promoted, ...regular];
 }

--- a/trackio/frontend/src/lib/grouping.test.js
+++ b/trackio/frontend/src/lib/grouping.test.js
@@ -76,11 +76,60 @@ describe("computeGroupByOptions", () => {
 
   test("does not surface a user-defined key named 'Group' as a duplicate", () => {
     const configs = {
-      "run-a": { _Group: "exp-1", Group: "user-named", lr: 0.01 },
+      "run-a": { _Group: "exp-1", Group: "user-1", lr: 0.01 },
+      "run-b": { _Group: "exp-2", Group: "user-2", lr: 0.02 },
     };
     const options = computeGroupByOptions(configs);
     expect(options.filter((o) => o === "Group")).toHaveLength(1);
     expect(options).toEqual(["None", "Group", "lr"]);
+  });
+
+  test("promotes _Username to 'Username' when usernames vary", () => {
+    const configs = {
+      "run-a": { _Username: "alice", lr: 0.01 },
+      "run-b": { _Username: "bob", lr: 0.02 },
+    };
+    expect(computeGroupByOptions(configs)).toEqual([
+      "None",
+      "Username",
+      "lr",
+    ]);
+  });
+
+  test("hides 'Username' in a single-user project (all values equal)", () => {
+    const configs = {
+      "run-a": { _Username: "alice", lr: 0.01 },
+      "run-b": { _Username: "alice", lr: 0.02 },
+    };
+    expect(computeGroupByOptions(configs)).toEqual(["None", "lr"]);
+  });
+
+  test("hides 'Group' when every run shares the same group value", () => {
+    const configs = {
+      "run-a": { _Group: "exp-1", lr: 0.01 },
+      "run-b": { _Group: "exp-1", lr: 0.02 },
+    };
+    expect(computeGroupByOptions(configs)).toEqual(["None", "lr"]);
+  });
+
+  test("orders promoted keys by declaration: Group before Username", () => {
+    const configs = {
+      "run-a": { _Group: "exp-1", _Username: "alice" },
+      "run-b": { _Group: "exp-2", _Username: "bob" },
+    };
+    expect(computeGroupByOptions(configs)).toEqual([
+      "None",
+      "Group",
+      "Username",
+    ]);
+  });
+
+  test("includes 'Group' when some runs have a value and others are unset", () => {
+    const configs = {
+      "run-a": { _Group: "exp-1", lr: 0.01 },
+      "run-b": { _Group: null, lr: 0.02 },
+    };
+    expect(computeGroupByOptions(configs)).toEqual(["None", "Group", "lr"]);
   });
 });
 
@@ -93,6 +142,10 @@ describe("resolveGroupByKey", () => {
 
   test("maps the 'Group' display label back to '_Group'", () => {
     expect(resolveGroupByKey("Group")).toBe("_Group");
+  });
+
+  test("maps the 'Username' display label back to '_Username'", () => {
+    expect(resolveGroupByKey("Username")).toBe("_Username");
   });
 
   test("passes regular keys through unchanged", () => {

--- a/trackio/frontend/src/lib/grouping.test.js
+++ b/trackio/frontend/src/lib/grouping.test.js
@@ -44,6 +44,14 @@ describe("computeGroupByOptions", () => {
     expect(computeGroupByOptions(configs)).toEqual([none, opt("lr")]);
   });
 
+  test("excludes keys with object or array values", () => {
+    const configs = {
+      "run-a": { optimizer: { lr: 0.01 }, tags: ["a", "b"], seed: 42 },
+      "run-b": { optimizer: { lr: 0.02 }, tags: ["c"], seed: 7 },
+    };
+    expect(computeGroupByOptions(configs)).toEqual([none, opt("seed")]);
+  });
+
   test("hides reserved underscore-prefixed keys", () => {
     const configs = {
       "run-a": {

--- a/trackio/frontend/src/lib/grouping.test.js
+++ b/trackio/frontend/src/lib/grouping.test.js
@@ -1,0 +1,162 @@
+import { describe, expect, test } from "vitest";
+import {
+  computeGroupByOptions,
+  computeGroupedRuns,
+  resolveGroupByKey,
+} from "./grouping.js";
+
+describe("computeGroupByOptions", () => {
+  test("returns just 'None' when there are no configs", () => {
+    expect(computeGroupByOptions({})).toEqual(["None"]);
+    expect(computeGroupByOptions(null)).toEqual(["None"]);
+    expect(computeGroupByOptions(undefined)).toEqual(["None"]);
+  });
+
+  test("collects the union of keys across all runs, sorted", () => {
+    const configs = {
+      "run-a": { lr: 0.01, model: "resnet" },
+      "run-b": { lr: 0.02, seed: 42 },
+    };
+    expect(computeGroupByOptions(configs)).toEqual([
+      "None",
+      "lr",
+      "model",
+      "seed",
+    ]);
+  });
+
+  test("ignores keys whose value is null or undefined", () => {
+    const configs = {
+      "run-a": { lr: 0.01, dropped: null },
+      "run-b": { lr: 0.02, dropped: undefined, kept: "yes" },
+    };
+    expect(computeGroupByOptions(configs)).toEqual(["None", "kept", "lr"]);
+  });
+
+  test("tolerates non-object config entries", () => {
+    const configs = {
+      "run-a": { lr: 0.01 },
+      "run-b": null,
+      "run-c": "not-a-config",
+    };
+    expect(computeGroupByOptions(configs)).toEqual(["None", "lr"]);
+  });
+
+  test("hides reserved underscore-prefixed keys", () => {
+    const configs = {
+      "run-a": {
+        _Username: "saba",
+        _Created: "2026-05-18T00:00:00Z",
+        lr: 0.01,
+      },
+    };
+    expect(computeGroupByOptions(configs)).toEqual(["None", "lr"]);
+  });
+
+  test("promotes _Group to 'Group' and pins it after 'None'", () => {
+    const configs = {
+      "run-a": { _Group: "exp-1", framework: "pytorch", lr: 0.01 },
+      "run-b": { _Group: "exp-2", framework: "pytorch", lr: 0.02 },
+    };
+    expect(computeGroupByOptions(configs)).toEqual([
+      "None",
+      "Group",
+      "framework",
+      "lr",
+    ]);
+  });
+
+  test("omits 'Group' when no run sets _Group to a real value", () => {
+    const configs = {
+      "run-a": { _Group: null, lr: 0.01 },
+      "run-b": { _Group: undefined, lr: 0.02 },
+    };
+    expect(computeGroupByOptions(configs)).toEqual(["None", "lr"]);
+  });
+
+  test("does not surface a user-defined key named 'Group' as a duplicate", () => {
+    const configs = {
+      "run-a": { _Group: "exp-1", Group: "user-named", lr: 0.01 },
+    };
+    const options = computeGroupByOptions(configs);
+    expect(options.filter((o) => o === "Group")).toHaveLength(1);
+    expect(options).toEqual(["None", "Group", "lr"]);
+  });
+});
+
+describe("resolveGroupByKey", () => {
+  test("returns null for null/undefined/empty", () => {
+    expect(resolveGroupByKey(null)).toBeNull();
+    expect(resolveGroupByKey(undefined)).toBeNull();
+    expect(resolveGroupByKey("")).toBeNull();
+  });
+
+  test("maps the 'Group' display label back to '_Group'", () => {
+    expect(resolveGroupByKey("Group")).toBe("_Group");
+  });
+
+  test("passes regular keys through unchanged", () => {
+    expect(resolveGroupByKey("lr")).toBe("lr");
+    expect(resolveGroupByKey("model")).toBe("model");
+  });
+});
+
+describe("computeGroupedRuns", () => {
+  const runs = [
+    { id: "1", name: "run-a" },
+    { id: "2", name: "run-b" },
+    { id: "3", name: "run-c" },
+  ];
+  const configs = {
+    "run-a": { lr: 0.01, model: "resnet" },
+    "run-b": { lr: 0.01, model: "vit" },
+    "run-c": { lr: 0.02, model: "resnet" },
+  };
+
+  test("returns null when no field is selected", () => {
+    expect(computeGroupedRuns(runs, configs, null)).toBeNull();
+    expect(computeGroupedRuns(runs, configs, "")).toBeNull();
+  });
+
+  test("buckets runs by stringified config value", () => {
+    const groups = computeGroupedRuns(runs, configs, "lr");
+    expect([...groups.keys()]).toEqual(["0.01", "0.02"]);
+    expect(groups.get("0.01").map((r) => r.name)).toEqual(["run-a", "run-b"]);
+    expect(groups.get("0.02").map((r) => r.name)).toEqual(["run-c"]);
+  });
+
+  test("puts runs with missing config values into '(unset)'", () => {
+    const groups = computeGroupedRuns(
+      [...runs, { id: "4", name: "run-d" }],
+      configs,
+      "lr",
+    );
+    expect(groups.get("(unset)").map((r) => r.name)).toEqual(["run-d"]);
+  });
+
+  test("treats null and undefined config values as '(unset)'", () => {
+    const groups = computeGroupedRuns(
+      [{ id: "1", name: "r" }],
+      { r: { lr: null } },
+      "lr",
+    );
+    expect([...groups.keys()]).toEqual(["(unset)"]);
+  });
+
+  test("preserves bucket insertion order (first run wins)", () => {
+    const groups = computeGroupedRuns(runs, configs, "model");
+    expect([...groups.keys()]).toEqual(["resnet", "vit"]);
+  });
+
+  test("looks up the underlying '_Group' key when given the 'Group' label", () => {
+    const groupedConfigs = {
+      "run-a": { _Group: "exp-1" },
+      "run-b": { _Group: "exp-2" },
+      "run-c": { _Group: "exp-1" },
+    };
+    const groups = computeGroupedRuns(runs, groupedConfigs, "Group");
+    expect([...groups.keys()]).toEqual(["exp-1", "exp-2"]);
+    expect(groups.get("exp-1").map((r) => r.name)).toEqual(["run-a", "run-c"]);
+    expect(groups.get("exp-2").map((r) => r.name)).toEqual(["run-b"]);
+  });
+});

--- a/trackio/frontend/src/lib/grouping.test.js
+++ b/trackio/frontend/src/lib/grouping.test.js
@@ -2,14 +2,16 @@ import { describe, expect, test } from "vitest";
 import {
   computeGroupByOptions,
   computeGroupedRuns,
-  resolveGroupByKey,
 } from "./grouping.js";
 
+const none = { label: "None", value: null };
+const opt = (label, value) => ({ label, value: value ?? label });
+
 describe("computeGroupByOptions", () => {
-  test("returns just 'None' when there are no configs", () => {
-    expect(computeGroupByOptions({})).toEqual(["None"]);
-    expect(computeGroupByOptions(null)).toEqual(["None"]);
-    expect(computeGroupByOptions(undefined)).toEqual(["None"]);
+  test("returns just the None option when there are no configs", () => {
+    expect(computeGroupByOptions({})).toEqual([none]);
+    expect(computeGroupByOptions(null)).toEqual([none]);
+    expect(computeGroupByOptions(undefined)).toEqual([none]);
   });
 
   test("collects the union of keys across all runs, sorted", () => {
@@ -18,10 +20,10 @@ describe("computeGroupByOptions", () => {
       "run-b": { lr: 0.02, seed: 42 },
     };
     expect(computeGroupByOptions(configs)).toEqual([
-      "None",
-      "lr",
-      "model",
-      "seed",
+      none,
+      opt("lr"),
+      opt("model"),
+      opt("seed"),
     ]);
   });
 
@@ -30,7 +32,7 @@ describe("computeGroupByOptions", () => {
       "run-a": { lr: 0.01, dropped: null },
       "run-b": { lr: 0.02, dropped: undefined, kept: "yes" },
     };
-    expect(computeGroupByOptions(configs)).toEqual(["None", "kept", "lr"]);
+    expect(computeGroupByOptions(configs)).toEqual([none, opt("kept"), opt("lr")]);
   });
 
   test("tolerates non-object config entries", () => {
@@ -39,7 +41,7 @@ describe("computeGroupByOptions", () => {
       "run-b": null,
       "run-c": "not-a-config",
     };
-    expect(computeGroupByOptions(configs)).toEqual(["None", "lr"]);
+    expect(computeGroupByOptions(configs)).toEqual([none, opt("lr")]);
   });
 
   test("hides reserved underscore-prefixed keys", () => {
@@ -50,19 +52,19 @@ describe("computeGroupByOptions", () => {
         lr: 0.01,
       },
     };
-    expect(computeGroupByOptions(configs)).toEqual(["None", "lr"]);
+    expect(computeGroupByOptions(configs)).toEqual([none, opt("lr")]);
   });
 
-  test("promotes _Group to 'Group' and pins it after 'None'", () => {
+  test("promotes _Group to 'Group' and pins it after None", () => {
     const configs = {
       "run-a": { _Group: "exp-1", framework: "pytorch", lr: 0.01 },
       "run-b": { _Group: "exp-2", framework: "pytorch", lr: 0.02 },
     };
     expect(computeGroupByOptions(configs)).toEqual([
-      "None",
-      "Group",
-      "framework",
-      "lr",
+      none,
+      { label: "Group", value: "_Group" },
+      opt("framework"),
+      opt("lr"),
     ]);
   });
 
@@ -71,7 +73,7 @@ describe("computeGroupByOptions", () => {
       "run-a": { _Group: null, lr: 0.01 },
       "run-b": { _Group: undefined, lr: 0.02 },
     };
-    expect(computeGroupByOptions(configs)).toEqual(["None", "lr"]);
+    expect(computeGroupByOptions(configs)).toEqual([none, opt("lr")]);
   });
 
   test("does not surface a user-defined key named 'Group' as a duplicate", () => {
@@ -80,8 +82,8 @@ describe("computeGroupByOptions", () => {
       "run-b": { _Group: "exp-2", Group: "user-2", lr: 0.02 },
     };
     const options = computeGroupByOptions(configs);
-    expect(options.filter((o) => o === "Group")).toHaveLength(1);
-    expect(options).toEqual(["None", "Group", "lr"]);
+    expect(options.filter((o) => o.label === "Group")).toHaveLength(1);
+    expect(options).toEqual([none, { label: "Group", value: "_Group" }, opt("lr")]);
   });
 
   test("surfaces a user-defined 'Group' key when _Group has no variance", () => {
@@ -89,7 +91,7 @@ describe("computeGroupByOptions", () => {
       "run-a": { Group: "team-a", lr: 0.01 },
       "run-b": { Group: "team-b", lr: 0.02 },
     };
-    expect(computeGroupByOptions(configs)).toEqual(["None", "Group", "lr"]);
+    expect(computeGroupByOptions(configs)).toEqual([none, opt("Group"), opt("lr")]);
   });
 
   test("promotes _Username to 'Username' when usernames vary", () => {
@@ -98,9 +100,9 @@ describe("computeGroupByOptions", () => {
       "run-b": { _Username: "bob", lr: 0.02 },
     };
     expect(computeGroupByOptions(configs)).toEqual([
-      "None",
-      "Username",
-      "lr",
+      none,
+      { label: "Username", value: "_Username" },
+      opt("lr"),
     ]);
   });
 
@@ -109,7 +111,7 @@ describe("computeGroupByOptions", () => {
       "run-a": { _Username: "alice", lr: 0.01 },
       "run-b": { _Username: "alice", lr: 0.02 },
     };
-    expect(computeGroupByOptions(configs)).toEqual(["None", "lr"]);
+    expect(computeGroupByOptions(configs)).toEqual([none, opt("lr")]);
   });
 
   test("hides 'Group' when every run shares the same group value", () => {
@@ -117,7 +119,7 @@ describe("computeGroupByOptions", () => {
       "run-a": { _Group: "exp-1", lr: 0.01 },
       "run-b": { _Group: "exp-1", lr: 0.02 },
     };
-    expect(computeGroupByOptions(configs)).toEqual(["None", "lr"]);
+    expect(computeGroupByOptions(configs)).toEqual([none, opt("lr")]);
   });
 
   test("orders promoted keys by declaration: Group before Username", () => {
@@ -126,9 +128,9 @@ describe("computeGroupByOptions", () => {
       "run-b": { _Group: "exp-2", _Username: "bob" },
     };
     expect(computeGroupByOptions(configs)).toEqual([
-      "None",
-      "Group",
-      "Username",
+      none,
+      { label: "Group", value: "_Group" },
+      { label: "Username", value: "_Username" },
     ]);
   });
 
@@ -137,41 +139,11 @@ describe("computeGroupByOptions", () => {
       "run-a": { _Group: "exp-1", lr: 0.01 },
       "run-b": { _Group: null, lr: 0.02 },
     };
-    expect(computeGroupByOptions(configs)).toEqual(["None", "Group", "lr"]);
-  });
-});
-
-describe("resolveGroupByKey", () => {
-  test("returns null for null/undefined/empty", () => {
-    expect(resolveGroupByKey(null)).toBeNull();
-    expect(resolveGroupByKey(undefined)).toBeNull();
-    expect(resolveGroupByKey("")).toBeNull();
-  });
-
-  test("maps 'Group' to '_Group' when _Group has variance", () => {
-    const configs = { "run-a": { _Group: "exp-1" }, "run-b": { _Group: "exp-2" } };
-    expect(resolveGroupByKey("Group", configs)).toBe("_Group");
-  });
-
-  test("maps 'Username' to '_Username' when _Username has variance", () => {
-    const configs = { "run-a": { _Username: "alice" }, "run-b": { _Username: "bob" } };
-    expect(resolveGroupByKey("Username", configs)).toBe("_Username");
-  });
-
-  test("returns 'Group' literally when _Group has no variance", () => {
-    const configs = { "run-a": { _Group: "exp-1" }, "run-b": { _Group: "exp-1" } };
-    expect(resolveGroupByKey("Group", configs)).toBe("Group");
-  });
-
-  test("returns 'Group' literally when no runConfigs provided", () => {
-    expect(resolveGroupByKey("Group", null)).toBe("Group");
-    expect(resolveGroupByKey("Group", undefined)).toBe("Group");
-    expect(resolveGroupByKey("Group")).toBe("Group");
-  });
-
-  test("passes regular keys through unchanged", () => {
-    expect(resolveGroupByKey("lr")).toBe("lr");
-    expect(resolveGroupByKey("model")).toBe("model");
+    expect(computeGroupByOptions(configs)).toEqual([
+      none,
+      { label: "Group", value: "_Group" },
+      opt("lr"),
+    ]);
   });
 });
 
@@ -222,19 +194,19 @@ describe("computeGroupedRuns", () => {
     expect([...groups.keys()]).toEqual(["resnet", "vit"]);
   });
 
-  test("looks up the underlying '_Group' key when given the 'Group' label", () => {
+  test("groups by _Group key directly", () => {
     const groupedConfigs = {
       "run-a": { _Group: "exp-1" },
       "run-b": { _Group: "exp-2" },
       "run-c": { _Group: "exp-1" },
     };
-    const groups = computeGroupedRuns(runs, groupedConfigs, "Group");
+    const groups = computeGroupedRuns(runs, groupedConfigs, "_Group");
     expect([...groups.keys()]).toEqual(["exp-1", "exp-2"]);
     expect(groups.get("exp-1").map((r) => r.name)).toEqual(["run-a", "run-c"]);
     expect(groups.get("exp-2").map((r) => r.name)).toEqual(["run-b"]);
   });
 
-  test("groups by a literal 'Group' user config key when _Group has no variance", () => {
+  test("groups by a literal 'Group' user config key", () => {
     const groupedConfigs = {
       "run-a": { Group: "team-a" },
       "run-b": { Group: "team-b" },

--- a/trackio/frontend/src/lib/grouping.test.js
+++ b/trackio/frontend/src/lib/grouping.test.js
@@ -52,6 +52,14 @@ describe("computeGroupByOptions", () => {
     expect(computeGroupByOptions(configs)).toEqual([none, opt("seed")]);
   });
 
+  test("excludes keys where any run has an object value even if others are scalar", () => {
+    const configs = {
+      "run-a": { optimizer: "adam", seed: 42 },
+      "run-b": { optimizer: { type: "adam", lr: 0.01 }, seed: 7 },
+    };
+    expect(computeGroupByOptions(configs)).toEqual([none, opt("seed")]);
+  });
+
   test("hides reserved underscore-prefixed keys", () => {
     const configs = {
       "run-a": {

--- a/trackio/frontend/src/lib/grouping.test.js
+++ b/trackio/frontend/src/lib/grouping.test.js
@@ -84,6 +84,14 @@ describe("computeGroupByOptions", () => {
     expect(options).toEqual(["None", "Group", "lr"]);
   });
 
+  test("surfaces a user-defined 'Group' key when _Group has no variance", () => {
+    const configs = {
+      "run-a": { Group: "team-a", lr: 0.01 },
+      "run-b": { Group: "team-b", lr: 0.02 },
+    };
+    expect(computeGroupByOptions(configs)).toEqual(["None", "Group", "lr"]);
+  });
+
   test("promotes _Username to 'Username' when usernames vary", () => {
     const configs = {
       "run-a": { _Username: "alice", lr: 0.01 },
@@ -140,12 +148,25 @@ describe("resolveGroupByKey", () => {
     expect(resolveGroupByKey("")).toBeNull();
   });
 
-  test("maps the 'Group' display label back to '_Group'", () => {
-    expect(resolveGroupByKey("Group")).toBe("_Group");
+  test("maps 'Group' to '_Group' when _Group has variance", () => {
+    const configs = { "run-a": { _Group: "exp-1" }, "run-b": { _Group: "exp-2" } };
+    expect(resolveGroupByKey("Group", configs)).toBe("_Group");
   });
 
-  test("maps the 'Username' display label back to '_Username'", () => {
-    expect(resolveGroupByKey("Username")).toBe("_Username");
+  test("maps 'Username' to '_Username' when _Username has variance", () => {
+    const configs = { "run-a": { _Username: "alice" }, "run-b": { _Username: "bob" } };
+    expect(resolveGroupByKey("Username", configs)).toBe("_Username");
+  });
+
+  test("returns 'Group' literally when _Group has no variance", () => {
+    const configs = { "run-a": { _Group: "exp-1" }, "run-b": { _Group: "exp-1" } };
+    expect(resolveGroupByKey("Group", configs)).toBe("Group");
+  });
+
+  test("returns 'Group' literally when no runConfigs provided", () => {
+    expect(resolveGroupByKey("Group", null)).toBe("Group");
+    expect(resolveGroupByKey("Group", undefined)).toBe("Group");
+    expect(resolveGroupByKey("Group")).toBe("Group");
   });
 
   test("passes regular keys through unchanged", () => {
@@ -211,5 +232,17 @@ describe("computeGroupedRuns", () => {
     expect([...groups.keys()]).toEqual(["exp-1", "exp-2"]);
     expect(groups.get("exp-1").map((r) => r.name)).toEqual(["run-a", "run-c"]);
     expect(groups.get("exp-2").map((r) => r.name)).toEqual(["run-b"]);
+  });
+
+  test("groups by a literal 'Group' user config key when _Group has no variance", () => {
+    const groupedConfigs = {
+      "run-a": { Group: "team-a" },
+      "run-b": { Group: "team-b" },
+      "run-c": { Group: "team-a" },
+    };
+    const groups = computeGroupedRuns(runs, groupedConfigs, "Group");
+    expect([...groups.keys()]).toEqual(["team-a", "team-b"]);
+    expect(groups.get("team-a").map((r) => r.name)).toEqual(["run-a", "run-c"]);
+    expect(groups.get("team-b").map((r) => r.name)).toEqual(["run-b"]);
   });
 });

--- a/trackio/frontend/src/lib/staticApi.js
+++ b/trackio/frontend/src/lib/staticApi.js
@@ -459,6 +459,25 @@ export async function getProjectFiles() {
   return fileListData;
 }
 
+export async function getRunConfigs() {
+  const CONFIG_STRUCTURAL_KEYS = new Set(["id", "run_id", "run_name", "created_at"]);
+  const cfgRaw = await getConfigsData().catch(() => null);
+  if (!cfgRaw) return {};
+  const { rows } = parseRows(cfgRaw);
+  const result = {};
+  for (const row of rows) {
+    const runName = row.run_name;
+    if (!runName) continue;
+    const cfg = {};
+    for (const [key, value] of Object.entries(row)) {
+      if (CONFIG_STRUCTURAL_KEYS.has(key)) continue;
+      if (value !== null && value !== undefined) cfg[key] = value;
+    }
+    result[runName] = cfg;
+  }
+  return result;
+}
+
 export async function getRunMutationStatus() {
   return { allowed: false };
 }

--- a/trackio/frontend/src/lib/staticApi.js
+++ b/trackio/frontend/src/lib/staticApi.js
@@ -473,7 +473,7 @@ export async function getRunConfigs() {
       if (CONFIG_STRUCTURAL_KEYS.has(key)) continue;
       if (value !== null && value !== undefined) cfg[key] = value;
     }
-    result[runName] = cfg;
+    result[row.run_id ?? runName] = cfg;
   }
   return result;
 }

--- a/trackio/server.py
+++ b/trackio/server.py
@@ -684,6 +684,10 @@ def get_runs_for_project(project: str) -> list[dict[str, Any]]:
     return SQLiteStorage.get_run_records(project)
 
 
+def get_run_configs(project: str) -> dict[str, Any]:
+    return SQLiteStorage.get_all_run_configs(project)
+
+
 def get_metrics_for_run(
     project: str, run: str | None = None, run_id: str | None = None
 ) -> list[str]:
@@ -949,6 +953,7 @@ def _api_registry() -> dict[str, Any]:
         "get_alerts": get_alerts,
         "get_metric_values": get_metric_values,
         "get_runs_for_project": get_runs_for_project,
+        "get_run_configs": get_run_configs,
         "get_metrics_for_run": get_metrics_for_run,
         "get_all_projects": get_all_projects,
         "get_project_summary": get_project_summary,

--- a/trackio/sqlite_storage.py
+++ b/trackio/sqlite_storage.py
@@ -2872,16 +2872,17 @@ class SQLiteStorage:
         with SQLiteStorage._get_connection(db_path) as conn:
             cursor = conn.cursor()
             try:
-                cursor.execute(
-                    """
-                    SELECT run_id, config FROM configs
-                    """
+                config_col = (
+                    "run_id"
+                    if SQLiteStorage._supports_run_ids(conn, "configs")
+                    else "run_name"
                 )
+                cursor.execute(f"SELECT {config_col}, config FROM configs")
 
                 results = {}
                 for row in cursor.fetchall():
                     config = orjson.loads(row["config"])
-                    results[row["run_id"]] = deserialize_values(config)
+                    results[row[config_col]] = deserialize_values(config)
                 return results
             except sqlite3.OperationalError as e:
                 if "no such table: configs" in str(e):

--- a/trackio/sqlite_storage.py
+++ b/trackio/sqlite_storage.py
@@ -2874,14 +2874,14 @@ class SQLiteStorage:
             try:
                 cursor.execute(
                     """
-                    SELECT run_name, config FROM configs
+                    SELECT run_id, config FROM configs
                     """
                 )
 
                 results = {}
                 for row in cursor.fetchall():
                     config = orjson.loads(row["config"])
-                    results[row["run_name"]] = deserialize_values(config)
+                    results[row["run_id"]] = deserialize_values(config)
                 return results
             except sqlite3.OperationalError as e:
                 if "no such table: configs" in str(e):


### PR DESCRIPTION
---

## Short Description

<img width="1087" height="576" alt="trackio-grouping" src="https://github.com/user-attachments/assets/d4f5b878-9c3a-4382-90b0-192fc8a60a17" />

This PR adds support for grouping runs by config fields in the sidebar.

Users can select any run config key from a **Group by** dropdown. Runs are then displayed in labeled sections with select-all checkboxes per group.

Two reserved keys are promoted to the top of the dropdown:

- `_Group` — set via `wandb.init(group=...)`, displayed as **Group**
- `_Username` — displayed as **Username**

These reserved keys only appear when they have at least two distinct values across runs. Config keys prefixed with `_` that are not explicitly promoted are hidden from the dropdown.

## AI Disclosure

I used AI to write the code on this branch.

## Type of Change

- New feature, non-breaking

## Related Issues

Closes:

## Testing and Linting

- Added two integration tests for the `/get_run_configs` endpoint:
  - `test_get_run_configs_returns_config_per_run`
  - `test_get_run_configs_returns_empty_for_unknown_project`
- Added Vitest unit tests for `grouping.js`, covering:
  - Option computation
  - Key promotion and hiding
  - Variance filtering
  - Run bucketing
- Confirmed `pytest` passes
- Applied:
  - `ruff check --fix --select I`
  - `ruff format`

---