### PR TITLE
fix: serve static-Space assets at /static/trackio

### DIFF
--- a/.changeset/clean-deer-bake.md
+++ b/.changeset/clean-deer-bake.md
@@ -1,0 +1,5 @@
+---
+"trackio": minor
+---
+
+feat:fix: serve static-Space assets at /static/trackio

--- a/.changeset/clean-deer-bake.md
+++ b/.changeset/clean-deer-bake.md
@@ -1,5 +1,5 @@
 ---
-"trackio": minor
+"trackio": patch
 ---
 
 feat:fix: serve static-Space assets at /static/trackio

--- a/trackio/deploy.py
+++ b/trackio/deploy.py
@@ -993,7 +993,7 @@ def deploy_as_static_space(
                 repo_id=space_id,
                 repo_type="space",
                 folder_path=str(assets_dir),
-                path_in_repo="assets",
+                path_in_repo="static/trackio",
             ),
         )
 

--- a/trackio/frontend/src/lib/staticApi.js
+++ b/trackio/frontend/src/lib/staticApi.js
@@ -410,8 +410,8 @@ export async function getSettings() {
   const settings = await getSettingsJson();
   return {
     logo_urls: {
-      light: "/assets/trackio_logo_type_light_transparent.png",
-      dark: "/assets/trackio_logo_type_dark_transparent.png",
+      light: "/static/trackio/trackio_logo_type_light_transparent.png",
+      dark: "/static/trackio/trackio_logo_type_dark_transparent.png",
     },
     color_palette: settings.color_palette || [],
     plot_order: settings.plot_order || [],


### PR DESCRIPTION
Fixes #545.

The frontend bundle hard-codes asset paths under `/static/trackio/` — logo defaults in `App.svelte`/`Sidebar.svelte`, the favicon in `index.html`, and the loading-screen logo in `LoadingTrackio.svelte`. On a live server that path is mounted from `trackio/assets/` by `frontend_server.py`. On static-SDK Spaces we instead uploaded those files to `assets/` in the repo and patched `logo_urls` at runtime via `getSettings()`, which:

- leaves a broken-image flash on first paint while the async settings fetch is in flight (the original #545 symptom), and
- silently leaves the favicon and loading-screen logo broken on static Spaces, since nothing rewrites their URLs.

## Summary

- `trackio/deploy.py`: upload the assets folder to `static/trackio/` in the static-Space repo instead of `assets/`.
- `trackio/frontend/src/lib/staticApi.js`: point `logo_urls` at the same `/static/trackio/...` paths the bundle already uses.

The `/assets/` → `/static/trackio/` runtime swap is now unnecessary and removed.

## Note for existing static Spaces

Spaces deployed before this change have stale PNGs under `assets/` in their repo. After the next `trackio.sync(..., sdk="static")` the live URLs will resolve correctly from `static/trackio/`, but the old files will linger. Harmless; can be removed manually if desired.

## Test plan

- [x] `npm test` — all frontend tests pass.
- [x] `npm run build` — production build succeeds.
- [x] `ruff check` / `ruff format` clean.
- [ ] Deploy a static Space with `trackio.sync(..., sdk="static")` and confirm the logo, favicon, and loading screen all render on first paint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)