### PR TITLE
fix: keep selected x-axis option in dropdown and dismiss dropdown on re-click

### DIFF
--- a/.changeset/warm-drinks-kick.md
+++ b/.changeset/warm-drinks-kick.md
@@ -1,0 +1,5 @@
+---
+"trackio": minor
+---
+
+feat:fix: keep selected x-axis option in dropdown and dismiss dropdown on re-click

--- a/trackio/frontend/src/components/Dropdown.svelte
+++ b/trackio/frontend/src/components/Dropdown.svelte
@@ -68,6 +68,13 @@
     }
   }
 
+  function handleMouseDown(e) {
+    if (showOptions) {
+      e.preventDefault();
+      filterInput?.blur();
+    }
+  }
+
   function handleBlur() {
     if (choices.includes(inputText)) {
       value = inputText;
@@ -143,6 +150,7 @@
           autocomplete="off"
           bind:value={inputText}
           bind:this={filterInput}
+          onmousedown={handleMouseDown}
           onkeydown={handleKeydown}
           onblur={handleBlur}
           onfocus={handleFocus}

--- a/trackio/frontend/src/pages/Metrics.svelte
+++ b/trackio/frontend/src/pages/Metrics.svelte
@@ -140,11 +140,12 @@
     const originals = allRows.filter(
       (r) => r.data_type === "original" || !r.data_type,
     );
-    const cols = getMetricColumns(originals).filter(
-      (c) => c !== xColumn && c !== "run" && c !== "data_type" && c !== "x_axis",
+    const allCols = getMetricColumns(originals).filter(
+      (c) => c !== "run" && c !== "data_type" && c !== "x_axis",
     );
+    const cols = allCols.filter((c) => c !== xColumn);
     metrics = cols;
-    metricColumns = cols;
+    metricColumns = allCols;
 
     const countPerRunMetric = new Map();
     for (const r of originals) {


### PR DESCRIPTION
## Short description

Fixes issue where if you select a X-axis variable except for `step` or `time` it would get removed from the X-axis dropdown list.

Also, we now dismiss the dropdown list if you click on the dropdown again.

<img width="1085" height="639" alt="trackio-dropdown-3" src="https://github.com/user-attachments/assets/da9a6e7c-b368-445e-8d5d-ededc2ef17e0" />

## AI Disclosure

- [x] I used AI to write this PR

## Type of Change

- [x] Bug fix

## Related Issues

N/A

## Testing and linting

Please run tests before submitting changes:
   ```bash
   python -m pytest
   ```

and format your code using Ruff:

   ```bash
   ruff check --fix --select I && ruff format
   ```
