### PR TITLE
Store traces separately from metrics

### DIFF
--- a/.changeset/thick-vans-vanish.md
+++ b/.changeset/thick-vans-vanish.md
@@ -1,0 +1,5 @@
+---
+"trackio": minor
+---
+
+feat:Avoid loading trace payloads in Metrics

--- a/trackio/frontend/src/lib/api.js
+++ b/trackio/frontend/src/lib/api.js
@@ -105,6 +105,83 @@ export async function getLogsBatch(project, runs) {
   return await callApi("/get_logs_batch", payload);
 }
 
+function sqlString(value) {
+  return `'${String(value ?? "").replaceAll("'", "''")}'`;
+}
+
+function scalarLogsFromQueryRows(rows) {
+  return (rows || []).map((row) => {
+    const metrics = (() => {
+      try {
+        return JSON.parse(row.metrics || "{}");
+      } catch {
+        return {};
+      }
+    })();
+    return {
+      ...metrics,
+      timestamp: row.timestamp,
+      step: row.step,
+    };
+  });
+}
+
+function scalarOnlyLogs(logs) {
+  return (logs || []).map((row) => {
+    const out = {
+      timestamp: row.timestamp,
+      step: row.step,
+    };
+    for (const [key, value] of Object.entries(row)) {
+      if (key === "timestamp" || key === "step") continue;
+      if (typeof value === "number" && Number.isFinite(value)) out[key] = value;
+    }
+    return out;
+  });
+}
+
+async function queryProject(project, query) {
+  return await callApi("/query_project", { project, query });
+}
+
+export async function getScalarLogsBatch(project, runs) {
+  if (await isStaticMode()) {
+    const out = [];
+    for (const run of runs) {
+      const logs = await staticApi.getLogs(project, run);
+      out.push({ ...normalizeRun(run), logs: scalarOnlyLogs(logs) });
+    }
+    return out;
+  }
+
+  const out = [];
+  for (const run of runs) {
+    const normalized = normalizeRun(run);
+    const where = normalized.run_id
+      ? `m.run_id = ${sqlString(normalized.run_id)}`
+      : `m.run_name = ${sqlString(normalized.run)}`;
+    const result = await queryProject(
+      project,
+      `
+        SELECT
+          m.timestamp,
+          m.step,
+          json_group_object(j.key, j.value) AS metrics
+        FROM metrics m, json_each(CAST(m.metrics AS TEXT)) j
+        WHERE ${where}
+          AND j.type IN ('integer', 'real')
+        GROUP BY m.id, m.timestamp, m.step
+        ORDER BY timestamp
+      `,
+    );
+    out.push({
+      ...normalized,
+      logs: scalarLogsFromQueryRows(result.rows),
+    });
+  }
+  return out;
+}
+
 export async function getTraces(project, run, options = {}) {
   const params = { project, ...normalizeRun(run), ...options };
   if (await isStaticMode()) return staticApi.getTraces(project, run, options);

--- a/trackio/frontend/src/lib/api.test.js
+++ b/trackio/frontend/src/lib/api.test.js
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+function jsonResponse(data, ok = true, status = 200) {
+  return {
+    ok,
+    status,
+    async json() {
+      return data;
+    },
+  };
+}
+
+async function loadApi() {
+  vi.resetModules();
+  globalThis.window = { __trackio_base: "" };
+  globalThis.sessionStorage = {
+    getItem: vi.fn(() => null),
+  };
+  return await import("./api.js");
+}
+
+describe("getScalarLogsBatch", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    delete globalThis.fetch;
+    delete globalThis.window;
+    delete globalThis.sessionStorage;
+  });
+
+  test("returns all scalar query rows without fetching trace payloads", async () => {
+    const queryRows = Array.from({ length: 1601 }, (_, index) => ({
+      timestamp: `2026-01-01T00:${String(index % 60).padStart(2, "0")}:00Z`,
+      step: index,
+      metrics: JSON.stringify({ "train/loss": index, "train/lr": index / 1000 }),
+    }));
+
+    let query = "";
+    const fetch = vi.fn(async (url, options) => {
+      if (url === "/config.json") {
+        return jsonResponse({ mode: "server" });
+      }
+      if (url === "/api/query_project") {
+        const body = JSON.parse(options.body);
+        query = body.query;
+        return jsonResponse({
+          data: {
+            rows: queryRows,
+          },
+        });
+      }
+      throw new Error(`Unexpected fetch URL: ${url}`);
+    });
+    globalThis.fetch = fetch;
+
+    const { getScalarLogsBatch } = await loadApi();
+    const result = await getScalarLogsBatch("proj", [{ id: "run-1", name: "run-name" }]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].logs).toHaveLength(queryRows.length);
+    expect(result[0].logs[1600]).toMatchObject({
+      timestamp: queryRows[1600].timestamp,
+      step: 1600,
+      "train/loss": 1600,
+      "train/lr": 1.6,
+    });
+
+    expect(query).toContain("AND j.type IN ('integer', 'real')");
+    expect(query).toContain("GROUP BY m.id, m.timestamp, m.step");
+    expect(query).toContain("ORDER BY timestamp");
+    expect(query).not.toContain("ROW_NUMBER");
+    expect(query).not.toContain("row_count");
+    expect(query).not.toContain("1500");
+  });
+});

--- a/trackio/frontend/src/pages/Metrics.svelte
+++ b/trackio/frontend/src/pages/Metrics.svelte
@@ -5,7 +5,7 @@
   import BarPlot from "../components/BarPlot.svelte";
   import Accordion from "../components/Accordion.svelte";
   import LoadingTrackio from "../components/LoadingTrackio.svelte";
-  import { getLogsBatch } from "../lib/api.js";
+  import { getScalarLogsBatch } from "../lib/api.js";
   import {
     getMetricsPollIntervalMs,
     isRateLimitCooldownActive,
@@ -168,7 +168,7 @@
     const results = [];
     for (let i = 0; i < runs.length; i += MAX_BATCH_RUNS) {
       const chunk = runs.slice(i, i + MAX_BATCH_RUNS);
-      const batch = await getLogsBatch(project, chunk);
+      const batch = await getScalarLogsBatch(project, chunk);
       results.push(...batch);
     }
     return results;


### PR DESCRIPTION
## Summary
- Add a dedicated SQLite `traces` table and split `Trace` payloads out of metric rows at write time.
- Make `get_traces` query the traces table directly with backend search, sorting, limit, and offset instead of loading all metric logs and slicing in Python.
- Export/import traces through parquet and teach the static frontend API to read `aux/traces.parquet`.
- Keep scalar metric logs free of large trace payloads by construction.

## Validation
- pytest tests/unit/test_trace.py -q
- pytest tests/unit/test_sqlite_storage.py -q
- python -m compileall -q trackio
- npm --prefix trackio/frontend run lint
- npm --prefix trackio/frontend run build