### PR TITLE
Paginate Traces tab with step filter

### DIFF
--- a/.changeset/young-views-do.md
+++ b/.changeset/young-views-do.md
@@ -1,0 +1,5 @@
+---
+"trackio": minor
+---
+
+feat:Paginate Traces tab with step filter

--- a/examples/traces/large-trace-batch.py
+++ b/examples/traces/large-trace-batch.py
@@ -1,0 +1,95 @@
+"""Stress-test the Traces viewer with a large batched trace run.
+
+Logs N_STEPS training steps, each containing TRACES_PER_STEP traces, to give
+the trace viewer a realistic large batched workload (e.g. an RL training loop
+where each step rolls out a batch of samples).
+"""
+
+import random
+
+import trackio
+
+PROJECT_NAME = "trace-perf-large-batch"
+N_STEPS = 200
+TRACES_PER_STEP = 40
+
+QUESTIONS = [
+    "Solve the math problem step by step.",
+    "Summarize this passage in one sentence.",
+    "Translate the following to French.",
+    "Write Python code that does what is asked.",
+    "Explain the concept like I'm five.",
+    "Critique the assistant's previous answer.",
+    "Continue the story with one more paragraph.",
+    "Identify the bug in this code.",
+]
+
+PROMPTS = [
+    "What is the derivative of x^3 + 2x?",
+    "Why is the sky blue at noon and red at sunset?",
+    "Refactor this loop to use map().",
+    "List three pros and cons of unit testing.",
+    "Compose a haiku about gradient descent.",
+    "Outline the proof of the Pythagorean theorem.",
+    "Describe a transformer in two sentences.",
+    "Suggest a name for a friendly chatbot.",
+]
+
+COMPLETIONS = [
+    "The derivative is 3x^2 + 2.",
+    "Rayleigh scattering: shorter wavelengths scatter more in the atmosphere.",
+    "Use [fn(x) for x in items] or list(map(fn, items)).",
+    "Pros: confidence, regression catch, design pressure. Cons: maintenance, false sense of security, slow when over-mocked.",
+    "Slopes descend slowly, / Learning rate kisses the loss, / Minima nearby.",
+    "Construct squares on each side; show areas a^2 + b^2 = c^2 by rearrangement.",
+    "A transformer is a sequence model built from self-attention layers and feed-forward blocks.",
+    "Call it Trax — it tracks the conversation and stays out of the way.",
+]
+
+if __name__ == "__main__":
+    print(
+        f"Logging {N_STEPS} steps x {TRACES_PER_STEP} traces "
+        f"= {N_STEPS * TRACES_PER_STEP} total traces..."
+    )
+
+    run = trackio.init(project=PROJECT_NAME, name="rollout-batch")
+
+    for step in range(N_STEPS):
+        loss = max(0.01, 2.5 * (0.985**step) + random.uniform(-0.05, 0.05))
+        reward = min(1.0, 0.1 + step / N_STEPS + random.uniform(-0.05, 0.05))
+
+        rollouts = []
+        for trace_idx in range(TRACES_PER_STEP):
+            question = QUESTIONS[trace_idx % len(QUESTIONS)]
+            prompt = PROMPTS[trace_idx % len(PROMPTS)]
+            completion = COMPLETIONS[trace_idx % len(COMPLETIONS)]
+            rollouts.append(
+                trackio.Trace(
+                    messages=[
+                        {"role": "system", "content": question},
+                        {"role": "user", "content": prompt},
+                        {
+                            "role": "assistant",
+                            "content": (
+                                f"[step {step} | sample {trace_idx}] {completion}"
+                            ),
+                        },
+                    ],
+                    metadata={
+                        "sample_index": trace_idx,
+                        "reward": round(random.uniform(0.0, 1.0), 4),
+                        "tokens": random.randint(40, 220),
+                    },
+                )
+            )
+
+        trackio.log(
+            {"loss": loss, "reward": reward, "rollouts": rollouts},
+            step=step,
+        )
+
+        if step % 20 == 0:
+            print(f"  step {step}/{N_STEPS}")
+
+    trackio.finish()
+    print(f"Done. Open the dashboard and pick project '{PROJECT_NAME}' to view traces.")

--- a/trackio/frontend/src/lib/api.js
+++ b/trackio/frontend/src/lib/api.js
@@ -111,6 +111,12 @@ export async function getTraces(project, run, options = {}) {
   return await callApi("/get_traces", params);
 }
 
+export async function getTraceSteps(project, run) {
+  const params = { project, ...normalizeRun(run) };
+  if (await isStaticMode()) return staticApi.getTraceSteps(project, run);
+  return await callApi("/get_trace_steps", params);
+}
+
 export async function getProjectSummary(project) {
   if (await isStaticMode()) return staticApi.getProjectSummary(project);
   return await callApi("/get_project_summary", { project });

--- a/trackio/frontend/src/lib/staticApi.js
+++ b/trackio/frontend/src/lib/staticApi.js
@@ -234,6 +234,21 @@ function parseTraceJsonField(value, fallback) {
   }
 }
 
+export async function getTraceSteps(_project, run) {
+  const raw = await getTracesData();
+  const counts = new Map();
+  for (const row of raw) {
+    if (!matchesRun(row, run)) continue;
+    const step = row.step;
+    counts.set(step, (counts.get(step) || 0) + 1);
+  }
+  const steps = [...counts.entries()]
+    .map(([step, count]) => ({ step, count }))
+    .sort((a, b) => (a.step ?? 0) - (b.step ?? 0));
+  const total = steps.reduce((acc, item) => acc + item.count, 0);
+  return { total, steps };
+}
+
 export async function getTraces(_project, run, options = {}) {
   const normalizedRun = normalizeRun(run);
   const raw = await getTracesData();
@@ -254,6 +269,9 @@ export async function getTraces(_project, run, options = {}) {
   });
 
   let filtered = traces;
+  if (options.step != null) {
+    filtered = filtered.filter((trace) => trace.step === options.step);
+  }
   if (options.search && options.search.trim()) {
     const needle = options.search.trim().toLowerCase();
     filtered = filtered.filter((trace) => trace._search_text.includes(needle));

--- a/trackio/frontend/src/pages/Traces.svelte
+++ b/trackio/frontend/src/pages/Traces.svelte
@@ -1,18 +1,29 @@
 <script>
   import LoadingTrackio from "../components/LoadingTrackio.svelte";
-  import { getMediaUrl, getTraces } from "../lib/api.js";
+  import { getMediaUrl, getTraces, getTraceSteps } from "../lib/api.js";
 
   let {
     project = null,
     selectedRuns = [],
   } = $props();
 
+  const PAGE_SIZE = 50;
+
   let loading = $state(false);
   let search = $state("");
   let sortBy = $state("request_time_desc");
+  let stepFilter = $state("all");
+  let page = $state(0);
   let expandedTraceId = $state(null);
   let traces = $state([]);
+  let availableSteps = $state([]);
+  let totalCount = $state(0);
   let loadRequestId = 0;
+  let summaryRequestId = 0;
+
+  function runsKey(runs) {
+    return runs.map((r) => `${r.id || ""}:${r.name || ""}`).join("|");
+  }
 
   function textFromContent(content) {
     if (typeof content === "string") return content;
@@ -44,7 +55,7 @@
     };
   }
 
-  function sortTraces(items, sort) {
+  function mergeSortedTraces(items, sort) {
     return [...items].sort((left, right) => {
       switch (sort) {
         case "step_asc":
@@ -60,7 +71,39 @@
     });
   }
 
-  async function loadTraces(searchQuery, sort) {
+  async function loadSummary() {
+    const requestId = ++summaryRequestId;
+    if (!project || selectedRuns.length === 0) {
+      availableSteps = [];
+      totalCount = 0;
+      return;
+    }
+    try {
+      const results = await Promise.all(
+        selectedRuns.map((run) => getTraceSteps(project, run)),
+      );
+      if (requestId !== summaryRequestId) return;
+      const merged = new Map();
+      let total = 0;
+      for (const result of results) {
+        total += result?.total || 0;
+        for (const entry of result?.steps || []) {
+          merged.set(entry.step, (merged.get(entry.step) || 0) + entry.count);
+        }
+      }
+      availableSteps = [...merged.entries()]
+        .map(([step, count]) => ({ step, count }))
+        .sort((a, b) => (a.step ?? 0) - (b.step ?? 0));
+      totalCount = total;
+    } catch (error) {
+      if (requestId !== summaryRequestId) return;
+      console.error("Failed to load trace summary:", error);
+      availableSteps = [];
+      totalCount = 0;
+    }
+  }
+
+  async function loadTraces(searchQuery, sort, stepValue, currentPage) {
     const requestId = ++loadRequestId;
     if (!project || selectedRuns.length === 0) {
       traces = [];
@@ -70,17 +113,30 @@
 
     loading = true;
     try {
+      const stepNum = stepValue === "all" ? null : Number(stepValue);
+      const offset = currentPage * PAGE_SIZE;
+      const isSingleRun = selectedRuns.length === 1;
+      const perRunLimit = isSingleRun ? PAGE_SIZE : offset + PAGE_SIZE;
+      const perRunOffset = isSingleRun ? offset : 0;
+
       const batches = await Promise.all(
         selectedRuns.map(async (run) => {
           const runTraces = await getTraces(project, run, {
             search: searchQuery,
             sort,
+            step: stepNum,
+            limit: perRunLimit,
+            offset: perRunOffset,
           });
           return runTraces.map((trace) => normalizeTrace(trace, run.name));
         }),
       );
       if (requestId !== loadRequestId) return;
-      traces = sortTraces(batches.flat(), sort);
+      let merged = mergeSortedTraces(batches.flat(), sort);
+      if (!isSingleRun) {
+        merged = merged.slice(offset, offset + PAGE_SIZE);
+      }
+      traces = merged;
       if (!traces.find((trace) => trace.id === expandedTraceId)) {
         expandedTraceId = null;
       }
@@ -95,16 +151,36 @@
     }
   }
 
+  let lastRunsKey = "";
+  let lastSearch = "";
+  let lastSort = "";
+  let lastStep = "all";
+
   $effect(() => {
     project;
-    selectedRuns;
-    search;
-    sortBy;
+    const key = runsKey(selectedRuns);
+    if (key !== lastRunsKey) {
+      lastRunsKey = key;
+      page = 0;
+      stepFilter = "all";
+      loadSummary();
+    }
+  });
+
+  $effect(() => {
+    const trimmed = search.trim();
+    if (trimmed !== lastSearch || sortBy !== lastSort || stepFilter !== lastStep) {
+      if (lastSearch !== "" || trimmed !== "" || sortBy !== lastSort || stepFilter !== lastStep) {
+        page = 0;
+      }
+      lastSearch = trimmed;
+      lastSort = sortBy;
+      lastStep = stepFilter;
+    }
 
     const timeout = setTimeout(() => {
-      loadTraces(search.trim(), sortBy);
+      loadTraces(trimmed, sortBy, stepFilter, page);
     }, 150);
-
     return () => clearTimeout(timeout);
   });
 
@@ -189,16 +265,25 @@
     return Object.entries(trace.metadata || {});
   }
 
-  function countLabel() {
-    if (!search.trim()) return `${traces.length} trace${traces.length === 1 ? "" : "s"}`;
-    return `${traces.length} match${traces.length === 1 ? "" : "es"}`;
+  let activeTotal = $derived.by(() => {
+    if (stepFilter === "all") return totalCount;
+    const stepNum = Number(stepFilter);
+    const entry = availableSteps.find((s) => s.step === stepNum);
+    return entry ? entry.count * Math.max(1, selectedRuns.length) : 0;
+  });
+
+  let totalPages = $derived(Math.max(1, Math.ceil(activeTotal / PAGE_SIZE)));
+
+  function gotoPrev() {
+    if (page > 0) page -= 1;
+  }
+  function gotoNext() {
+    if (page < totalPages - 1) page += 1;
   }
 </script>
 
 <div class="traces-page">
-  {#if loading}
-    <LoadingTrackio />
-  {:else if !project}
+  {#if !project}
     <div class="empty-state">
       <h2>Select a project</h2>
       <p>Pick a project to browse trace logs.</p>
@@ -213,7 +298,16 @@
       <div class="search-wrap">
         <input type="text" bind:value={search} placeholder="Search traces by request" />
       </div>
-      <label class="sort-wrap">
+      <label class="filter-wrap">
+        <span>Step:</span>
+        <select bind:value={stepFilter}>
+          <option value="all">All steps ({totalCount})</option>
+          {#each availableSteps as entry}
+            <option value={String(entry.step)}>Step {entry.step} ({entry.count})</option>
+          {/each}
+        </select>
+      </label>
+      <label class="filter-wrap">
         <span>Sort:</span>
         <select bind:value={sortBy}>
           <option value="request_time_desc">Request time</option>
@@ -222,16 +316,20 @@
           <option value="step_asc">Step ascending</option>
         </select>
       </label>
-      <div class="count">{countLabel()}</div>
+      <div class="count">
+        {activeTotal} trace{activeTotal === 1 ? "" : "s"}
+      </div>
     </div>
 
-    {#if traces.length === 0}
+    {#if loading && traces.length === 0}
+      <LoadingTrackio />
+    {:else if traces.length === 0}
       <div class="empty-state">
         <h2>No traces match the current filters</h2>
-        <p>Try a different search query or model filter.</p>
+        <p>Try a different search query, step, or run selection.</p>
       </div>
     {:else}
-      <div class="traces-table-wrap">
+      <div class="traces-table-wrap" class:dim={loading}>
         <table class="traces-table">
           <thead>
             <tr>
@@ -243,7 +341,7 @@
             </tr>
           </thead>
           <tbody>
-            {#each traces as trace}
+            {#each traces as trace (trace.id)}
               <tr
                 class="trace-row"
                 role="button"
@@ -331,6 +429,22 @@
           </tbody>
         </table>
       </div>
+
+      <div class="pagination">
+        <button type="button" onclick={gotoPrev} disabled={page === 0 || loading}>
+          ← Previous
+        </button>
+        <span class="page-info">
+          Page {page + 1} of {totalPages}
+        </span>
+        <button
+          type="button"
+          onclick={gotoNext}
+          disabled={page >= totalPages - 1 || loading}
+        >
+          Next →
+        </button>
+      </div>
     {/if}
   {/if}
 </div>
@@ -352,7 +466,7 @@
     flex: 1;
   }
   .search-wrap input,
-  .sort-wrap select {
+  .filter-wrap select {
     width: 100%;
     border: 1px solid var(--border-color-primary, #e5e7eb);
     border-radius: var(--radius-md, 6px);
@@ -362,7 +476,7 @@
     padding: 10px 12px;
     font-family: inherit;
   }
-  .sort-wrap {
+  .filter-wrap {
     display: flex;
     align-items: center;
     gap: 8px;
@@ -380,6 +494,10 @@
     border: 1px solid var(--border-color-primary, #e5e7eb);
     border-radius: var(--radius-lg, 8px);
     overflow: hidden;
+    transition: opacity 0.15s ease;
+  }
+  .traces-table-wrap.dim {
+    opacity: 0.55;
   }
   .traces-table {
     width: 100%;
@@ -428,6 +546,10 @@
     color: var(--body-text-color-subdued, #6b7280);
     font-size: 13px;
     line-height: 1.45;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
   }
   .expanded-row td {
     padding: 0;
@@ -526,6 +648,36 @@
   .empty-state p {
     margin: 12px 0 8px;
     color: var(--body-text-color-subdued, #6b7280);
+  }
+  .pagination {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 12px;
+    padding: 16px 0 4px;
+  }
+  .pagination button {
+    border: 1px solid var(--border-color-primary, #e5e7eb);
+    border-radius: var(--radius-md, 6px);
+    background: var(--background-fill-primary, white);
+    color: var(--body-text-color, #1f2937);
+    font-size: 14px;
+    padding: 8px 14px;
+    cursor: pointer;
+    font-family: inherit;
+  }
+  .pagination button:hover:not(:disabled) {
+    background: var(--background-fill-secondary, #f9fafb);
+  }
+  .pagination button:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+  .page-info {
+    color: var(--body-text-color-subdued, #6b7280);
+    font-size: 14px;
+    min-width: 120px;
+    text-align: center;
   }
   @media (max-width: 1100px) {
     .toolbar {

--- a/trackio/run.py
+++ b/trackio/run.py
@@ -840,6 +840,20 @@ class Run:
                         project=self.project, run=self.name, step=media_step
                     )
                     self._scan_and_queue_media_uploads(metrics[key], media_step)
+                elif (
+                    isinstance(value, list)
+                    and value
+                    and all(isinstance(item, Trace) for item in value)
+                ):
+                    converted = [
+                        item._to_dict(
+                            project=self.project, run=self.name, step=media_step
+                        )
+                        for item in value
+                    ]
+                    metrics[key] = converted
+                    for item in converted:
+                        self._scan_and_queue_media_uploads(item, media_step)
                 elif isinstance(value, Histogram):
                     metrics[key] = value._to_dict()
                 elif isinstance(value, Markdown):

--- a/trackio/server.py
+++ b/trackio/server.py
@@ -837,6 +837,7 @@ def get_traces(
     sort: str | None = None,
     limit: int | None = None,
     offset: int | None = 0,
+    step: int | None = None,
 ) -> list[dict[str, Any]]:
     try:
         normalized_offset = max(0, int(offset)) if offset is not None else 0
@@ -850,6 +851,14 @@ def get_traces(
             normalized_limit = max(0, int(limit))
         except (TypeError, ValueError):
             normalized_limit = None
+    normalized_step: int | None
+    if step is None:
+        normalized_step = None
+    else:
+        try:
+            normalized_step = int(step)
+        except (TypeError, ValueError):
+            normalized_step = None
     normalized_sort = sort if sort in _ALLOWED_TRACE_SORTS else None
     return SQLiteStorage.get_traces(
         project,
@@ -859,7 +868,16 @@ def get_traces(
         limit=normalized_limit,
         offset=normalized_offset,
         run_id=run_id,
+        step=normalized_step,
     )
+
+
+def get_trace_steps(
+    project: str,
+    run: str | None = None,
+    run_id: str | None = None,
+) -> dict[str, Any]:
+    return SQLiteStorage.get_trace_steps(project, run, run_id=run_id)
 
 
 def query_project(project: str, query: str) -> dict[str, Any]:
@@ -960,6 +978,7 @@ def _api_registry() -> dict[str, Any]:
         "get_logs": get_logs,
         "get_logs_batch": get_logs_batch,
         "get_traces": get_traces,
+        "get_trace_steps": get_trace_steps,
         "query_project": query_project,
         "get_settings": get_settings,
         "get_project_files": get_project_files,

--- a/trackio/sqlite_storage.py
+++ b/trackio/sqlite_storage.py
@@ -2196,6 +2196,7 @@ class SQLiteStorage:
         limit: int | None = None,
         offset: int = 0,
         run_id: str | None = None,
+        step: int | None = None,
     ) -> list[dict[str, Any]]:
         try:
             offset = max(0, int(offset or 0))
@@ -2228,6 +2229,9 @@ class SQLiteStorage:
 
                 where = [f"{run_identity[0]} = ?"]
                 params: list[Any] = [run_identity[1]]
+                if step is not None:
+                    where.append("step = ?")
+                    params.append(step)
                 if search:
                     needle = search.strip().lower()
                     if needle:
@@ -2271,6 +2275,49 @@ class SQLiteStorage:
             }
             for row in rows
         ]
+
+    @staticmethod
+    def get_trace_steps(
+        project: str,
+        run: str | None = None,
+        run_id: str | None = None,
+    ) -> dict[str, Any]:
+        """Return per-step trace counts and total for a run.
+
+        Returns: {"total": int, "steps": [{"step": int, "count": int}, ...]}
+        Steps are returned in ascending order.
+        """
+        db_path = SQLiteStorage.get_project_db_path(project)
+        if not db_path.exists():
+            return {"total": 0, "steps": []}
+
+        try:
+            with SQLiteStorage._get_connection(db_path) as conn:
+                run_identity = SQLiteStorage._resolve_run_identity(
+                    conn, run_name=run, run_id=run_id, table="traces"
+                )
+                if run_identity is None:
+                    return {"total": 0, "steps": []}
+                cursor = conn.cursor()
+                cursor.execute(
+                    f"""
+                    SELECT step, COUNT(*) AS c
+                    FROM traces
+                    WHERE {run_identity[0]} = ?
+                    GROUP BY step
+                    ORDER BY step ASC
+                    """,
+                    (run_identity[1],),
+                )
+                rows = cursor.fetchall()
+        except sqlite3.OperationalError as e:
+            if "no such table: traces" in str(e):
+                return {"total": 0, "steps": []}
+            raise
+
+        steps = [{"step": row["step"], "count": row["c"]} for row in rows]
+        total = sum(item["count"] for item in steps)
+        return {"total": total, "steps": steps}
 
     @staticmethod
     def load_from_dataset():


### PR DESCRIPTION
Continuing the work that @edbeeching started in https://github.com/gradio-app/trackio/pull/540, this PR implements:

- Server-paginated Traces tab: `get_traces` gains `step` + `limit`/`offset`; new `get_trace_steps` returns per-step counts.
- `Traces.svelte` adds a step dropdown and 50/page prev/next; existing search, sort, and expandable rows are preserved.
- `trackio.log()` accepts `list[Trace]` so one step can carry a batch of rollouts.
- Example: `examples/traces/large-trace-batch.py` logs 200 steps × 40 traces (8000 total) for performance testing.
