### PR TITLE
Fix Traces UI a bit

### DIFF
--- a/.changeset/eager-meals-call.md
+++ b/.changeset/eager-meals-call.md
@@ -1,0 +1,5 @@
+---
+"trackio": minor
+---
+
+feat:Fix Traces UI a bit

--- a/.changeset/eager-meals-call.md
+++ b/.changeset/eager-meals-call.md
@@ -1,5 +1,5 @@
 ---
-"trackio": minor
+"trackio": patch
 ---
 
 feat:Fix Traces UI a bit

--- a/trackio/frontend/src/pages/Traces.svelte
+++ b/trackio/frontend/src/pages/Traces.svelte
@@ -151,23 +151,26 @@
     }
   }
 
-  let lastRunsKey = "";
+  let lastScopeKey = "";
   let lastSearch = "";
   let lastSort = "";
   let lastStep = "all";
 
   $effect(() => {
-    project;
-    const key = runsKey(selectedRuns);
-    if (key !== lastRunsKey) {
-      lastRunsKey = key;
+    const scopeKey = `${project || ""}::${runsKey(selectedRuns)}`;
+    if (scopeKey !== lastScopeKey) {
+      lastScopeKey = scopeKey;
       page = 0;
       stepFilter = "all";
+      expandedTraceId = null;
+      traces = [];
       loadSummary();
     }
   });
 
   $effect(() => {
+    project;
+    runsKey(selectedRuns);
     const trimmed = search.trim();
     if (trimmed !== lastSearch || sortBy !== lastSort || stepFilter !== lastStep) {
       if (lastSearch !== "" || trimmed !== "" || sortBy !== lastSort || stepFilter !== lastStep) {
@@ -261,18 +264,34 @@
     return typeof text === "string" && text.length > 500;
   }
 
-  function displayTraceId(id) {
-    if (!id) return "—";
+  function publicTraceId(id) {
+    if (!id) return "";
     const parts = String(id).split(":");
     if (parts.length >= 4) {
-      const logId = parts[1] || parts[0];
+      const logId = parts[1];
       const index = parts[parts.length - 1];
-      return `${logId.slice(0, 12)}…:${index}`;
+      return index !== "" && !Number.isNaN(Number(index)) ? `${logId}:${index}` : logId;
     }
-    const text = String(id);
-    if (text.length <= 18) return text;
-    return `…${text.slice(-18)}`;
+    return String(id);
   }
+
+  function traceHash(id) {
+    if (!id) return "";
+    const parts = String(id).split(":");
+    const source = parts.length >= 4 ? parts[1] || parts[0] : String(id);
+    return source.replace(/[^a-zA-Z0-9]/g, "").slice(0, 7) || source.slice(0, 7);
+  }
+
+  function traceIndex(id) {
+    if (!id) return null;
+    const parts = String(id).split(":");
+    if (parts.length >= 4) {
+      const last = parts[parts.length - 1];
+      if (last !== "" && !Number.isNaN(Number(last))) return last;
+    }
+    return null;
+  }
+
 
   function formatMetadataValue(value) {
     if (value == null) return "—";
@@ -382,7 +401,11 @@
                 onkeydown={(event) => handleRowKeydown(event, trace.id)}
               >
                 <td class="trace-id-cell">
-                  <span class="trace-id" title={trace.id}>{displayTraceId(trace.id)}</span>
+                  <span class="trace-id-chip" title={publicTraceId(trace.id)}
+                    >{traceHash(trace.id)}{traceIndex(trace.id) !== null
+                      ? `:${traceIndex(trace.id)}`
+                      : ""}</span
+                  >
                 </td>
                 <td class="request-cell">
                   <div class="request">{trace.request}</div>
@@ -397,7 +420,7 @@
                   <td colspan="5">
                     <div class="trace-detail">
                       <div class="detail-meta">
-                        <span>Trace ID: {trace.id}</span>
+                        <span>Trace ID: {publicTraceId(trace.id)}</span>
                         <span>Logged as: {trace.key}</span>
                         <span>Timestamp: {trace.timestamp || "—"}</span>
                         {#each metadataEntries(trace) as [key, value]}
@@ -538,7 +561,7 @@
     table-layout: fixed;
   }
   .trace-id-col {
-    width: 160px;
+    width: 140px;
   }
   .request-col {
     width: auto;
@@ -575,19 +598,10 @@
   .trace-row:hover {
     background: var(--background-fill-secondary, #f9fafb);
   }
-  .trace-id {
-    display: inline-block;
-    max-width: 136px;
-    background: var(--background-fill-secondary, #f3f4f6);
-    color: var(--body-text-color, #1f2937);
-    border: 1px solid var(--border-color-primary, #e5e7eb);
-    border-radius: var(--radius-md, 6px);
-    padding: 6px 10px;
+  .trace-id-chip {
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
     font-size: 13px;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    line-height: 1.35;
+    color: #000;
   }
   .request {
     font-weight: 500;

--- a/trackio/frontend/src/pages/Traces.svelte
+++ b/trackio/frontend/src/pages/Traces.svelte
@@ -261,6 +261,30 @@
     return typeof text === "string" && text.length > 500;
   }
 
+  function displayTraceId(id) {
+    if (!id) return "—";
+    const parts = String(id).split(":");
+    if (parts.length >= 4) {
+      const logId = parts[1] || parts[0];
+      const index = parts[parts.length - 1];
+      return `${logId.slice(0, 12)}…:${index}`;
+    }
+    const text = String(id);
+    if (text.length <= 18) return text;
+    return `…${text.slice(-18)}`;
+  }
+
+  function formatMetadataValue(value) {
+    if (value == null) return "—";
+    if (typeof value === "string") return value;
+    if (typeof value === "number" || typeof value === "boolean") return String(value);
+    try {
+      return JSON.stringify(value);
+    } catch (_error) {
+      return String(value);
+    }
+  }
+
   function metadataEntries(trace) {
     return Object.entries(trace.metadata || {});
   }
@@ -331,6 +355,13 @@
     {:else}
       <div class="traces-table-wrap" class:dim={loading}>
         <table class="traces-table">
+          <colgroup>
+            <col class="trace-id-col" />
+            <col class="request-col" />
+            <col class="run-col" />
+            <col class="step-col" />
+            <col class="request-time-col" />
+          </colgroup>
           <thead>
             <tr>
               <th>Trace ID</th>
@@ -351,7 +382,7 @@
                 onkeydown={(event) => handleRowKeydown(event, trace.id)}
               >
                 <td class="trace-id-cell">
-                  <span class="trace-id">{trace.id}</span>
+                  <span class="trace-id" title={trace.id}>{displayTraceId(trace.id)}</span>
                 </td>
                 <td class="request-cell">
                   <div class="request">{trace.request}</div>
@@ -366,10 +397,11 @@
                   <td colspan="5">
                     <div class="trace-detail">
                       <div class="detail-meta">
+                        <span>Trace ID: {trace.id}</span>
                         <span>Logged as: {trace.key}</span>
                         <span>Timestamp: {trace.timestamp || "—"}</span>
                         {#each metadataEntries(trace) as [key, value]}
-                          <span>{key}: {value}</span>
+                          <span>{key}: {formatMetadataValue(value)}</span>
                         {/each}
                       </div>
 
@@ -503,6 +535,22 @@
     width: 100%;
     border-collapse: collapse;
     font-size: 14px;
+    table-layout: fixed;
+  }
+  .trace-id-col {
+    width: 160px;
+  }
+  .request-col {
+    width: auto;
+  }
+  .run-col {
+    width: 180px;
+  }
+  .step-col {
+    width: 76px;
+  }
+  .request-time-col {
+    width: 150px;
   }
   .traces-table th {
     text-align: left;
@@ -529,13 +577,16 @@
   }
   .trace-id {
     display: inline-block;
+    max-width: 136px;
     background: var(--background-fill-secondary, #f3f4f6);
     color: var(--body-text-color, #1f2937);
     border: 1px solid var(--border-color-primary, #e5e7eb);
     border-radius: var(--radius-md, 6px);
     padding: 6px 10px;
     font-size: 13px;
-    word-break: break-all;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
     line-height: 1.35;
   }
   .request {

--- a/trackio/frontend/src/pages/Traces.svelte
+++ b/trackio/frontend/src/pages/Traces.svelte
@@ -601,7 +601,7 @@
   .trace-id-chip {
     font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
     font-size: 13px;
-    color: #000;
+    color: var(--body-text-color, #1f2937);
   }
   .request {
     font-weight: 500;

--- a/trackio/frontend/src/pages/Traces.svelte
+++ b/trackio/frontend/src/pages/Traces.svelte
@@ -280,7 +280,7 @@
     if (typeof value === "number" || typeof value === "boolean") return String(value);
     try {
       return JSON.stringify(value);
-    } catch (_error) {
+    } catch {
       return String(value);
     }
   }


### PR DESCRIPTION
- show relevant part of trace ID
- shortern the trace ID column

Before:

<img width="1503" height="643" alt="Screenshot 2026-05-21 at 10 48 32 AM" src="https://github.com/user-attachments/assets/6c8d2ecd-c9e5-4784-8af4-949276803f8c" />


After:

<img width="1503" height="764" alt="image" src="https://github.com/user-attachments/assets/987a6d29-d5cd-437f-b3dd-baa8920ea2f9" />

