### PR TITLE
Fix IndexError when importing CSV with no numeric metric columns

### DIFF
--- a/.changeset/fresh-rocks-lead.md
+++ b/.changeset/fresh-rocks-lead.md
@@ -1,0 +1,5 @@
+---
+"trackio": minor
+---
+
+feat:Fix IndexError when importing CSV with no numeric metric columns

--- a/tests/unit/test_local_logging.py
+++ b/tests/unit/test_local_logging.py
@@ -3,6 +3,8 @@ import time
 import warnings
 from unittest.mock import patch
 
+import pytest
+
 import trackio
 from trackio import gpu
 from trackio.sqlite_storage import SQLiteStorage
@@ -184,3 +186,23 @@ def test_auto_log_gpu_multi(temp_dir):
     assert log["gpu/0/utilization"] == 75
     assert log["gpu/1/utilization"] == 65
     assert log["gpu/mean_utilization"] == 70
+
+
+def test_import_from_csv_without_numeric_metrics_raises(temp_dir, tmp_path):
+    csv_path = tmp_path / "logs.csv"
+    csv_path.write_text(
+        "\n".join(
+            [
+                "step,timestamp,note",
+                "1,2024-01-01T00:00:00+00:00,start",
+                "2,2024-01-01T00:01:00+00:00,end",
+            ]
+        )
+    )
+
+    with pytest.raises(ValueError, match="No numeric metric data"):
+        trackio.import_csv(
+            csv_path=str(csv_path),
+            project="test_project_no_metrics",
+            name="test_run",
+        )

--- a/trackio/imports.py
+++ b/trackio/imports.py
@@ -119,14 +119,19 @@ def import_csv(
             else:
                 timestamps.append("")
 
-    if metrics_list:
-        SQLiteStorage.bulk_log(
-            project=project,
-            run=name,
-            metrics_list=metrics_list,
-            steps=steps,
-            timestamps=timestamps,
+    if not metrics_list:
+        raise ValueError(
+            f"No numeric metric data found in CSV file: {csv_path}. Columns other "
+            "than 'step' and 'timestamp' must contain numeric values."
         )
+
+    SQLiteStorage.bulk_log(
+        project=project,
+        run=name,
+        metrics_list=metrics_list,
+        steps=steps,
+        timestamps=timestamps,
+    )
 
     print(
         f"* Imported {len(metrics_list)} rows from {csv_path} into project '{project}' as run '{name}'"


### PR DESCRIPTION
## Problem
`import_csv()` guards `SQLiteStorage.bulk_log()` with `if metrics_list:`, but then calls `metrics_list[0].keys()` unconditionally two lines later. When a CSV has a valid `step` column but no parseable numeric metric columns, `metrics_list` is empty — the import prints a misleading `* Imported 0 rows` and then crashes with `IndexError: list index out of range`.

## Repro
```python
# logs.csv:
# step,timestamp,note
# 1,2024-01-01T00:00:00+00:00,start
import trackio
trackio.import_csv("logs.csv", project="demo")  # IndexError