### PR TITLE
Render plot/metric titles as searchable DOM text

### DIFF
--- a/.changeset/lazy-weeks-act.md
+++ b/.changeset/lazy-weeks-act.md
@@ -1,0 +1,5 @@
+---
+"trackio": minor
+---
+
+feat:Render plot/metric titles as searchable DOM text

--- a/trackio/frontend/src/components/BarPlot.svelte
+++ b/trackio/frontend/src/components/BarPlot.svelte
@@ -88,11 +88,6 @@
 
     return {
       $schema: "https://vega.github.io/schema/vega-lite/v5.json",
-      title: {
-        text: title,
-        fontSize: 13,
-        color: cssVar("--body-text-color", "#374151"),
-      },
       width: "container",
       height: fullscreen ? "container" : 250,
       autosize: { type: "fit", contains: "padding" },
@@ -405,6 +400,9 @@
     </div>
   {/if}
   {#if !fullscreen}
+    {#if title}
+      <div class="plot-title">{title}</div>
+    {/if}
     <div class="plot-chart-wrap">
       <div class="plot" bind:this={container}></div>
     </div>
@@ -477,6 +475,9 @@
         </svg>
       </button>
     </div>
+    {#if title}
+      <div class="plot-title plot-title--fs">{title}</div>
+    {/if}
     <div class="fullscreen-chart-wrap">
       <div class="plot-chart-wrap plot-chart-wrap--fs">
         <div class="plot fullscreen-plot" bind:this={container}></div>
@@ -584,6 +585,17 @@
     min-height: 0;
     display: flex;
     flex-direction: column;
+  }
+  .plot-title {
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--body-text-color, #374151);
+    text-align: center;
+    padding: 0 0 6px;
+    word-break: break-word;
+  }
+  .plot-title--fs {
+    flex-shrink: 0;
   }
   .plot {
     width: 100%;

--- a/trackio/frontend/src/components/LinePlot.svelte
+++ b/trackio/frontend/src/components/LinePlot.svelte
@@ -264,11 +264,6 @@
 
     return {
       $schema: "https://vega.github.io/schema/vega-lite/v5.json",
-      title: {
-        text: title,
-        fontSize: 13,
-        color: cssVar("--body-text-color", "#374151"),
-      },
       width: "container",
       height: fullscreen ? "container" : 250,
       autosize: { type: "fit", contains: "padding" },
@@ -637,6 +632,9 @@
     </div>
   {/if}
   {#if !fullscreen}
+    {#if title}
+      <div class="plot-title">{title}</div>
+    {/if}
     <div class="plot-chart-wrap">
       <div class="plot" bind:this={container}></div>
       {#if xLim && onResetZoom}
@@ -747,6 +745,9 @@
         </svg>
       </button>
     </div>
+    {#if title}
+      <div class="plot-title plot-title--fs">{title}</div>
+    {/if}
     <div class="fullscreen-chart-wrap">
       <div class="plot-chart-wrap plot-chart-wrap--fs">
         <div class="plot fullscreen-plot" bind:this={container}></div>
@@ -924,6 +925,17 @@
     display: block;
     flex-shrink: 0;
     filter: drop-shadow(0 0 0.5px rgba(255, 255, 255, 0.95));
+  }
+  .plot-title {
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--body-text-color, #374151);
+    text-align: center;
+    padding: 0 0 6px;
+    word-break: break-word;
+  }
+  .plot-title--fs {
+    flex-shrink: 0;
   }
   .plot {
     width: 100%;


### PR DESCRIPTION
Closes #574

Graph/metric names in the dashboard were drawn inside the Vega **canvas** (`title.text` in the spec, `renderer: "canvas"`), so they were rendered as pixels rather than real text. Users could not select them or use the browser's native find (Ctrl+F / Cmd+F) to jump to a specific plot (e.g. typing "ssim" to scroll to the SSIM chart) — slow for runs with many metrics.

The fix is to render the title as an HTML element (`<div class="plot-title">`) above the chart instead of inside the Vega spec, for both `LinePlot` and `BarPlot`, in both the normal and fullscreen views. The canvas `title` block is removed from each spec. Visual appearance is unchanged (centered, 13px, same color), but the title is now selectable, searchable DOM text.

<img width="1493" height="591" alt="image" src="https://github.com/user-attachments/assets/790cdd52-2984-4b61-9094-25ea8d6d0e30" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only presentation change in two Svelte plot components; no auth, data, or API impact. Minor risk that PNG exports omit titles that were previously drawn in the Vega spec.
> 
> **Overview**
> **Plot/metric titles are now real DOM text** instead of Vega canvas titles, so users can select them and use the browser find-in-page (Ctrl/Cmd+F) to jump to a specific chart on busy dashboards.
> 
> In **`LinePlot.svelte`** and **`BarPlot.svelte`**, the Vega-Lite `title` block is removed from `buildSpec`, and a conditional `<div class="plot-title">` is rendered above the chart in both the grid view and fullscreen. Shared styling keeps the look aligned with the old spec (centered, 13px, theme text color, word-break for long names). A minor **trackio** changeset records the feature.
> 
> **Note:** PNG export still comes from the Vega canvas only, so downloaded images may no longer include the metric title unless that is handled elsewhere.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9ecf61c2cc54e8fd07f1aa894293836716554f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->