### PR TITLE
Sort and paginate media items

### DIFF
--- a/.changeset/funny-trams-press.md
+++ b/.changeset/funny-trams-press.md
@@ -1,0 +1,5 @@
+---
+"trackio": minor
+---
+
+feat:Sort and paginate media items

--- a/.changeset/funny-trams-press.md
+++ b/.changeset/funny-trams-press.md
@@ -2,4 +2,4 @@
 "trackio": minor
 ---
 
-feat:Sort and paginate media items
+feat: Sort and paginate media items

--- a/trackio/frontend/src/pages/Media.svelte
+++ b/trackio/frontend/src/pages/Media.svelte
@@ -25,6 +25,7 @@
   let rawMediaItems = $state(EMPTY_MEDIA_ITEMS);
   let sortOrder = $state("newest");
   let visibleCounts = $state(createVisibleCounts());
+  let selectedImage = $state(null);
   let loading = $state(false);
 
   function createVisibleCounts() {
@@ -185,7 +186,36 @@
       cell.every((v) => v && typeof v === "object" && v._type === "trackio.image")
     );
   }
+
+  function markImageLoaded(event) {
+    event.currentTarget.parentElement?.classList.add("image-loaded");
+  }
+
+  function markImageFailed(event) {
+    event.currentTarget.parentElement?.classList.add("image-failed");
+  }
+
+  function openImage(image, parent = null) {
+    selectedImage = {
+      ...image,
+      key: image.key ?? parent?.key,
+      step: image.step ?? parent?.step,
+      _run: image._run ?? parent?._run,
+      _runId: image._runId ?? parent?._runId,
+      caption: image.caption ?? parent?.caption,
+    };
+  }
+
+  function closeImage() {
+    selectedImage = null;
+  }
+
+  function handleKeydown(event) {
+    if (event.key === "Escape") closeImage();
+  }
 </script>
+
+<svelte:window onkeydown={handleKeydown} />
 
 <div class="media-page">
   {#if loading}
@@ -235,7 +265,22 @@
           {#each visibleMediaItems.images as img}
             <div class="gallery-item">
               <div class="media-label">{img.key}</div>
-              <img src={getFilePath(img)} alt={img.caption || img.key} loading="lazy" />
+              <button
+                class="image-frame"
+                type="button"
+                onclick={() => openImage(img)}
+                aria-label={`Open ${img.caption || img.key}`}
+              >
+                <span class="image-placeholder">Loading image…</span>
+                <img
+                  src={getFilePath(img)}
+                  alt={img.caption || img.key}
+                  loading="lazy"
+                  decoding="async"
+                  onload={markImageLoaded}
+                  onerror={markImageFailed}
+                />
+              </button>
               {#if img.caption}
                 <div class="caption">{img.caption}</div>
               {/if}
@@ -334,21 +379,43 @@
                     {#each Object.values(row) as cell}
                       <td>
                         {#if isImageCell(cell)}
-                          <img
-                            class="table-image"
-                            src={getFilePath(cell)}
-                            alt={cell.caption || ""}
-                            loading="lazy"
-                          />
+                          <button
+                            class="table-image-frame"
+                            type="button"
+                            onclick={() => openImage(cell, tbl)}
+                            aria-label="Open table image"
+                          >
+                            <span class="table-image-placeholder">Loading…</span>
+                            <img
+                              class="table-image"
+                              src={getFilePath(cell)}
+                              alt={cell.caption || ""}
+                              loading="lazy"
+                              decoding="async"
+                              onload={markImageLoaded}
+                              onerror={markImageFailed}
+                            />
+                          </button>
                         {:else if isImageList(cell)}
                           <div class="table-image-list">
                             {#each cell as img}
-                              <img
-                                class="table-image"
-                                src={getFilePath(img)}
-                                alt={img.caption || ""}
-                                loading="lazy"
-                              />
+                              <button
+                                class="table-image-frame"
+                                type="button"
+                                onclick={() => openImage(img, tbl)}
+                                aria-label="Open table image"
+                              >
+                                <span class="table-image-placeholder">Loading…</span>
+                                <img
+                                  class="table-image"
+                                  src={getFilePath(img)}
+                                  alt={img.caption || ""}
+                                  loading="lazy"
+                                  decoding="async"
+                                  onload={markImageLoaded}
+                                  onerror={markImageFailed}
+                                />
+                              </button>
                             {/each}
                           </div>
                         {:else}
@@ -374,6 +441,44 @@
     {/if}
   {/if}
 </div>
+
+{#if selectedImage}
+  <div class="image-modal-backdrop" role="presentation" onclick={closeImage}>
+    <div
+      class="image-modal"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Image preview"
+      tabindex="-1"
+      onclick={(event) => event.stopPropagation()}
+      onkeydown={(event) => event.stopPropagation()}
+    >
+      <button class="image-modal-close" type="button" onclick={closeImage} aria-label="Close image preview">×</button>
+      <div class="modal-image-frame">
+        <span class="modal-image-placeholder">Loading image…</span>
+        <img
+          src={getFilePath(selectedImage)}
+          alt={selectedImage.caption || selectedImage.key || "Image preview"}
+          decoding="async"
+          onload={markImageLoaded}
+          onerror={markImageFailed}
+        />
+      </div>
+      <div class="image-modal-info">
+        {#if selectedImage.key}
+          <div class="image-modal-title">{selectedImage.key}</div>
+        {/if}
+        {#if selectedImage.caption}
+          <div class="image-modal-caption">{selectedImage.caption}</div>
+        {/if}
+        <div class="meta image-modal-meta">
+          <span class="run-dot" style:background={runColor(selectedImage)}></span>
+          <span class="meta-text">Run: {selectedImage._run}, Step: {selectedImage.step}</span>
+        </div>
+      </div>
+    </div>
+  </div>
+{/if}
 
 <style>
   .media-page {
@@ -496,7 +601,40 @@
   .runs-table tr:hover {
     background: var(--background-fill-secondary, #f3f4f6);
   }
+  .table-image-frame {
+    position: relative;
+    display: inline-flex;
+    width: 120px;
+    height: 80px;
+    align-items: center;
+    justify-content: center;
+    overflow: hidden;
+    border: 0;
+    border-radius: var(--radius-sm, 4px);
+    background: var(--background-fill-secondary, #f3f4f6);
+    color: var(--body-text-color-subdued, #6b7280);
+    cursor: zoom-in;
+    font: inherit;
+    padding: 0;
+    text-decoration: none;
+    vertical-align: top;
+  }
+  .table-image-placeholder {
+    position: absolute;
+    inset: 0;
+    display: grid;
+    place-items: center;
+    font-size: var(--text-xs, 11px);
+  }
+  .table-image-frame:global(.image-loaded) .table-image-placeholder {
+    display: none;
+  }
+  .table-image-frame:global(.image-failed) .table-image-placeholder {
+    color: var(--error-text-color, #b91c1c);
+  }
   .table-image {
+    position: relative;
+    z-index: 1;
     max-height: 80px;
     max-width: 120px;
     border-radius: var(--radius-sm, 4px);
@@ -523,7 +661,42 @@
     background: var(--background-fill-secondary, #f9fafb);
     overflow: hidden;
   }
-  .gallery-item img,
+  .image-frame {
+    position: relative;
+    display: block;
+    width: 100%;
+    aspect-ratio: 4 / 3;
+    overflow: hidden;
+    border: 0;
+    border-radius: var(--radius-sm, 4px);
+    background: var(--background-fill-primary, #f3f4f6);
+    color: var(--body-text-color-subdued, #6b7280);
+    cursor: zoom-in;
+    font: inherit;
+    padding: 0;
+    text-decoration: none;
+  }
+  .image-placeholder {
+    position: absolute;
+    inset: 0;
+    display: grid;
+    place-items: center;
+    font-size: var(--text-sm, 12px);
+  }
+  .image-frame:global(.image-loaded) .image-placeholder {
+    display: none;
+  }
+  .image-frame:global(.image-failed) .image-placeholder {
+    color: var(--error-text-color, #b91c1c);
+  }
+  .image-frame img {
+    position: relative;
+    z-index: 1;
+    width: 100%;
+    height: 100%;
+    display: block;
+    object-fit: contain;
+  }
   .gallery-item video {
     width: 100%;
     display: block;
@@ -535,6 +708,91 @@
   .caption {
     font-size: var(--text-sm, 12px);
     color: var(--body-text-color-subdued, #9ca3af);
+  }
+  .image-modal-backdrop {
+    position: fixed;
+    inset: 0;
+    z-index: 1000;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 32px;
+    background: rgb(0 0 0 / 75%);
+  }
+  .image-modal {
+    position: relative;
+    display: flex;
+    max-width: min(92vw, 1200px);
+    max-height: 92vh;
+    flex-direction: column;
+    overflow: hidden;
+    border-radius: var(--radius-lg, 8px);
+    background: var(--background-fill-primary, white);
+    box-shadow: 0 20px 60px rgb(0 0 0 / 35%);
+  }
+  .image-modal-close {
+    position: absolute;
+    top: 8px;
+    right: 8px;
+    z-index: 2;
+    width: 32px;
+    height: 32px;
+    border: 0;
+    border-radius: 999px;
+    background: rgb(0 0 0 / 55%);
+    color: white;
+    cursor: pointer;
+    font-size: 24px;
+    line-height: 1;
+  }
+  .modal-image-frame {
+    position: relative;
+    display: grid;
+    min-width: min(70vw, 720px);
+    min-height: min(65vh, 520px);
+    place-items: center;
+    overflow: hidden;
+    background: var(--background-fill-secondary, #f3f4f6);
+    color: var(--body-text-color-subdued, #6b7280);
+  }
+  .modal-image-placeholder {
+    position: absolute;
+    inset: 0;
+    display: grid;
+    place-items: center;
+    font-size: var(--text-sm, 12px);
+  }
+  .modal-image-frame:global(.image-loaded) .modal-image-placeholder {
+    display: none;
+  }
+  .modal-image-frame:global(.image-failed) .modal-image-placeholder {
+    color: var(--error-text-color, #b91c1c);
+  }
+  .modal-image-frame img {
+    position: relative;
+    z-index: 1;
+    max-width: 100%;
+    max-height: calc(92vh - 96px);
+    object-fit: contain;
+  }
+  .image-modal-info {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    padding: 10px 14px 12px;
+    text-align: center;
+  }
+  .image-modal-title {
+    font-size: var(--text-md, 14px);
+    font-weight: 600;
+    color: var(--body-text-color, #1f2937);
+  }
+  .image-modal-caption {
+    font-size: var(--text-sm, 12px);
+    color: var(--body-text-color-subdued, #6b7280);
+  }
+  .image-modal-meta {
+    justify-content: center;
   }
   .table-section {
     margin-bottom: 16px;

--- a/trackio/frontend/src/pages/Media.svelte
+++ b/trackio/frontend/src/pages/Media.svelte
@@ -19,12 +19,76 @@
     return runColorMap[item._runId] ?? runColorMap[item._run] ?? "#9ca3af";
   }
 
-  let mediaItems = $state({ images: [], videos: [], audios: [], tables: [] });
+  const PAGE_SIZE = 48;
+  const EMPTY_MEDIA_ITEMS = { images: [], videos: [], audios: [], tables: [] };
+
+  let rawMediaItems = $state(EMPTY_MEDIA_ITEMS);
+  let sortOrder = $state("newest");
+  let visibleCounts = $state(createVisibleCounts());
   let loading = $state(false);
+
+  function createVisibleCounts() {
+    return {
+      images: PAGE_SIZE,
+      videos: PAGE_SIZE,
+      audios: PAGE_SIZE,
+      tables: PAGE_SIZE,
+    };
+  }
+
+  function resetVisibleCounts() {
+    visibleCounts = createVisibleCounts();
+  }
+
+  function compareMediaItems(a, b) {
+    const aStep = Number.isFinite(a.step) ? a.step : 0;
+    const bStep = Number.isFinite(b.step) ? b.step : 0;
+    const stepDelta = sortOrder === "newest" ? bStep - aStep : aStep - bStep;
+    if (stepDelta !== 0) return stepDelta;
+
+    const aIndex = Number.isFinite(a._index) ? a._index : 0;
+    const bIndex = Number.isFinite(b._index) ? b._index : 0;
+    return sortOrder === "newest" ? bIndex - aIndex : aIndex - bIndex;
+  }
+
+  function sortMediaItems(items) {
+    return [...items].sort(compareMediaItems);
+  }
+
+  let mediaItems = $derived.by(() => ({
+    images: sortMediaItems(rawMediaItems.images),
+    videos: sortMediaItems(rawMediaItems.videos),
+    audios: sortMediaItems(rawMediaItems.audios),
+    tables: sortMediaItems(rawMediaItems.tables),
+  }));
+
+  let visibleMediaItems = $derived.by(() => ({
+    images: mediaItems.images.slice(0, visibleCounts.images),
+    videos: mediaItems.videos.slice(0, visibleCounts.videos),
+    audios: mediaItems.audios.slice(0, visibleCounts.audios),
+    tables: mediaItems.tables.slice(0, visibleCounts.tables),
+  }));
+
+  let hasMedia = $derived(
+    mediaItems.images.length > 0 ||
+      mediaItems.videos.length > 0 ||
+      mediaItems.audios.length > 0 ||
+      mediaItems.tables.length > 0,
+  );
+
+  function showMore(type) {
+    visibleCounts[type] += PAGE_SIZE;
+  }
+
+  $effect(() => {
+    sortOrder;
+    rawMediaItems;
+    resetVisibleCounts();
+  });
 
   async function loadMedia() {
     if (!project || selectedRuns.length === 0) {
-      mediaItems = { images: [], videos: [], audios: [], tables: [] };
+      rawMediaItems = EMPTY_MEDIA_ITEMS;
       return;
     }
 
@@ -48,6 +112,7 @@
       const videos = [];
       const audios = [];
       const tables = [];
+      let mediaIndex = 0;
 
       if (logs) {
         logs.forEach((log, step) => {
@@ -55,7 +120,8 @@
             if (value && typeof value === "object" && value._type) {
               const item = {
                 key,
-                step: log.step || step,
+                step: log.step ?? step,
+                _index: mediaIndex++,
                 _run: log._run,
                 _runId: log._runId,
                 ...value,
@@ -114,7 +180,7 @@
         ]);
       }
 
-      mediaItems = { images, videos, audios, tables };
+      rawMediaItems = { images, videos, audios, tables };
     } catch (e) {
       console.error("Failed to load media:", e);
     } finally {
@@ -155,7 +221,7 @@
 <div class="media-page">
   {#if loading}
     <LoadingTrackio />
-  {:else if mediaItems.images.length === 0 && mediaItems.videos.length === 0 && mediaItems.audios.length === 0 && mediaItems.tables.length === 0}
+  {:else if !hasMedia}
     <div class="empty-state">
       {#if !project}
         <h2>Select a project</h2>
@@ -172,6 +238,16 @@
       {/if}
     </div>
   {:else}
+    <div class="media-toolbar">
+      <label class="media-control" for="media-sort-order">
+        <span>Sort</span>
+        <select id="media-sort-order" bind:value={sortOrder}>
+          <option value="newest">Newest first</option>
+          <option value="oldest">Oldest first</option>
+        </select>
+      </label>
+    </div>
+
     {#snippet meta(item)}
       <div class="meta">
         <span class="run-dot" style:background={runColor(item)}></span>
@@ -187,7 +263,7 @@
           <span class="section-title">Images ({mediaItems.images.length})</span>
         </summary>
         <div class="gallery">
-          {#each mediaItems.images as img}
+          {#each visibleMediaItems.images as img}
             <div class="gallery-item">
               <div class="media-label">{img.key}</div>
               <img src={getFilePath(img)} alt={img.caption || img.key} loading="lazy" />
@@ -198,6 +274,12 @@
             </div>
           {/each}
         </div>
+        {#if visibleCounts.images < mediaItems.images.length}
+          <div class="pagination-row">
+            <span>Showing {visibleMediaItems.images.length} of {mediaItems.images.length}</span>
+            <button type="button" class="load-more-button" onclick={() => showMore("images")}>Load more</button>
+          </div>
+        {/if}
       </details>
     {/if}
 
@@ -210,7 +292,7 @@
           <span class="section-title">Videos ({mediaItems.videos.length})</span>
         </summary>
         <div class="gallery">
-          {#each mediaItems.videos as vid}
+          {#each visibleMediaItems.videos as vid}
             <div class="gallery-item">
               <div class="media-label">{vid.key}</div>
               <video controls src={getFilePath(vid)} preload="metadata">
@@ -220,6 +302,12 @@
             </div>
           {/each}
         </div>
+        {#if visibleCounts.videos < mediaItems.videos.length}
+          <div class="pagination-row">
+            <span>Showing {visibleMediaItems.videos.length} of {mediaItems.videos.length}</span>
+            <button type="button" class="load-more-button" onclick={() => showMore("videos")}>Load more</button>
+          </div>
+        {/if}
       </details>
     {/if}
 
@@ -232,7 +320,7 @@
           <span class="section-title">Audio ({mediaItems.audios.length})</span>
         </summary>
         <div class="gallery">
-          {#each mediaItems.audios as aud}
+          {#each visibleMediaItems.audios as aud}
             <div class="gallery-item audio-gallery-item">
               <div class="media-label">{aud.key}</div>
               <WaveformAudio src={getFilePath(aud)} />
@@ -240,6 +328,12 @@
             </div>
           {/each}
         </div>
+        {#if visibleCounts.audios < mediaItems.audios.length}
+          <div class="pagination-row">
+            <span>Showing {visibleMediaItems.audios.length} of {mediaItems.audios.length}</span>
+            <button type="button" class="load-more-button" onclick={() => showMore("audios")}>Load more</button>
+          </div>
+        {/if}
       </details>
     {/if}
 
@@ -251,7 +345,7 @@
           </svg>
           <span class="section-title">Tables ({mediaItems.tables.length})</span>
         </summary>
-        {#each mediaItems.tables as tbl}
+        {#each visibleMediaItems.tables as tbl}
           {#if tbl._value && tbl._value.length > 0}
             <div class="table-section">
               <div class="table-header">
@@ -303,6 +397,12 @@
             </div>
           {/if}
         {/each}
+        {#if visibleCounts.tables < mediaItems.tables.length}
+          <div class="pagination-row">
+            <span>Showing {visibleMediaItems.tables.length} of {mediaItems.tables.length}</span>
+            <button type="button" class="load-more-button" onclick={() => showMore("tables")}>Load more</button>
+          </div>
+        {/if}
       </details>
     {/if}
   {/if}
@@ -316,6 +416,29 @@
   }
   .section {
     margin: 16px 0;
+  }
+  .media-toolbar {
+    display: flex;
+    justify-content: flex-end;
+    align-items: center;
+    gap: 12px;
+    margin-bottom: 12px;
+  }
+  .media-control {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: var(--text-sm, 12px);
+    color: var(--body-text-color-subdued, #6b7280);
+  }
+  .media-control select {
+    height: 30px;
+    border: 1px solid var(--border-color-primary, #d1d5db);
+    border-radius: var(--radius-sm, 4px);
+    background: var(--background-fill-primary, white);
+    color: var(--body-text-color, #1f2937);
+    font-size: var(--text-sm, 12px);
+    padding: 0 28px 0 8px;
   }
   .section-summary {
     display: flex;
@@ -449,6 +572,29 @@
   .table-section {
     margin-bottom: 16px;
     overflow-x: auto;
+  }
+  .pagination-row {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 12px;
+    margin-top: 12px;
+    font-size: var(--text-sm, 12px);
+    color: var(--body-text-color-subdued, #6b7280);
+  }
+  .load-more-button {
+    height: 30px;
+    border: 1px solid var(--border-color-primary, #d1d5db);
+    border-radius: var(--radius-sm, 4px);
+    background: var(--background-fill-primary, white);
+    color: var(--body-text-color, #1f2937);
+    font-size: var(--text-sm, 12px);
+    font-weight: 500;
+    padding: 0 10px;
+    cursor: pointer;
+  }
+  .load-more-button:hover {
+    background: var(--background-fill-secondary, #f9fafb);
   }
   .empty-state {
     max-width: 640px;

--- a/trackio/frontend/src/pages/Media.svelte
+++ b/trackio/frontend/src/pages/Media.svelte
@@ -1,7 +1,7 @@
 <script>
   import LoadingTrackio from "../components/LoadingTrackio.svelte";
   import WaveformAudio from "../components/WaveformAudio.svelte";
-  import { getLogs, getMediaUrl, isStaticMode, fetchMediaBlob } from "../lib/api.js";
+  import { getLogs, getMediaUrl } from "../lib/api.js";
   import { buildColorMap } from "../lib/stores.js";
 
   let {
@@ -55,11 +55,15 @@
     return [...items].sort(compareMediaItems);
   }
 
+  function isDisplayableTable(item) {
+    return Array.isArray(item._value) && item._value.length > 0;
+  }
+
   let mediaItems = $derived.by(() => ({
     images: sortMediaItems(rawMediaItems.images),
     videos: sortMediaItems(rawMediaItems.videos),
     audios: sortMediaItems(rawMediaItems.audios),
-    tables: sortMediaItems(rawMediaItems.tables),
+    tables: sortMediaItems(rawMediaItems.tables.filter(isDisplayableTable)),
   }));
 
   let visibleMediaItems = $derived.by(() => ({
@@ -143,41 +147,6 @@
             }
           });
         });
-      }
-
-      if (await isStaticMode()) {
-        const resolveAll = (items) =>
-          Promise.all(
-            items.map(async (item) => {
-              if (item.file_path) {
-                item._resolvedUrl = await fetchMediaBlob(item.file_path);
-              }
-              return item;
-            }),
-          );
-        const tableImageItems = [];
-        for (const tbl of tables) {
-          if (!Array.isArray(tbl._value)) continue;
-          for (const row of tbl._value) {
-            for (const value of Object.values(row)) {
-              if (value && typeof value === "object" && !Array.isArray(value) && value._type === "trackio.image") {
-                tableImageItems.push(value);
-              } else if (Array.isArray(value)) {
-                for (const v of value) {
-                  if (v && typeof v === "object" && v._type === "trackio.image") {
-                    tableImageItems.push(v);
-                  }
-                }
-              }
-            }
-          }
-        }
-        await Promise.all([
-          resolveAll(images),
-          resolveAll(videos),
-          resolveAll(audios),
-          resolveAll(tableImageItems),
-        ]);
       }
 
       rawMediaItems = { images, videos, audios, tables };
@@ -346,56 +315,54 @@
           <span class="section-title">Tables ({mediaItems.tables.length})</span>
         </summary>
         {#each visibleMediaItems.tables as tbl}
-          {#if tbl._value && tbl._value.length > 0}
-            <div class="table-section">
-              <div class="table-header">
-                <div class="media-label">{tbl.key}</div>
-                {@render meta(tbl)}
-              </div>
-              <table class="runs-table">
-                <thead>
+          <div class="table-section">
+            <div class="table-header">
+              <div class="media-label">{tbl.key}</div>
+              {@render meta(tbl)}
+            </div>
+            <table class="runs-table">
+              <thead>
+                <tr>
+                  {#each Object.keys(tbl._value[0]) as header}
+                    <th>{header}</th>
+                  {/each}
+                </tr>
+              </thead>
+              <tbody>
+                {#each tbl._value as row}
                   <tr>
-                    {#each Object.keys(tbl._value[0]) as header}
-                      <th>{header}</th>
+                    {#each Object.values(row) as cell}
+                      <td>
+                        {#if isImageCell(cell)}
+                          <img
+                            class="table-image"
+                            src={getFilePath(cell)}
+                            alt={cell.caption || ""}
+                            loading="lazy"
+                          />
+                        {:else if isImageList(cell)}
+                          <div class="table-image-list">
+                            {#each cell as img}
+                              <img
+                                class="table-image"
+                                src={getFilePath(img)}
+                                alt={img.caption || ""}
+                                loading="lazy"
+                              />
+                            {/each}
+                          </div>
+                        {:else}
+                          {typeof cell === "string" && cell.length > tableTruncateLength
+                            ? cell.slice(0, tableTruncateLength) + "…"
+                            : (cell ?? "")}
+                        {/if}
+                      </td>
                     {/each}
                   </tr>
-                </thead>
-                <tbody>
-                  {#each tbl._value as row}
-                    <tr>
-                      {#each Object.values(row) as cell}
-                        <td>
-                          {#if isImageCell(cell)}
-                            <img
-                              class="table-image"
-                              src={getFilePath(cell)}
-                              alt={cell.caption || ""}
-                              loading="lazy"
-                            />
-                          {:else if isImageList(cell)}
-                            <div class="table-image-list">
-                              {#each cell as img}
-                                <img
-                                  class="table-image"
-                                  src={getFilePath(img)}
-                                  alt={img.caption || ""}
-                                  loading="lazy"
-                                />
-                              {/each}
-                            </div>
-                          {:else}
-                            {typeof cell === "string" && cell.length > tableTruncateLength
-                              ? cell.slice(0, tableTruncateLength) + "…"
-                              : (cell ?? "")}
-                          {/if}
-                        </td>
-                      {/each}
-                    </tr>
-                  {/each}
-                </tbody>
-              </table>
-            </div>
-          {/if}
+                {/each}
+              </tbody>
+            </table>
+          </div>
         {/each}
         {#if visibleCounts.tables < mediaItems.tables.length}
           <div class="pagination-row">


### PR DESCRIPTION
- Sort media and table items newest-first by default on the Media page
- Add a sort selector to switch between newest-first and oldest-first
- Paginate each media/table section with a Load more control

Closes: #575


https://github.com/user-attachments/assets/4021481a-ef20-4928-bc95-6139a0b8e9fc

