### PR TITLE
fix: limit default run selection to most recent N runs on open

### DIFF
--- a/trackio/server.py
+++ b/trackio/server.py
@@ -680,8 +680,16 @@ def get_metric_values(
     )
 
 
-def get_runs_for_project(project: str) -> list[dict[str, Any]]:
-    return SQLiteStorage.get_run_records(project)
+MAX_SELECTED_RUNS = 10
+
+
+def get_runs_for_project(
+    project: str, max_runs: int | None = MAX_SELECTED_RUNS
+) -> list[dict[str, Any]]:
+    runs = SQLiteStorage.get_run_records(project)
+    if max_runs is not None:
+        runs = runs[:max_runs]
+    return runs
 
 
 def get_run_configs(project: str) -> dict[str, Any]:


### PR DESCRIPTION
Fixes #573

## Problem
When a project has many runs, all of them are selected on open, which makes the Trackio dashboard very slow.

## Solution
Added a 'MAX_SELECTED_RUNS = 10' constant and a 'max_runs' parameter to 'get_runs_for_project()'. Only the most recent N runs are selected by default. All runs remain visible — only the default Selection is capped.

## Changes
- Added 'MAX_SELECTED_RUNS = 10' constant in 'server.py'
- Updated 'get_runs_for_project()' to accept and apply 'max_runs'