### PR TITLE
Use TRACKIO_WRITE_TOKEN for server write token

### DIFF
--- a/.changeset/angry-onions-take.md
+++ b/.changeset/angry-onions-take.md
@@ -1,0 +1,5 @@
+---
+"trackio": minor
+---
+
+feat:Use TRACKIO_WRITE_TOKEN for server write token

--- a/.changeset/angry-onions-take.md
+++ b/.changeset/angry-onions-take.md
@@ -1,5 +1,5 @@
 ---
-"trackio": minor
+"trackio": patch
 ---
 
 feat:Use TRACKIO_WRITE_TOKEN for server write token

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ it will use an existing or automatically deploy a new Hugging Face Space as need
 
 ## Self-hosted Trackio server
 
-You can run the Trackio dashboard and API on your own machine or infrastructure and point training jobs at it over HTTP. Pass the write-access URL from `trackio.show()` (which may include `write_token` in the query), or a base URL plus the `TRACKIO_WRITE_TOKEN` environment variable. The client sends that token on requests; it is not your Hugging Face token.
+You can run the Trackio dashboard and API on your own machine or infrastructure and point training jobs at it over HTTP. Pass the write-access URL from `trackio.show()` (which may include `write_token` in the query), or a base URL plus the `TRACKIO_WRITE_TOKEN` environment variable. Set `TRACKIO_WRITE_TOKEN` before launching the server if you want to provide the server write token instead of using a random startup token. The client sends that token on requests; it is not your Hugging Face token.
 
 ```py
 trackio.init(project="my-project", server_url="http://127.0.0.1:7860?write_token=YOUR_TOKEN")

--- a/docs/source/environment_variables.md
+++ b/docs/source/environment_variables.md
@@ -29,7 +29,7 @@ export TRACKIO_WRITE_TOKEN="YOUR_TOKEN"
 
 ### `TRACKIO_WRITE_TOKEN`
 
-The dashboard **write token** for a self-hosted Trackio server (same value as the `write_token` query parameter in the write-access URL). When set on the server process, this value is used as the server's write token instead of generating a random token at startup. When set on the training process, use this when `TRACKIO_SERVER_URL` or `server_url` is a base URL without query parameters. The client sends this token on each request (for example as the `X-Trackio-Write-Token` header) so metric ingestion and uploads are authenticated when not running on Hugging Face Spaces.
+The dashboard **write token** for a self-hosted Trackio server (same value as the `write_token` query parameter in the write-access URL). When set on the Trackio server, this value is used as the server's write token instead of generating a random token at startup. When set on the Trackio client, use this when `TRACKIO_SERVER_URL` or `server_url` is a base URL without query parameters. The client sends this token on each request (for example as the `X-Trackio-Write-Token` header) so metric ingestion and uploads are authenticated when not running on Hugging Face Spaces.
 
 ### `TRACKIO_FRONTEND_DIR`
 

--- a/docs/source/environment_variables.md
+++ b/docs/source/environment_variables.md
@@ -29,7 +29,7 @@ export TRACKIO_WRITE_TOKEN="YOUR_TOKEN"
 
 ### `TRACKIO_WRITE_TOKEN`
 
-The dashboard **write token** for a self-hosted Trackio server (same value as the `write_token` query parameter in the write-access URL). Use this when `TRACKIO_SERVER_URL` or `server_url` is a base URL without query parameters. The client sends this token on each request (for example as the `X-Trackio-Write-Token` header) so metric ingestion and uploads are authenticated when not running on Hugging Face Spaces.
+The dashboard **write token** for a self-hosted Trackio server (same value as the `write_token` query parameter in the write-access URL). When set on the server process, this value is used as the server's write token instead of generating a random token at startup. When set on the training process, use this when `TRACKIO_SERVER_URL` or `server_url` is a base URL without query parameters. The client sends this token on each request (for example as the `X-Trackio-Write-Token` header) so metric ingestion and uploads are authenticated when not running on Hugging Face Spaces.
 
 ### `TRACKIO_FRONTEND_DIR`
 

--- a/docs/source/self_hosted_server.md
+++ b/docs/source/self_hosted_server.md
@@ -54,7 +54,7 @@ Ensure your firewall and security policies allow the traffic you intend.
 
 ## Point training code at your server
 
-In your training script, pass a `server_url` and supply the **write token**: either embed `write_token` in the query string (the same URL the dashboard prints for write access, or the `full_url` return value from `trackio.show()`), or pass a base URL like `http://127.0.0.1:7860/` and set the `TRACKIO_WRITE_TOKEN` environment variable to that token. You can also set `TRACKIO_WRITE_TOKEN` on the server process before launching `trackio.show()` to choose the server's write token instead of using the random token generated at startup. Metric ingestion and uploads require this token when the server is not on Hugging Face Spaces. You can also set `TRACKIO_SERVER_URL` instead of passing `server_url` in code.
+In your training script, pass a `server_url` and supply the **write token**: either embed `write_token` in the query string (the same URL the dashboard prints for write access, or the `full_url` return value from `trackio.show()`), or pass a base URL like `http://127.0.0.1:7860/` and set the `TRACKIO_WRITE_TOKEN` environment variable to that token. You can also set `TRACKIO_WRITE_TOKEN` on the Trackio server before launching `trackio.show()` to choose the server's write token instead of using the random token generated at startup. Metric ingestion and uploads require this token when the server is not on Hugging Face Spaces. You can also set `TRACKIO_SERVER_URL` instead of passing `server_url` in code.
 
 ```py
 import trackio

--- a/docs/source/self_hosted_server.md
+++ b/docs/source/self_hosted_server.md
@@ -54,7 +54,7 @@ Ensure your firewall and security policies allow the traffic you intend.
 
 ## Point training code at your server
 
-In your training script, pass a `server_url` and supply the **write token**: either embed `write_token` in the query string (the same URL the dashboard prints for write access, or the `full_url` return value from `trackio.show()`), or pass a base URL like `http://127.0.0.1:7860/` and set the `TRACKIO_WRITE_TOKEN` environment variable to that token. Metric ingestion and uploads require this token when the server is not on Hugging Face Spaces. You can also set `TRACKIO_SERVER_URL` instead of passing `server_url` in code.
+In your training script, pass a `server_url` and supply the **write token**: either embed `write_token` in the query string (the same URL the dashboard prints for write access, or the `full_url` return value from `trackio.show()`), or pass a base URL like `http://127.0.0.1:7860/` and set the `TRACKIO_WRITE_TOKEN` environment variable to that token. You can also set `TRACKIO_WRITE_TOKEN` on the server process before launching `trackio.show()` to choose the server's write token instead of using the random token generated at startup. Metric ingestion and uploads require this token when the server is not on Hugging Face Spaces. You can also set `TRACKIO_SERVER_URL` instead of passing `server_url` in code.
 
 ```py
 import trackio

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ repository = "https://github.com/gradio-app/trackio"
 dev = [
     "ruff==0.9.3",
     "pytest>=8.0.0,<9.0.0",
-    "playwright>=1.40.0,<2.0.0",
+    "playwright==1.60.0",
     "pytest-playwright>=0.7.0,<1.0.0",
 ]
 tensorboard = [

--- a/tests/unit/test_env_vars.py
+++ b/tests/unit/test_env_vars.py
@@ -1,6 +1,19 @@
+import importlib
+
 from trackio import server, utils
 from trackio.run import Run
 from trackio.table import Table
+
+
+def test_write_token_from_env(monkeypatch):
+    monkeypatch.setenv("TRACKIO_WRITE_TOKEN", "server-token")
+    importlib.reload(server)
+
+    try:
+        assert server.write_token == "server-token"
+    finally:
+        monkeypatch.delenv("TRACKIO_WRITE_TOKEN", raising=False)
+        importlib.reload(server)
 
 
 def test_get_settings_default_values(monkeypatch):

--- a/trackio/server.py
+++ b/trackio/server.py
@@ -169,7 +169,7 @@ def _flush_loop() -> None:
         _write_queue.clear()
 
 
-write_token = secrets.token_urlsafe(32)
+write_token = os.environ.get("TRACKIO_WRITE_TOKEN") or secrets.token_urlsafe(32)
 
 OAUTH_CALLBACK_PATH = "/login/callback"
 OAUTH_START_PATH = "/oauth/hf/start"

--- a/uv.lock
+++ b/uv.lock
@@ -1251,21 +1251,21 @@ wheels = [
 
 [[package]]
 name = "playwright"
-version = "1.58.0"
+version = "1.60.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "greenlet" },
     { name = "pyee" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f8/c9/9c6061d5703267f1baae6a4647bfd1862e386fbfdb97d889f6f6ae9e3f64/playwright-1.58.0-py3-none-macosx_10_13_x86_64.whl", hash = "sha256:96e3204aac292ee639edbfdef6298b4be2ea0a55a16b7068df91adac077cc606", size = 42251098, upload-time = "2026-01-30T15:09:24.028Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/40/59d34a756e02f8c670f0fee987d46f7ee53d05447d43cd114ca015cb168c/playwright-1.58.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:70c763694739d28df71ed578b9c8202bb83e8fe8fb9268c04dd13afe36301f71", size = 41039625, upload-time = "2026-01-30T15:09:27.558Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/ee/3ce6209c9c74a650aac9028c621f357a34ea5cd4d950700f8e2c4b7fe2c4/playwright-1.58.0-py3-none-macosx_11_0_universal2.whl", hash = "sha256:185e0132578733d02802dfddfbbc35f42be23a45ff49ccae5081f25952238117", size = 42251098, upload-time = "2026-01-30T15:09:30.461Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/af/009958cbf23fac551a940d34e3206e6c7eed2b8c940d0c3afd1feb0b0589/playwright-1.58.0-py3-none-manylinux1_x86_64.whl", hash = "sha256:c95568ba1eda83812598c1dc9be60b4406dffd60b149bc1536180ad108723d6b", size = 46235268, upload-time = "2026-01-30T15:09:33.787Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/a6/0e66ad04b6d3440dae73efb39540c5685c5fc95b17c8b29340b62abbd952/playwright-1.58.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8f9999948f1ab541d98812de25e3a8c410776aa516d948807140aff797b4bffa", size = 45964214, upload-time = "2026-01-30T15:09:36.751Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/4b/236e60ab9f6d62ed0fd32150d61f1f494cefbf02304c0061e78ed80c1c32/playwright-1.58.0-py3-none-win32.whl", hash = "sha256:1e03be090e75a0fabbdaeab65ce17c308c425d879fa48bb1d7986f96bfad0b99", size = 36815998, upload-time = "2026-01-30T15:09:39.627Z" },
-    { url = "https://files.pythonhosted.org/packages/41/f8/5ec599c5e59d2f2f336a05b4f318e733077cd5044f24adb6f86900c3e6a7/playwright-1.58.0-py3-none-win_amd64.whl", hash = "sha256:a2bf639d0ce33b3ba38de777e08697b0d8f3dc07ab6802e4ac53fb65e3907af8", size = 36816005, upload-time = "2026-01-30T15:09:42.449Z" },
-    { url = "https://files.pythonhosted.org/packages/c8/c4/cc0229fea55c87d6c9c67fe44a21e2cd28d1d558a5478ed4d617e9fb0c93/playwright-1.58.0-py3-none-win_arm64.whl", hash = "sha256:32ffe5c303901a13a0ecab91d1c3f74baf73b84f4bedbb6b935f5bc11cc98e1b", size = 33085919, upload-time = "2026-01-30T15:09:45.71Z" },
+    { url = "https://files.pythonhosted.org/packages/21/f0/832bd9677194908da118064eef20082f2791e3d18215cc6d9391ee2c5a67/playwright-1.60.0-py3-none-macosx_10_13_x86_64.whl", hash = "sha256:6a8cd0fec171fb3089e95e898c8bc8a6f35dea0b78b399e12fcc19427e91b1d7", size = 43474635, upload-time = "2026-05-18T12:00:31.969Z" },
+    { url = "https://files.pythonhosted.org/packages/59/7b/e1d32ae8a3ed937ec2be3721c5f728b13d731a0b7c6442e0b3bec5094ac0/playwright-1.60.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:39b5420ba6145045b69ced4c5c47d4d9fe5bddfc8ff816c518913afcb25ec7a5", size = 42261327, upload-time = "2026-05-18T12:00:35.638Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/bc/23de499ded6411c188a20c5a0dea6f0cd4ed5d2b3cc6042a5dbd3ed609aa/playwright-1.60.0-py3-none-macosx_11_0_universal2.whl", hash = "sha256:2581d0e6a3392c71f91b27460c7fd093356818dc430f48153896c8aeeaef7705", size = 43474636, upload-time = "2026-05-18T12:00:39.294Z" },
+    { url = "https://files.pythonhosted.org/packages/22/7b/1d679f4fced4ea94efadd17103856d8c565384f68382a1681264e46f5925/playwright-1.60.0-py3-none-manylinux1_x86_64.whl", hash = "sha256:1c2bfae7884fb3fb05b853290eab8f343d524e5016f2f1def702acbbdf14c93e", size = 47467220, upload-time = "2026-05-18T12:00:43.179Z" },
+    { url = "https://files.pythonhosted.org/packages/84/c2/1528d267d4442bd2c6b8eaeab819dd52c2030bf80e89293f0ba1f687473b/playwright-1.60.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:43e66564125ee31b07a58cefb21e256d62d67d8d1713e6858df7a3019d8ed353", size = 47154856, upload-time = "2026-05-18T12:00:46.715Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/4e/b008b6440a7a1624378041da94829956d4b8f7ab9ef5aad22d0dc3f2e26d/playwright-1.60.0-py3-none-win32.whl", hash = "sha256:ec94e416ea320711e0ad4bf185dcbf41833672961e90773e1885255d7db7b7e7", size = 37902157, upload-time = "2026-05-18T12:00:50.374Z" },
+    { url = "https://files.pythonhosted.org/packages/55/f0/0541524133104f9cc20bf900870ff4a736b76a23483f3a55295ddfa58409/playwright-1.60.0-py3-none-win_amd64.whl", hash = "sha256:9566821ce6030a1f9e7146a24e19355ab0d98805fd0f9be50bb3d8fef1750c02", size = 37902159, upload-time = "2026-05-18T12:00:53.728Z" },
+    { url = "https://files.pythonhosted.org/packages/80/c8/210f282d278e4709cdd71b12a31af45a30a22ab3207b387e29b37e478713/playwright-1.60.0-py3-none-win_arm64.whl", hash = "sha256:6e4f6700a4c2250efff8e690a81d66e3855754fb587b6b87cf5c784014f91537", size = 34037981, upload-time = "2026-05-18T12:00:57.584Z" },
 ]
 
 [[package]]
@@ -2181,7 +2181,7 @@ requires-dist = [
     { name = "nvidia-ml-py", marker = "extra == 'gpu'", specifier = ">=12.0.0" },
     { name = "orjson", specifier = ">=3.0,<4.0.0" },
     { name = "pillow", specifier = "<13.0.0" },
-    { name = "playwright", marker = "extra == 'dev'", specifier = ">=1.40.0,<2.0.0" },
+    { name = "playwright", marker = "extra == 'dev'", specifier = "==1.60.0" },
     { name = "psutil", marker = "extra == 'apple-gpu'", specifier = ">=5.9.0" },
     { name = "psutil", marker = "extra == 'cpu'", specifier = ">=5.9.0" },
     { name = "psutil", marker = "extra == 'gpu'", specifier = ">=5.9.0" },


### PR DESCRIPTION
We had an existing `TRACKIO_WRITE_TOKEN` env variable, which would get passed by the client. Now, if this is set on the Trackio server, it is used as the write token as well. Closes #588.