### PR TITLE
Document private= and bucket_id= in the agent skill examples

### DIFF
--- a/.agents/skills/trackio/SKILL.md
+++ b/.agents/skills/trackio/SKILL.md
@@ -26,7 +26,7 @@ Use `import trackio` in your training scripts to log metrics:
 - Log metrics with `trackio.log()` or use TRL's `report_to="trackio"`
 - Finalize with `trackio.finish()`
 
-**Key concept**: For remote/cloud training, pass `space_id` — metrics sync to a Space dashboard so they persist after the instance terminates.
+**Key concept**: For remote/cloud training, pass `space_id` — metrics sync to a Space dashboard so they persist after the instance terminates. Auto-created Spaces are **public by default** — pass `private=True` if the metrics should not be public.
 
 → See [logging_metrics.md](logging_metrics.md) for setup, TRL integration, and configuration options.
 
@@ -65,7 +65,9 @@ Use the `trackio` command to query logged metrics and alerts:
 ```python
 import trackio
 
-trackio.init(project="my-project", space_id="username/trackio")
+# Spaces are PUBLIC by default (good for shareable dashboards);
+# pass private=True if the metrics should not be public
+trackio.init(project="my-project", space_id="username/trackio", private=True)
 trackio.log({"loss": 0.1, "accuracy": 0.9})
 trackio.log({"loss": 0.09, "accuracy": 0.91})
 trackio.finish()

--- a/.agents/skills/trackio/logging_metrics.md
+++ b/.agents/skills/trackio/logging_metrics.md
@@ -53,6 +53,10 @@ trackio.init(
     name="run-name",                # Optional: name for this specific run
     config={...},                   # Hyperparameters and config to log
     space_id="username/trackio",    # Optional: sync to HF Space for remote dashboard
+    private=True,                   # Optional: make an auto-created Space private.
+                                    #   Default: PUBLIC (unless your org defaults to private)
+    bucket_id="username/my-bucket", # Optional: pin the HF Bucket used for metric storage.
+                                    #   Default: auto-derived from space_id
     group="experiment-group",       # Optional: group related runs
 )
 ```
@@ -84,11 +88,12 @@ Pass `space_id` to sync metrics to a Hugging Face Space for persistent, shareabl
 ```python
 trackio.init(
     project="my-project",
-    space_id="username/trackio"  # Auto-creates Space if it doesn't exist
+    space_id="username/trackio",  # Auto-creates Space if it doesn't exist
+    private=True,                 # Spaces are PUBLIC by default; omit for a shareable dashboard
 )
 ```
 
-⚠️ **For remote training** (cloud GPUs, HF Jobs, etc.): Always use `space_id` since local storage is lost when the instance terminates.
+⚠️ **For remote training** (cloud GPUs, HF Jobs, etc.): Always use `space_id` since local storage is lost when the instance terminates. If the metrics should not be public, also pass `private=True` — an auto-created Space is public by default (unless your org's default is private); the flag is ignored if the Space already exists.
 
 ### Sync Local to Remote
 
@@ -121,6 +126,7 @@ import trackio
 trackio.init(
     project="sft-training",
     space_id="username/trackio",
+    private=True,  # Spaces are public by default; omit for a shareable dashboard
     config={"model": "Qwen/Qwen2.5-0.5B", "dataset": "trl-lib/Capybara"}
 )
 


### PR DESCRIPTION
Follow-up to the Slack thread and #595. Agents following the skill's `init()` examples create **public** Spaces by default — the examples show `space_id=` but never `private=` (which `init()` supports) — and never pin `bucket_id=`.

This documents both params in the parameter block and adds `private=True` to the remote-training examples, with comments noting Spaces are public by default and that omitting it gives the shareable public dashboard. **Docs only — no change to library behaviour.**

Sanity check against real agent behaviour: in an A/B test, fresh agents given only the skill and asked to set up tracking for a private research project produced a public Space 5/5 times with the current examples; 0/5 with `private=True` documented in the examples.

A matching update to the mirror in `huggingface/skills` is in huggingface/skills#185.

🤖 Generated with [Claude Code](https://claude.com/claude-code)