### PR TITLE
Pass hf_token when building the remote client so sync works with private spaces

### DIFF
--- a/tests/unit/test_deploy.py
+++ b/tests/unit/test_deploy.py
@@ -197,3 +197,21 @@ def test_deploy_as_static_space_rejects_private_true(tmp_path, monkeypatch):
             private=True,
             frontend_dir=frontend_dir,
         )
+
+
+def test_build_remote_client_with_retry_passes_hf_token(monkeypatch):
+    monkeypatch.setattr(
+        deploy.huggingface_hub.utils, "get_token", lambda: "hf_supersecrettoken"
+    )
+    captured_kwargs = {}
+
+    def fake_remote_client(space_id, **kwargs):
+        captured_kwargs.update(kwargs)
+        return SimpleNamespace(space_id=space_id)
+
+    monkeypatch.setattr(deploy, "RemoteClient", fake_remote_client)
+
+    client = deploy._build_remote_client_with_retry("abidlabs/private-space")
+
+    assert client.space_id == "abidlabs/private-space"
+    assert captured_kwargs["hf_token"] == "hf_supersecrettoken"

--- a/tests/unit/test_deploy.py
+++ b/tests/unit/test_deploy.py
@@ -197,21 +197,3 @@ def test_deploy_as_static_space_rejects_private_true(tmp_path, monkeypatch):
             private=True,
             frontend_dir=frontend_dir,
         )
-
-
-def test_build_remote_client_with_retry_passes_hf_token(monkeypatch):
-    monkeypatch.setattr(
-        deploy.huggingface_hub.utils, "get_token", lambda: "hf_supersecrettoken"
-    )
-    captured_kwargs = {}
-
-    def fake_remote_client(space_id, **kwargs):
-        captured_kwargs.update(kwargs)
-        return SimpleNamespace(space_id=space_id)
-
-    monkeypatch.setattr(deploy, "RemoteClient", fake_remote_client)
-
-    client = deploy._build_remote_client_with_retry("abidlabs/private-space")
-
-    assert client.space_id == "abidlabs/private-space"
-    assert captured_kwargs["hf_token"] == "hf_supersecrettoken"

--- a/trackio/deploy.py
+++ b/trackio/deploy.py
@@ -838,7 +838,12 @@ def _build_remote_client_with_retry(
     last_error: Exception | None = None
     while time.time() < deadline:
         try:
-            return RemoteClient(space_id, verbose=verbose, httpx_kwargs={"timeout": 90})
+            return RemoteClient(
+                space_id,
+                hf_token=huggingface_hub.utils.get_token(),
+                verbose=verbose,
+                httpx_kwargs={"timeout": 90},
+            )
         except (ValueError, ConnectionError) as e:
             last_error = e
             time.sleep(delay)


### PR DESCRIPTION
## Short description
`trackio sync` against a private space hangs for 6 minutes and then dies with an unrelated-looking error:

    ConnectionError: Could not connect to Space 'user/space' within 360s: Expecting value: line 1 column 1 (char 0)

cause: `_build_remote_client_with_retry` builds the `RemoteClient` without `hf_token`. On a private space every request gets the HF login page instead of JSON, the JSON parse fails, and the helper retries until the deadline.

fix: pass `hf_token=huggingface_hub.utils.get_token()`, same as the other client constructions in `deploy.py` (e.g. `upload_db_to_space`).

Tested against a private space: before, `trackio sync --project x --space-id user/private-space` fails as above; after, the client connects in under a second and sync completes. Public spaces and logged-out users are unaffected (`get_token()` returns `None` there, which is the current behavior).
## AI Disclosure

- [x] I used AI to find the cause of the error.
- [ ] I did not use AI

----

## Type of Change

- [x] Bug fix
