### PR TITLE
Add wandb importer

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,7 +47,7 @@ jobs:
 
     - name: Install Python dependencies
       run: |
-        uv pip install --system -e '.[dev,tensorboard,spaces]' --prerelease=allow --python "${{ steps.setup-python.outputs.python-path }}"
+        uv pip install --system -e '.[dev,tensorboard,wandb,spaces]' --prerelease=allow --python "${{ steps.setup-python.outputs.python-path }}"
         uv pip install --system pytest --prerelease=allow --python "${{ steps.setup-python.outputs.python-path }}"
 
     - name: Build frontend

--- a/docs/source/api.md
+++ b/docs/source/api.md
@@ -56,6 +56,10 @@
 
 [[autodoc]] import_tf_events
 
+## import_wandb
+
+[[autodoc]] import_wandb
+
 ## save
 
 [[autodoc]] save

--- a/docs/source/migration.md
+++ b/docs/source/migration.md
@@ -82,6 +82,25 @@ wandb.log({"training_results": table})
 wandb.finish()
 ```
 
+### Importing Existing Runs
+
+You can also copy the runs of an existing wandb project into Trackio with `import_wandb` (requires `pip install trackio[wandb]` and being logged in to wandb):
+
+```python
+import trackio
+
+trackio.import_wandb("my-entity/my-project", project="my-project")
+```
+
+Each wandb run is imported as a separate run with its full metric history and config. Metrics logged with a custom step metric (`wandb.define_metric(..., step_metric=...)`) are imported at the value of that step metric, so they keep the same x-axis as in wandb. If a run's stored metric definitions are incomplete, you can pass them explicitly:
+
+```python
+trackio.import_wandb(
+    "my-entity/my-project",
+    project="my-project",
+    step_metrics={"eval/*": "eval_iter"},
+)
+```
 
 ## Neptune (`neptune`)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,9 @@ tensorboard = [
     "tbparse==0.0.9",
     "tensorboardX>=2.0.0,<3.0.0",
 ]
+wandb = [
+    "wandb>=0.19.0",
+]
 gpu = [
     "nvidia-ml-py>=12.0.0",
     "psutil>=5.9.0",

--- a/tests/unit/test_local_logging.py
+++ b/tests/unit/test_local_logging.py
@@ -1,5 +1,8 @@
+import json
 import math
+import sys
 import time
+import types
 import warnings
 from unittest.mock import patch
 
@@ -206,3 +209,186 @@ def test_import_from_csv_without_numeric_metrics_raises(temp_dir, tmp_path):
             project="test_project_no_metrics",
             name="test_run",
         )
+
+
+class FakeWandbRun:
+    def __init__(self, run_id, name, rows, metric_definitions=None, config=None):
+        self.id = run_id
+        self.name = name
+        self.config = config or {}
+        self.json_config = json.dumps(
+            {"_wandb": {"value": {"m": metric_definitions or []}}}
+        )
+        self._rows = rows
+
+    def scan_history(self, page_size=None):
+        return iter(self._rows)
+
+
+def _fake_wandb(monkeypatch, runs):
+    class FakeApi:
+        def runs(self, path):
+            return list(runs)
+
+    monkeypatch.setitem(sys.modules, "wandb", types.SimpleNamespace(Api=FakeApi))
+
+
+def test_import_from_wandb(temp_dir, monkeypatch):
+    # eval/* metrics use eval_iter as their x-axis (wandb define_metric encoding:
+    # "1"=name, "2"=glob, "5"=1-based index of the step-metric record)
+    metric_definitions = [
+        {"1": "eval_iter", "6": [3]},
+        {"2": "eval/*", "5": 1, "6": [1]},
+    ]
+    rows = [
+        {"_step": 10, "_timestamp": 1700000000.0, "loss": 1.5},
+        # wandb merges same-step logs into one row: train metric at _step 20
+        # plus an eval logged at eval_iter 5
+        {
+            "_step": 20,
+            "_timestamp": 1700000060.0,
+            "loss": 1.2,
+            "eval/acc": 0.8,
+            "eval_iter": 5,
+        },
+    ]
+    run = FakeWandbRun(
+        "abc123", "my-run", rows, metric_definitions, config={"lr": 0.001}
+    )
+    _fake_wandb(monkeypatch, [run])
+
+    trackio.import_wandb("entity/proj", project="test_wandb_project")
+
+    results = SQLiteStorage.get_logs(project="test_wandb_project", run="my-run")
+    by_step = {r["step"]: r for r in results}
+    assert len(results) == 3
+    assert by_step[10]["loss"] == 1.5
+    assert by_step[20]["loss"] == 1.2
+    assert "eval/acc" not in by_step[20]
+    assert by_step[5]["eval/acc"] == 0.8
+    assert "loss" not in by_step[5]
+    assert "eval_iter" not in by_step[5]
+    config = SQLiteStorage.get_run_config("test_wandb_project", "my-run")
+    assert config["lr"] == 0.001
+
+    with pytest.raises(ValueError, match="already exists"):
+        trackio.import_wandb("entity/proj", project="test_wandb_project")
+
+
+def test_import_from_wandb_step_metrics_override(temp_dir, monkeypatch):
+    # no stored metric definitions: the caller supplies the mapping instead
+    rows = [
+        {"_step": 20, "_timestamp": 1700000060.0, "loss": 1.2},
+        {"_step": 21, "_timestamp": 1700000120.0, "eval/acc": 0.8, "eval_iter": 5},
+    ]
+    run = FakeWandbRun("def456", "my-run", rows)
+    _fake_wandb(monkeypatch, [run])
+
+    trackio.import_wandb(
+        "entity/proj",
+        project="test_wandb_override",
+        step_metrics={"eval/*": "eval_iter"},
+    )
+
+    results = SQLiteStorage.get_logs(project="test_wandb_override", run="my-run")
+    by_step = {r["step"]: r for r in results}
+    assert by_step[20]["loss"] == 1.2
+    assert by_step[5]["eval/acc"] == 0.8
+
+
+def test_import_from_wandb_offline_run_encoding(temp_dir, tmp_path, monkeypatch):
+    """
+    End-to-end against the installed wandb client, to catch wandb updates changing
+    the metric-definition encoding that `import_wandb` decodes:
+
+    1. Assert the `MetricRecord` protobuf field numbers the decoder relies on.
+    2. Create a real offline run with `define_metric()`, read back the metric
+       records the client actually wrote to the run file, re-encode them the way
+       wandb stores them in the run config, and import through that.
+
+    The history transport is faked because offline runs are not queryable through
+    `wandb.Api` without a server; the client-written metric definitions are real.
+    """
+    wandb = pytest.importorskip("wandb")
+    from wandb.proto import wandb_internal_pb2
+
+    from trackio.imports import _wandb_step_metric_definitions
+
+    # 1. the decoder reads keys "1", "2", "4", "5" of the stored MetricRecord
+    fields = wandb_internal_pb2.MetricRecord.DESCRIPTOR.fields_by_name
+    assert fields["name"].number == 1
+    assert fields["glob_name"].number == 2
+    assert fields["step_metric"].number == 4
+    assert fields["step_metric_index"].number == 5
+
+    # 2. real offline run
+    source_run = wandb.init(
+        project="source-project",
+        name="offline-run",
+        dir=str(tmp_path),
+        mode="offline",
+    )
+    source_run.define_metric("eval_iter")
+    source_run.define_metric("eval/*", step_metric="eval_iter")
+    source_run.log({"loss": 1.5})
+    source_run.log({"loss": 1.2, "eval/acc": 0.8, "eval_iter": 5})
+    source_run.finish()
+
+    try:
+        from wandb.sdk.internal.datastore import DataStore
+    except ImportError:
+        pytest.skip(
+            "wandb moved its internal datastore reader; update this test to keep "
+            "covering the client-written metric definitions"
+        )
+
+    run_file = next((tmp_path / "wandb").glob("offline-run-*/run-*.wandb"))
+    datastore = DataStore()
+    datastore.open_for_scan(str(run_file))
+    metric_records = []
+    while True:
+        data = datastore.scan_data()
+        if data is None:
+            break
+        record = wandb_internal_pb2.Record()
+        record.ParseFromString(bytes(data))
+        if record.WhichOneof("record_type") == "metric":
+            metric_records.append(record.metric)
+    assert metric_records, "the wandb client wrote no metric records"
+
+    # re-encode the client-written records as they appear in a stored run config
+    # (a list of dicts keyed by stringified protobuf field number)
+    stored = [
+        {
+            str(field.number): value
+            for field, value in message.ListFields()
+            if isinstance(value, (str, int, float))
+        }
+        for message in metric_records
+    ]
+    json_config = json.dumps({"_wandb": {"value": {"m": stored}}})
+    assert _wandb_step_metric_definitions(json_config)["eval/*"] == "eval_iter"
+
+    rows = [
+        {"_step": 0, "_timestamp": 1700000000.0, "loss": 1.5},
+        {
+            "_step": 1,
+            "_timestamp": 1700000060.0,
+            "loss": 1.2,
+            "eval/acc": 0.8,
+            "eval_iter": 5,
+        },
+    ]
+    run = FakeWandbRun("off123", "offline-run", rows, config={"lr": 0.001})
+    run.json_config = json_config
+    _fake_wandb(monkeypatch, [run])
+
+    trackio.import_wandb("entity/proj", project="test_wandb_offline")
+
+    results = SQLiteStorage.get_logs(project="test_wandb_offline", run="offline-run")
+    by_step = {r["step"]: r for r in results}
+    assert len(results) == 3
+    assert by_step[0]["loss"] == 1.5
+    assert by_step[1]["loss"] == 1.2
+    assert by_step[5]["eval/acc"] == 0.8
+    assert "eval_iter" not in by_step[5]

--- a/trackio/__init__.py
+++ b/trackio/__init__.py
@@ -27,7 +27,7 @@ from trackio.frontend_config import resolve_frontend_dir
 from trackio.gpu import gpu_available
 from trackio.gpu import log_gpu as _log_nvidia_gpu
 from trackio.histogram import Histogram
-from trackio.imports import import_csv, import_tf_events
+from trackio.imports import import_csv, import_tf_events, import_wandb
 from trackio.launch import launch_trackio_dashboard
 from trackio.markdown import Markdown
 from trackio.media import (
@@ -74,6 +74,7 @@ __all__ = [
     "delete_project",
     "import_csv",
     "import_tf_events",
+    "import_wandb",
     "save",
     "Artifact",
     "Image",

--- a/trackio/imports.py
+++ b/trackio/imports.py
@@ -1,5 +1,8 @@
 import csv
+import fnmatch
+import json
 import os
+from datetime import datetime, timezone
 from pathlib import Path
 
 from trackio import deploy, utils
@@ -283,6 +286,229 @@ def import_tf_events(
         raise ValueError("No valid TensorFlow events data could be imported")
 
     print(f"* Total imported events: {total_imported}")
+    print(f"* Created runs: {', '.join(imported_runs)}")
+
+    space_id, dataset_id, _ = utils.preprocess_space_and_dataset_ids(
+        space_id, dataset_id
+    )
+    if dataset_id is not None:
+        os.environ["TRACKIO_DATASET_ID"] = dataset_id
+        print(f"* Trackio metrics will be synced to Hugging Face Dataset: {dataset_id}")
+
+    if space_id is None:
+        utils.print_dashboard_instructions(project)
+    else:
+        deploy.create_space_if_not_exists(
+            space_id, dataset_id=dataset_id, private=private
+        )
+        deploy.wait_until_space_exists(space_id)
+        deploy.upload_db_to_space(project, space_id, force=force)
+        print(
+            f"* View dashboard by going to: {deploy.SPACE_URL.format(space_id=space_id)}"
+        )
+
+
+def _wandb_step_metric_definitions(json_config: str) -> dict[str, str]:
+    """
+    Extracts `wandb.define_metric()` step-metric mappings from a wandb run config.
+
+    wandb stores metric definitions in the run config under `_wandb.value.m` as a
+    list of records keyed by `MetricRecord` protobuf field number: `"1"` is the
+    metric name, `"2"` is a metric glob, `"4"` is the step metric name, and `"5"`
+    is the 1-based index of the record that defines the metric's step metric (the
+    client writes the name, the server rewrites it to an index). Returns a mapping
+    of metric name/glob -> step metric name.
+    """
+    try:
+        records = (
+            json.loads(json_config).get("_wandb", {}).get("value", {}).get("m", [])
+        )
+    except (ValueError, TypeError, AttributeError):
+        return {}
+    if not isinstance(records, list):
+        return {}
+    mapping: dict[str, str] = {}
+    for record in records:
+        if not isinstance(record, dict):
+            continue
+        pattern = record.get("1") or record.get("2")
+        if not pattern:
+            continue
+        step_metric = record.get("4")
+        step_index = record.get("5")
+        if not step_metric and isinstance(step_index, int):
+            if 1 <= step_index <= len(records) and isinstance(
+                records[step_index - 1], dict
+            ):
+                step_metric = records[step_index - 1].get("1")
+        if step_metric:
+            mapping[str(pattern)] = str(step_metric)
+    return mapping
+
+
+def _resolve_step_metric(key: str, step_metrics: dict[str, str]) -> str | None:
+    """Resolves the step metric for a key: exact match first, then glob patterns."""
+    if key in step_metrics:
+        return step_metrics[key]
+    for pattern, step_metric in step_metrics.items():
+        if fnmatch.fnmatchcase(key, pattern):
+            return step_metric
+    return None
+
+
+def import_wandb(
+    wandb_project: str,
+    project: str,
+    run_ids: list[str] | None = None,
+    name: str | None = None,
+    step_metrics: dict[str, str] | None = None,
+    space_id: str | None = None,
+    dataset_id: str | None = None,
+    private: bool | None = None,
+    force: bool = False,
+) -> None:
+    """
+    Imports the runs of a Weights & Biases project into a Trackio project. Each wandb
+    run is imported as a separate run, with its full metric history and config.
+
+    Metrics logged with a custom step metric (`wandb.define_metric(..., step_metric=...)`)
+    are imported at the value of that step metric, so they keep the same x-axis as in
+    wandb. This matters because wandb merges everything logged at the same internal step
+    into one history row: without splitting, metrics on a custom axis would be imported
+    at the wrong step. Step-metric definitions are read from each run's stored config
+    and can be extended or overridden with the `step_metrics` argument; the step-metric
+    keys themselves are encoded as steps rather than imported as metrics.
+
+    Args:
+        wandb_project (`str`):
+            The wandb project to import, as `"entity/project"`.
+        project (`str`):
+            The name of the Trackio project to import the runs into. Must not be an
+            existing project.
+        run_ids (`list[str]`, *optional*):
+            If provided, only the wandb runs with these IDs are imported. By default,
+            all runs of the wandb project are imported.
+        name (`str`, *optional*):
+            A name prefix for the imported runs (if not provided, the wandb run names
+            are used as-is).
+        step_metrics (`dict[str, str]`, *optional*):
+            A mapping of metric name (or glob, e.g. `"eval/*"`) to the metric that
+            serves as its x-axis, e.g. `{"eval/*": "eval_iter"}`. Merged with (and
+            taking precedence over) the definitions stored in each run.
+        space_id (`str`, *optional*):
+            If provided, the project will be logged to a Hugging Face Space instead of a
+            local directory. Should be a complete Space name like `"username/reponame"`
+            or `"orgname/reponame"`, or just `"reponame"` in which case the Space will
+            be created in the currently-logged-in Hugging Face user's namespace. If the
+            Space does not exist, it will be created. If the Space already exists, the
+            project will be logged to it.
+        dataset_id (`str`, *optional*):
+            Deprecated. Use `bucket_id` instead.
+        private (`bool`, *optional*):
+            Whether to make the Space private. If None (default), the repo will be
+            public unless the organization's default is private. This value is ignored
+            if the repo already exists.
+    """
+    try:
+        import wandb
+    except ImportError:
+        raise ImportError(
+            "The `wandb` package is not installed but is required for `import_wandb`. Please install trackio with the `wandb` extra: `pip install trackio[wandb]`."
+        )
+
+    if SQLiteStorage.get_runs(project):
+        raise ValueError(
+            f"Project '{project}' already exists. Cannot import wandb runs into existing project."
+        )
+
+    api = wandb.Api()
+    runs = list(api.runs(wandb_project))
+    if run_ids is not None:
+        runs = [run for run in runs if run.id in run_ids]
+    if not runs:
+        raise ValueError(f"No wandb runs found in '{wandb_project}'")
+
+    internal_keys = {"_step", "_runtime", "_timestamp", "_wandb"}
+    total_imported = 0
+    imported_runs = []
+    used_names = set()
+
+    for run in runs:
+        run_step_metrics = _wandb_step_metric_definitions(
+            getattr(run, "json_config", None) or "{}"
+        )
+        run_step_metrics.update(step_metrics or {})
+        axis_keys = set(run_step_metrics.values())
+
+        run_name = run.name or run.id
+        if name:
+            run_name = f"{name}_{run_name}"
+        if run_name in used_names:
+            run_name = f"{run_name}-{run.id}"
+        used_names.add(run_name)
+
+        metrics_list = []
+        steps = []
+        timestamps = []
+
+        for row in run.scan_history():
+            default_step = int(row.get("_step", 0))
+            if row.get("_timestamp") is not None:
+                timestamp = datetime.fromtimestamp(
+                    float(row["_timestamp"]), tz=timezone.utc
+                ).isoformat()
+            else:
+                timestamp = ""
+
+            by_axis: dict[str | None, dict] = {}
+            for key, value in row.items():
+                if key in internal_keys or key in axis_keys or value is None:
+                    continue
+                if isinstance(value, bool) or not isinstance(value, (int, float)):
+                    continue
+                axis = _resolve_step_metric(key, run_step_metrics)
+                by_axis.setdefault(axis, {})[key] = value
+
+            for axis, metrics in by_axis.items():
+                if axis is not None and isinstance(row.get(axis), (int, float)):
+                    step = int(row[axis])
+                else:
+                    step = default_step
+                metrics_list.append(metrics)
+                steps.append(step)
+                timestamps.append(timestamp)
+
+        if not metrics_list:
+            print(f"* Skipping wandb run '{run.id}': no numeric metric data found")
+            continue
+
+        config = {}
+        for key, value in dict(run.config).items():
+            try:
+                json.dumps(value)
+            except (TypeError, ValueError):
+                continue
+            config[key] = value
+
+        SQLiteStorage.bulk_log(
+            project=project,
+            run=run_name,
+            metrics_list=metrics_list,
+            steps=steps,
+            timestamps=timestamps,
+            config=config or None,
+        )
+
+        total_imported += len(metrics_list)
+        imported_runs.append(run_name)
+        print(
+            f"* Imported {len(metrics_list)} rows from wandb run '{run.id}' as run '{run_name}'"
+        )
+
+    if not imported_runs:
+        raise ValueError("No valid wandb run data could be imported")
+
+    print(f"* Total imported rows: {total_imported}")
     print(f"* Created runs: {', '.join(imported_runs)}")
 
     space_id, dataset_id, _ = utils.preprocess_space_and_dataset_ids(


### PR DESCRIPTION
## Short description

Adds a local wandb importer feature. Why? The CSV importer gave me issues with my multi-run project: I needed to correct the x-axis name from wandb, was missing the run config, overall not working great.

But warning: the feature was heavily vibe coded. I made sure to supervise, add docs, integration test, etc. It was useful for migrating my runs, but it's totally fine if it's not worth reviewing; I understand these vibecoded PRs can eat too much maintainer time.

## Full description

Adds `trackio.import_wandb("entity/project", project="my-project")` alongside `import_csv` and `import_tf_events`. Each wandb run is imported as a separate trackio run with its full metric history (via `Api.runs()` + `scan_history()`) and config. Same structure as the existing importers: optional dependency behind a `wandb` extra, project-must-not-exist guard, same Space upload tail.

The non-obvious part is custom x-axes. wandb merges everything logged at the same internal step into one history row, so a row can hold a training metric at `_step=5360` *and* an eval metric whose real x is `eval_iter=5000`. A naive import puts both at one step and silently misplaces the eval series. `import_wandb` reads the `wandb.define_metric(..., step_metric=...)` definitions stored in the run config (`_wandb.value.m`, records keyed by `MetricRecord` protobuf field number) and splits each row so every metric lands at its own axis value. Both stored forms are handled: the client writes the step metric name (field `"4"`), the server rewrites it to an index (field `"5"`).

Since those stored definitions don't always survive (they can be lost when eval jobs resume a run), there's a `step_metrics={"eval/*": "eval_iter"}` argument to extend or override them.

### Tests: 
- two mocked-transport tests for the routing and the override
- integration test against the installed wandb client. It asserts the `MetricRecord` field numbers the decoder relies on, creates a real offline run with `define_metric()`, reads back the metric records the client actually wrote, and imports through them, so a wandb update that changes the encoding fails CI rather than corrupting imports. The CI workflow now installs the `wandb` extra (same as `tensorboard`); without it the test skips.

Verified on a real project (15 runs, ~40k history rows, two custom axes): all series land on the correct steps with values matching the wandb UI.

Docs: autodoc entry in `api.md` plus an "Importing Existing Runs" section in `migration.md`.

## AI Disclosure

- [x] I used AI to code, write docs, and test. Supervised myself and edited the end result.
- [ ] I did not use AI

----

## Type of Change

- [x] New feature (non-breaking)
- [x] Documentation update
- [x] Test improvements

