### PR TITLE
Move artifact downloads under .trackio

### DIFF
--- a/.changeset/artifact-download-location.md
+++ b/.changeset/artifact-download-location.md
@@ -1,0 +1,5 @@
+---
+"trackio": patch
+---
+
+Move default artifact downloads under `./.trackio/artifact-downloads/` so materialized files stay out of the project root.

--- a/docs/source/artifacts.md
+++ b/docs/source/artifacts.md
@@ -92,10 +92,10 @@ artifact = trackio.use_artifact("my-model", type="model")
 ```python
 artifact = trackio.use_artifact("my-model:latest")
 path = artifact.download()
-# files are now under ./artifacts/my_project/my-model_v2/
+# files are now under ./.trackio/artifact-downloads/my_project/my-model_v2/
 ```
 
-By default, files are written to `./artifacts/<project>/<name>_v<version>/`, keyed by project so same-named artifacts from different projects never collide; pass `root` to choose another directory. `download()` is idempotent — files already present are skipped — and when the run is backed by a Space, any file missing locally is fetched from the remote.
+By default, files are written to `./.trackio/artifact-downloads/<project>/<name>_v<version>/`, keyed by project so same-named artifacts from different projects never collide; pass `root` to choose another directory. `download()` is idempotent — files already present are skipped — and when the run is backed by a Space, any file missing locally is fetched from the remote.
 
 ## Remote storage
 

--- a/tests/unit/test_artifact_e2e.py
+++ b/tests/unit/test_artifact_e2e.py
@@ -20,6 +20,11 @@ def test_master_plan_example_runs_verbatim(temp_dir, tmp_path, monkeypatch):
     trackio.finish()
 
     materialized = Path(out) / "weights.bin"
+    assert (
+        Path(out)
+        == tmp_path / ".trackio" / "artifact-downloads" / "art-demo" / "my-model_v0"
+    )
+    assert not (tmp_path / "artifacts").exists()
     assert materialized.is_file()
     assert materialized.read_bytes() == weights.read_bytes()
     assert fetched.metadata == {"acc": 0.91}

--- a/trackio/artifact.py
+++ b/trackio/artifact.py
@@ -297,10 +297,11 @@ class Artifact:
         Args:
             root (`str` or `Path`, *optional*):
                 Directory to write the files into. Defaults to
-                `./artifacts/<project>/<name>_v<version>/`, keyed by project so
-                same-named artifacts from different projects never collide, and
-                by the resolved version so a moving alias like `latest` never
-                leaves behind stale files from a previous version.
+                `./.trackio/artifact-downloads/<project>/<name>_v<version>/`,
+                keyed by project so same-named artifacts from different projects
+                never collide, and by the resolved version so a moving alias
+                like `latest` never leaves behind stale files from a previous
+                version.
 
         Returns:
             The absolute path to the download directory, as a string.
@@ -315,7 +316,11 @@ class Artifact:
         if root is None:
             project = utils.canonical_project_name(self._project)
             root_path = (
-                Path.cwd() / "artifacts" / project / f"{self._name}_v{self._version}"
+                Path.cwd()
+                / ".trackio"
+                / "artifact-downloads"
+                / project
+                / f"{self._name}_v{self._version}"
             )
         else:
             root_path = Path(root)


### PR DESCRIPTION
## Summary
- move default artifact downloads from ./artifacts to ./.trackio/artifact-downloads
- update artifact docs for the new default path
- add a unit assertion that the default download path stays out of ./artifacts

## Tests
- python -m pytest tests/unit/test_artifact_e2e.py
- python -m ruff check trackio/artifact.py tests/unit/test_artifact_e2e.py