### PR TITLE
docs: clarify artifact types

### DIFF
--- a/.changeset/bitter-wolves-refuse.md
+++ b/.changeset/bitter-wolves-refuse.md
@@ -1,0 +1,5 @@
+---
+"trackio": minor
+---
+
+feat:docs: clarify artifact types

--- a/docs/source/artifacts.md
+++ b/docs/source/artifacts.md
@@ -30,6 +30,20 @@ When you pass a path, the artifact `name` defaults to `run-<run_id>-<basename>` 
 trackio.log_artifact("checkpoints/", name="my-model", type="model")
 ```
 
+### Artifact types
+
+Artifact `type` is a free-form category string. Trackio does not enforce a fixed list of types, but common conventions are:
+
+| Type | Use it for |
+| --- | --- |
+| `"model"` | Model checkpoints, adapter weights, tokenizers, model configs |
+| `"dataset"` | Training, validation, test, or generated datasets |
+| `"evaluation"` | Evaluation outputs, predictions, benchmark results, score files |
+| `"report"` | Figures, plots, tables, notebooks, or human-readable analysis bundles |
+| `"unspecified"` | The default when no type is provided |
+
+Use stable type names within a project so you can filter artifacts consistently and use `trackio.use_artifact(..., type="...")` to assert that a run is consuming the expected kind of artifact.
+
 ### Building an artifact explicitly
 
 For finer control — multiple files, custom logical paths, a description, or metadata — construct an [`Artifact`], add files to it, then log it:

--- a/trackio/deploy.py
+++ b/trackio/deploy.py
@@ -3,7 +3,6 @@ import io
 import json as json_mod
 import os
 import shutil
-import sys
 import tempfile
 import threading
 import time
@@ -11,11 +10,6 @@ import warnings
 from collections import Counter
 from importlib.resources import files
 from pathlib import Path
-
-if sys.version_info >= (3, 11):
-    import tomllib
-else:
-    import tomli as tomllib
 
 import httpx
 import huggingface_hub
@@ -293,6 +287,11 @@ def resolve_auto_bucket_id(
 
 def _get_source_install_dependencies() -> str:
     """Get trackio dependencies from pyproject.toml for source installs."""
+    try:
+        import tomllib  # noqa: PLC0415
+    except ModuleNotFoundError:
+        import tomli as tomllib  # noqa: PLC0415
+
     trackio_path = files("trackio")
     pyproject_path = Path(trackio_path).parent / "pyproject.toml"
     with open(pyproject_path, "rb") as f:


### PR DESCRIPTION
Add an Artifact types section to the artifacts docs. It explains that Trackio artifact `type` is free-form and documents common conventions such as model, dataset, evaluation, report, and unspecified.