### PR TITLE
Panels-per-row and row pagination controls to panel groups

### DIFF
--- a/tests/ui/test_metrics_group_pagination.py
+++ b/tests/ui/test_metrics_group_pagination.py
@@ -1,0 +1,128 @@
+from playwright.sync_api import expect, sync_playwright
+
+import trackio
+
+
+def _log_grouped_metrics(project):
+    trackio.init(project=project, name="run_0")
+    for s in range(5):
+        metrics = {f"big/m{i}": float(s + i) for i in range(8)}
+        metrics.update({f"small/m{i}": float(s + i) for i in range(3)})
+        trackio.log(metrics=metrics)
+    trackio.finish()
+
+
+def test_panels_per_row_is_capped_to_group_size(temp_dir):
+    _log_grouped_metrics("test_pagination_caps")
+
+    app, _, _, full_url = trackio.show(
+        project="test_pagination_caps", block_thread=False, open_browser=False
+    )
+
+    try:
+        with sync_playwright() as p:
+            browser = p.chromium.launch()
+            page = browser.new_page()
+            page.set_default_timeout(5000)
+            page.goto(full_url)
+            page.wait_for_load_state("networkidle")
+
+            small_group = page.locator(".accordion", has_text="small (3)")
+            expect(small_group.locator(".plot-container")).to_have_count(3)
+
+            # a 3-panel group must not offer a "4/row" (or higher) option
+            options = small_group.locator("select.per-row-select option")
+            expect(options).to_have_count(3)
+            values = options.evaluate_all("els => els.map(e => e.value)")
+            assert values == ["1", "2", "3"]
+
+            browser.close()
+    finally:
+        trackio.delete_project("test_pagination_caps", force=True)
+        app.close()
+
+
+def test_row_pagination_shows_pages_of_panels(temp_dir):
+    _log_grouped_metrics("test_pagination_pages")
+
+    app, _, _, full_url = trackio.show(
+        project="test_pagination_pages", block_thread=False, open_browser=False
+    )
+
+    try:
+        with sync_playwright() as p:
+            browser = p.chromium.launch()
+            page = browser.new_page()
+            page.set_default_timeout(5000)
+            page.goto(full_url)
+            page.wait_for_load_state("networkidle")
+
+            big_group = page.locator(".accordion", has_text="big (8)")
+
+            # default: 4/row, all rows shown -> every panel visible
+            expect(big_group.locator(".plot-container")).to_have_count(8)
+
+            # switch to 1 row per page -> only the first 4 panels render
+            big_group.locator("button.rows-button").click()
+            big_group.get_by_role("button", name="1 row per page", exact=True).click()
+            expect(big_group.locator(".plot-container")).to_have_count(4)
+            first_page_titles = big_group.locator(".plot-title").all_inner_texts()
+
+            next_button = big_group.locator("button.page-nav", has_text="›")
+            prev_button = big_group.locator("button.page-nav", has_text="‹")
+            expect(prev_button).to_be_disabled()
+
+            next_button.click()
+            expect(big_group.locator(".plot-container")).to_have_count(4)
+            second_page_titles = big_group.locator(".plot-title").all_inner_texts()
+            assert set(first_page_titles).isdisjoint(second_page_titles)
+            expect(next_button).to_be_disabled()
+
+            # "show all rows" restores every panel
+            big_group.locator("button.rows-button").click()
+            big_group.get_by_role("button", name="Show all rows", exact=True).click()
+            expect(big_group.locator(".plot-container")).to_have_count(8)
+
+            browser.close()
+    finally:
+        trackio.delete_project("test_pagination_pages", force=True)
+        app.close()
+
+
+def test_chart_resizes_when_panels_per_row_changes(temp_dir):
+    _log_grouped_metrics("test_pagination_resize")
+
+    app, _, _, full_url = trackio.show(
+        project="test_pagination_resize", block_thread=False, open_browser=False
+    )
+
+    try:
+        with sync_playwright() as p:
+            browser = p.chromium.launch()
+            page = browser.new_page(viewport={"width": 1400, "height": 1000})
+            page.set_default_timeout(5000)
+            page.goto(full_url)
+            page.wait_for_load_state("networkidle")
+
+            big_group = page.locator(".accordion", has_text="big (8)")
+            container = big_group.locator(".plot-container").first
+            canvas = container.locator("canvas")
+            expect(canvas).to_be_visible()
+
+            before_width = canvas.bounding_box()["width"]
+
+            big_group.locator("select.per-row-select").select_option("2")
+            page.wait_for_timeout(500)
+
+            after_box = container.bounding_box()
+            after_canvas_width = canvas.bounding_box()["width"]
+
+            # the canvas must actually grow with its (now wider) box, not
+            # stay stuck at its old size
+            assert after_canvas_width > before_width + 20
+            assert abs(after_canvas_width - after_box["width"]) < 30
+
+            browser.close()
+    finally:
+        trackio.delete_project("test_pagination_resize", force=True)
+        app.close()

--- a/trackio/frontend/src/components/Accordion.svelte
+++ b/trackio/frontend/src/components/Accordion.svelte
@@ -1,5 +1,11 @@
 <script>
-  let { label = "", open = $bindable(true), hidden = false, children } = $props();
+  let {
+    label = "",
+    open = $bindable(true),
+    hidden = false,
+    children,
+    controls,
+  } = $props();
 
   function toggle() {
     open = !open;
@@ -12,10 +18,17 @@
   </div>
 {:else}
   <div class="accordion">
-    <button class="accordion-header" onclick={toggle}>
-      <span class="arrow" class:rotated={open}>▾</span>
-      <span class="accordion-label">{label}</span>
-    </button>
+    <div class="accordion-header-row">
+      <button class="accordion-header" onclick={toggle}>
+        <span class="arrow" class:rotated={open}>▾</span>
+        <span class="accordion-label">{label}</span>
+      </button>
+      {#if controls}
+        <div class="accordion-controls">
+          {@render controls()}
+        </div>
+      {/if}
+    </div>
     {#if open}
       <div class="accordion-body">
         {#if children}{@render children()}{/if}
@@ -35,14 +48,20 @@
   .accordion-hidden {
     margin-bottom: 8px;
   }
+  .accordion-header-row {
+    display: flex;
+    align-items: center;
+    background: var(--background-fill-primary, white);
+  }
   .accordion-header {
     display: flex;
     align-items: center;
     gap: 8px;
-    width: 100%;
+    flex: 1;
+    min-width: 0;
     padding: 10px 14px;
     border: none;
-    background: var(--background-fill-primary, white);
+    background: none;
     color: var(--body-text-color, #1f2937);
     font-size: var(--text-md, 14px);
     font-weight: 600;
@@ -51,6 +70,12 @@
   }
   .accordion-header:hover {
     background: var(--background-fill-secondary, #f9fafb);
+  }
+  .accordion-controls {
+    display: flex;
+    align-items: center;
+    flex-shrink: 0;
+    padding-right: 12px;
   }
   .arrow {
     font-size: 14px;

--- a/trackio/frontend/src/components/BarPlot.svelte
+++ b/trackio/frontend/src/components/BarPlot.svelte
@@ -140,6 +140,13 @@
     };
   }
 
+  function syncViewSize() {
+    if (!view || !container) return;
+    view.width(container.clientWidth);
+    if (fullscreen) view.height(container.clientHeight);
+    view.resize().run();
+  }
+
   async function render() {
     await tick();
     if (!container || !data || data.length === 0 || !y) return;
@@ -159,9 +166,7 @@
         renderer: "canvas",
       });
       view = result.view;
-      requestAnimationFrame(() => {
-        result.view.resize();
-      });
+      requestAnimationFrame(syncViewSize);
     } catch (e) {
       console.error("Vega render error:", e);
     }
@@ -243,7 +248,7 @@
       await requestFullscreenEl(fullscreenHost);
       await tick();
       relocateTooltipElement(fullscreenHost);
-      view?.resize();
+      syncViewSize();
     } catch {
       document.body.style.overflow = "";
       fullscreen = false;
@@ -280,7 +285,7 @@
       relocateTooltipElement(document.body);
     }
     if (active && fullscreen) {
-      tick().then(() => view?.resize());
+      tick().then(syncViewSize);
     }
   }
 
@@ -303,9 +308,7 @@
   $effect(() => {
     if (!container) return;
     const ro = new ResizeObserver(() => {
-      queueMicrotask(() => {
-        view?.resize();
-      });
+      queueMicrotask(syncViewSize);
     });
     ro.observe(container);
     return () => ro.disconnect();

--- a/trackio/frontend/src/components/GroupPanelControls.svelte
+++ b/trackio/frontend/src/components/GroupPanelControls.svelte
@@ -1,0 +1,242 @@
+<script>
+  let {
+    panelsPerRow = 4,
+    rowsToShow = "all",
+    currentPage = 0,
+    totalPanels = 0,
+    perRowOptions = [1, 2, 3, 4, 5, 6],
+    onPanelsPerRowChange = () => {},
+    onRowsToShowChange = () => {},
+    onPageChange = () => {},
+  } = $props();
+
+  let rowsOpen = $state(false);
+  let containerEl;
+
+  let availableOptions = $derived(
+    perRowOptions.filter((n) => n <= Math.max(totalPanels, 1)),
+  );
+  let cols = $derived(Math.max(1, Math.min(panelsPerRow, totalPanels || 1)));
+  let totalRows = $derived(Math.max(1, Math.ceil(totalPanels / cols)));
+  let rowOptions = $derived(Array.from({ length: totalRows }, (_, i) => i + 1));
+  let effectiveRowsPerPage = $derived(
+    rowsToShow === "all" ? totalRows : Math.max(1, Math.min(rowsToShow, totalRows)),
+  );
+  let totalPages = $derived(Math.max(1, Math.ceil(totalRows / effectiveRowsPerPage)));
+  let page = $derived(Math.min(Math.max(0, currentPage), totalPages - 1));
+  let rowStart = $derived(page * effectiveRowsPerPage + 1);
+  let rowEnd = $derived(Math.min(totalRows, rowStart + effectiveRowsPerPage - 1));
+  let rowsLabel = $derived(
+    totalPages <= 1
+      ? `All rows (${totalRows})`
+      : `Rows ${rowStart}-${rowEnd} of ${totalRows}`,
+  );
+
+  function toggleRowsMenu() {
+    rowsOpen = !rowsOpen;
+  }
+
+  function selectRows(value) {
+    onRowsToShowChange(value);
+    rowsOpen = false;
+  }
+
+  function prevPage() {
+    if (page > 0) onPageChange(page - 1);
+  }
+
+  function nextPage() {
+    if (page < totalPages - 1) onPageChange(page + 1);
+  }
+
+  function handleOutsideClick(e) {
+    if (containerEl && !containerEl.contains(e.target)) {
+      rowsOpen = false;
+    }
+  }
+
+  $effect(() => {
+    if (!rowsOpen) return;
+    window.addEventListener("mousedown", handleOutsideClick);
+    return () => window.removeEventListener("mousedown", handleOutsideClick);
+  });
+</script>
+
+<div class="group-panel-controls" bind:this={containerEl}>
+  {#if totalPanels > 1}
+    <select
+      class="per-row-select"
+      value={cols}
+      onchange={(e) => onPanelsPerRowChange(Number(e.currentTarget.value))}
+      aria-label="Panels per row"
+      title="Panels per row"
+    >
+      {#each availableOptions as n}
+        <option value={n}>{n}/row</option>
+      {/each}
+    </select>
+  {/if}
+
+  {#if totalRows > 1}
+    <div class="rows-select">
+      {#if totalPages > 1}
+        <button
+          type="button"
+          class="page-nav"
+          onclick={prevPage}
+          disabled={page <= 0}
+          aria-label="Previous rows"
+        >
+          ‹
+        </button>
+      {/if}
+      <button type="button" class="rows-button" onclick={toggleRowsMenu}>
+        <span>{rowsLabel}</span>
+        <span class="chevron" class:open={rowsOpen}>▾</span>
+      </button>
+      {#if totalPages > 1}
+        <button
+          type="button"
+          class="page-nav"
+          onclick={nextPage}
+          disabled={page >= totalPages - 1}
+          aria-label="Next rows"
+        >
+          ›
+        </button>
+      {/if}
+      {#if rowsOpen}
+        <ul class="rows-menu" role="listbox">
+          {#each rowOptions as r}
+            <li>
+              <button
+                type="button"
+                class="rows-option"
+                class:selected={rowsToShow === r}
+                onclick={() => selectRows(r)}
+              >
+                {r} row{r === 1 ? "" : "s"} per page
+              </button>
+            </li>
+          {/each}
+          <li class="rows-menu-divider"></li>
+          <li>
+            <button
+              type="button"
+              class="rows-option"
+              class:selected={rowsToShow === "all"}
+              onclick={() => selectRows("all")}
+            >
+              Show all rows
+            </button>
+          </li>
+        </ul>
+      {/if}
+    </div>
+  {/if}
+</div>
+
+<style>
+  .group-panel-controls {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+  }
+  .per-row-select {
+    font-size: 12px;
+    color: var(--body-text-color-subdued, #6b7280);
+    background: var(--background-fill-secondary, #f9fafb);
+    border: 1px solid var(--border-color-primary, #e5e7eb);
+    border-radius: var(--radius-sm, 4px);
+    padding: 3px 6px;
+    cursor: pointer;
+  }
+  .rows-select {
+    position: relative;
+    display: flex;
+    align-items: center;
+    gap: 2px;
+  }
+  .page-nav {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 20px;
+    height: 22px;
+    font-size: 13px;
+    line-height: 1;
+    color: var(--body-text-color-subdued, #6b7280);
+    background: var(--background-fill-secondary, #f9fafb);
+    border: 1px solid var(--border-color-primary, #e5e7eb);
+    border-radius: var(--radius-sm, 4px);
+    cursor: pointer;
+    padding: 0;
+  }
+  .page-nav:hover:not(:disabled) {
+    color: var(--body-text-color, #1f2937);
+  }
+  .page-nav:disabled {
+    opacity: 0.4;
+    cursor: default;
+  }
+  .rows-button {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 12px;
+    color: var(--body-text-color-subdued, #6b7280);
+    background: var(--background-fill-secondary, #f9fafb);
+    border: 1px solid var(--border-color-primary, #e5e7eb);
+    border-radius: var(--radius-sm, 4px);
+    padding: 3px 6px;
+    cursor: pointer;
+    white-space: nowrap;
+  }
+  .rows-button:hover {
+    color: var(--body-text-color, #1f2937);
+  }
+  .chevron {
+    font-size: 10px;
+    transition: transform 0.15s;
+    display: inline-block;
+  }
+  .chevron.open {
+    transform: rotate(180deg);
+  }
+  .rows-menu {
+    position: absolute;
+    top: calc(100% + 4px);
+    right: 0;
+    z-index: var(--layer-top, 9999);
+    margin: 0;
+    padding: 4px 0;
+    min-width: 150px;
+    list-style: none;
+    background: var(--background-fill-primary, white);
+    border: 1px solid var(--border-color-primary, #e5e7eb);
+    border-radius: var(--radius-lg, 8px);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
+  }
+  .rows-menu-divider {
+    height: 1px;
+    margin: 4px 0;
+    background: var(--border-color-primary, #e5e7eb);
+  }
+  .rows-option {
+    display: block;
+    width: 100%;
+    text-align: left;
+    padding: 6px 12px;
+    font-size: 13px;
+    color: var(--body-text-color, #1f2937);
+    background: none;
+    border: none;
+    cursor: pointer;
+  }
+  .rows-option:hover {
+    background: var(--background-fill-secondary, #f9fafb);
+  }
+  .rows-option.selected {
+    font-weight: 600;
+  }
+</style>

--- a/trackio/frontend/src/components/LinePlot.svelte
+++ b/trackio/frontend/src/components/LinePlot.svelte
@@ -339,6 +339,13 @@
     }
   }
 
+  function syncViewSize() {
+    if (!view || !container) return;
+    view.width(container.clientWidth);
+    if (fullscreen) view.height(container.clientHeight);
+    view.resize().run();
+  }
+
   async function fullRender() {
     await tick();
     if (!container || !data || data.length === 0 || !y) return;
@@ -356,9 +363,7 @@
       });
       view = result.view;
       lastStructuralKey = getStructuralKey();
-      requestAnimationFrame(() => {
-        result.view.resize();
-      });
+      requestAnimationFrame(syncViewSize);
 
       if (onSelect) {
         let lastSelectTime = 0;
@@ -471,7 +476,7 @@
       await requestFullscreenEl(fullscreenHost);
       await tick();
       relocateTooltipElement(fullscreenHost);
-      view?.resize();
+      syncViewSize();
     } catch {
       document.body.style.overflow = "";
       fullscreen = false;
@@ -508,7 +513,7 @@
       relocateTooltipElement(document.body);
     }
     if (active && fullscreen) {
-      tick().then(() => view?.resize());
+      tick().then(syncViewSize);
     }
   }
 
@@ -535,9 +540,7 @@
   $effect(() => {
     if (!container) return;
     const ro = new ResizeObserver(() => {
-      queueMicrotask(() => {
-        view?.resize();
-      });
+      queueMicrotask(syncViewSize);
     });
     ro.observe(container);
     return () => ro.disconnect();

--- a/trackio/frontend/src/pages/Metrics.svelte
+++ b/trackio/frontend/src/pages/Metrics.svelte
@@ -4,6 +4,7 @@
   import LinePlot from "../components/LinePlot.svelte";
   import BarPlot from "../components/BarPlot.svelte";
   import Accordion from "../components/Accordion.svelte";
+  import GroupPanelControls from "../components/GroupPanelControls.svelte";
   import LoadingTrackio from "../components/LoadingTrackio.svelte";
   import { getLogsBatch } from "../lib/api.js";
   import {
@@ -46,6 +47,9 @@
   let hasLoaded = $state(false);
   let metricOrder = $state({});
   let dragState = $state({ group: null, index: -1 });
+  let panelsPerRowByGroup = $state({});
+  let rowsToShowByGroup = $state({});
+  let currentPageByGroup = $state({});
 
   let rawDataCache = new Map();
   let refreshTimer = null;
@@ -64,6 +68,34 @@
 
   function getPlotResult(metric) {
     return computeMetricPlotData(masterData, xColumn, metric, xLim);
+  }
+
+  function getVisibleMetrics(key, items) {
+    const perRow = panelsPerRowByGroup[key] ?? 4;
+    const cols = Math.max(1, Math.min(perRow, items.length || 1));
+    const rowsToShow = rowsToShowByGroup[key] ?? "all";
+    if (rowsToShow === "all") return items;
+    const totalRows = Math.max(1, Math.ceil(items.length / cols));
+    const rowsPerPage = Math.max(1, Math.min(rowsToShow, totalRows));
+    const totalPages = Math.max(1, Math.ceil(totalRows / rowsPerPage));
+    const page = Math.min(currentPageByGroup[key] ?? 0, totalPages - 1);
+    const pageSize = rowsPerPage * cols;
+    const start = page * pageSize;
+    return items.slice(start, start + pageSize);
+  }
+
+  function setPanelsPerRow(key, value) {
+    panelsPerRowByGroup = { ...panelsPerRowByGroup, [key]: value };
+    currentPageByGroup = { ...currentPageByGroup, [key]: 0 };
+  }
+
+  function setRowsToShow(key, value) {
+    rowsToShowByGroup = { ...rowsToShowByGroup, [key]: value };
+    currentPageByGroup = { ...currentPageByGroup, [key]: 0 };
+  }
+
+  function setCurrentPage(key, value) {
+    currentPageByGroup = { ...currentPageByGroup, [key]: value };
   }
 
   function getOrderedMetrics(key, items) {
@@ -302,6 +334,8 @@
       {@const group = metricGroups[groupName]}
       {@const directKey = `${groupName}:direct`}
       {@const orderedDirect = getOrderedMetrics(directKey, group.direct)}
+      {@const visibleDirect = getVisibleMetrics(directKey, orderedDirect)}
+      {@const directCols = Math.max(1, Math.min(panelsPerRowByGroup[directKey] ?? 4, orderedDirect.length || 1))}
       {@const directCount = group.direct.length}
       {@const subCount = Object.values(group.subgroups).reduce((a, b) => a + b.length, 0)}
       {@const totalCount = directCount + subCount}
@@ -311,9 +345,23 @@
         open={true}
         hidden={!showHeaders}
       >
-        {#if orderedDirect.length > 0}
-          <div class="plot-grid">
-            {#each orderedDirect as metric, i}
+        {#snippet controls()}
+          {#if orderedDirect.length > 0}
+            <GroupPanelControls
+              panelsPerRow={panelsPerRowByGroup[directKey] ?? 4}
+              rowsToShow={rowsToShowByGroup[directKey] ?? "all"}
+              currentPage={currentPageByGroup[directKey] ?? 0}
+              totalPanels={orderedDirect.length}
+              onPanelsPerRowChange={(v) => setPanelsPerRow(directKey, v)}
+              onRowsToShowChange={(v) => setRowsToShow(directKey, v)}
+              onPageChange={(v) => setCurrentPage(directKey, v)}
+            />
+          {/if}
+        {/snippet}
+
+        {#if visibleDirect.length > 0}
+          <div class="plot-grid" style="--cols: {directCols}">
+            {#each visibleDirect as metric, i}
               {@const plotResult = getPlotResult(metric)}
               {@const plotData = plotResult.data}
               {@const yExtent = plotResult.yExtent}
@@ -361,13 +409,27 @@
           {#each Object.entries(group.subgroups) as [subName, subMetrics]}
             {@const subKey = `${groupName}:${subName}`}
             {@const orderedSub = getOrderedMetrics(subKey, subMetrics)}
+            {@const visibleSub = getVisibleMetrics(subKey, orderedSub)}
+            {@const subCols = Math.max(1, Math.min(panelsPerRowByGroup[subKey] ?? 4, orderedSub.length || 1))}
             <Accordion
               label="{subName} ({subMetrics.length})"
               open={true}
               hidden={!showHeaders}
             >
-              <div class="plot-grid">
-                {#each orderedSub as metric, i}
+              {#snippet controls()}
+                <GroupPanelControls
+                  panelsPerRow={panelsPerRowByGroup[subKey] ?? 4}
+                  rowsToShow={rowsToShowByGroup[subKey] ?? "all"}
+                  currentPage={currentPageByGroup[subKey] ?? 0}
+                  totalPanels={orderedSub.length}
+                  onPanelsPerRowChange={(v) => setPanelsPerRow(subKey, v)}
+                  onRowsToShowChange={(v) => setRowsToShow(subKey, v)}
+                  onPageChange={(v) => setCurrentPage(subKey, v)}
+                />
+              {/snippet}
+
+              <div class="plot-grid" style="--cols: {subCols}">
+                {#each visibleSub as metric, i}
                   {@const plotResult = getPlotResult(metric)}
                   {@const plotData = plotResult.data}
                   {@const yExtent = plotResult.yExtent}
@@ -425,9 +487,13 @@
     min-height: 0;
   }
   .plot-grid {
-    display: flex;
-    flex-wrap: wrap;
+    display: grid;
+    grid-template-columns: repeat(var(--cols, 1), minmax(0, 1fr));
     gap: 16px;
+  }
+  .plot-grid :global(.plot-container) {
+    min-width: 0;
+    width: 100%;
   }
   .subgroup-list {
     margin-top: 16px;


### PR DESCRIPTION
## Short description

Metric groups currently pack every panel into one flex row that wraps based on a fixed 350px minimum width. With 4 panels this looks fine; with 6+ panels each chart gets squeezed too narrow to read, and there was no way to control it.

This adds two small controls to the top-right of each group's header (next to the title and fold arrow):

- Panels per row: a dropdown to pick how many panels fit per row (capped; a 3-panel group won't offer "4/row").
- Rows shown: a "Rows X-Y of Z" control with ‹/› navigation between pages of rows.

Screenshots:
<img width="1538" height="1223" alt="image" src="https://github.com/user-attachments/assets/9cbbfb14-dd09-457d-89ad-9637db5ec1a3" />
<img width="1538" height="856" alt="image" src="https://github.com/user-attachments/assets/b8bf0895-2965-4e0f-b09f-63fea412b105" />


Both settings are per-group and default to 4/row, all rows shown. So nothing changes visually until you touch the controls.


## AI Disclosure

- [x] I used AI to code the feature.
- [ ] I did not use AI

----

## Type of Change

- [x] New feature (non-breaking)

## Related Issues

If this PR closes an issue, please link it below: 

Closes: 

## Testing and linting

Please run tests before submitting changes:
   ```bash
   python -m pytest
   ```

and format your code using Ruff:

   ```bash
   ruff check --fix --select I && ruff format
   ```
