### PR TITLE
Serve live logbook preview from open

### DIFF
--- a/.agents/skills/trackio/logbook.md
+++ b/.agents/skills/trackio/logbook.md
@@ -36,6 +36,7 @@ trackio logbook sync                                    # push later edits to th
 - **The main page** (`pages/index.md`) is the **table of contents only** — an `## Pages` table with a single `Page` column by default, one row per page, each linking to that page. **Never write findings here.**
 - The default table is deliberately unopinionated. Add columns (e.g. `Status`, `Owner`, `Decision`) by editing the markdown directly; the CLI keeps appending rows correctly and fills a `Status` column if one exists.
 - **Each experiment has its own page** where findings accumulate.
+- **Open every page with a short context cell.** Before the first experiment lands on a page, add a markdown cell saying what the page is trying to show or reproduce (e.g. the paper's claim, in a sentence or two) and how you plan to test it. A reader landing on the page should understand the cells that follow without reading the rest of the logbook.
 
 ## Add pages as they become relevant
 

--- a/.changeset/plain-ideas-fix.md
+++ b/.changeset/plain-ideas-fix.md
@@ -1,0 +1,5 @@
+---
+"trackio": minor
+---
+
+feat:Logbook open live preview

--- a/.changeset/plain-ideas-fix.md
+++ b/.changeset/plain-ideas-fix.md
@@ -2,4 +2,4 @@
 "trackio": minor
 ---
 
-feat:Logbook open live preview
+feat:Serve live logbook preview from open

--- a/tests/unit/test_logbook.py
+++ b/tests/unit/test_logbook.py
@@ -28,6 +28,27 @@ def test_create_logbook_scaffolds_index_and_site(proj):
     )
     assert manifest["title"] == "Test Logbook"
     assert manifest["agent_view_tokens"] >= 1
+    assert manifest["revision"]
+    assert manifest["updated_at"]
+
+
+def test_write_site_files_refreshes_generated_viewer_assets(proj):
+    viewer_js = logbook.logbook_root(proj) / "logbook.js"
+    viewer_js.write_text("stale", encoding="utf-8")
+    logbook.write_site_files(proj)
+    assert viewer_js.read_text(encoding="utf-8") != "stale"
+
+
+def test_write_site_files_updates_revision_after_logbook_changes(proj):
+    manifest = json.loads(
+        (logbook.logbook_root(proj) / "logbook.json").read_text(encoding="utf-8")
+    )
+    slug = logbook.ensure_page(proj, "Live")
+    logbook.add_markdown_cell(proj, slug, "new result")
+    updated = json.loads(
+        (logbook.logbook_root(proj) / "logbook.json").read_text(encoding="utf-8")
+    )
+    assert updated["revision"] != manifest["revision"]
 
 
 def test_ensure_page_adds_toc_row(proj):

--- a/trackio/cli.py
+++ b/trackio/cli.py
@@ -1859,9 +1859,7 @@ def _handle_logbook(args):
                 if args.space_id:
                     print(f"Will publish to: {args.space_id}")
             if not args.no_serve:
-                lb.start_preview(
-                    proj, port=args.port, open_browser=not args.no_browser
-                )
+                lb.start_preview(proj, port=args.port, open_browser=not args.no_browser)
         elif action == "run":
             proj = lb.require_project_dir()
             command = list(args.command or [])

--- a/trackio/cli.py
+++ b/trackio/cli.py
@@ -1859,7 +1859,9 @@ def _handle_logbook(args):
                 if args.space_id:
                     print(f"Will publish to: {args.space_id}")
             if not args.no_serve:
-                lb.serve(port=args.port, open_browser=not args.no_browser)
+                lb.start_preview(
+                    proj, port=args.port, open_browser=not args.no_browser
+                )
         elif action == "run":
             proj = lb.require_project_dir()
             command = list(args.command or [])

--- a/trackio/cli.py
+++ b/trackio/cli.py
@@ -1032,6 +1032,13 @@ def main():
         "space_id", nargs="?", help="Optional HF Space id to publish to"
     )
     lb_open.add_argument("--title", help="Logbook title (only when creating)")
+    lb_open.add_argument(
+        "--no-serve",
+        action="store_true",
+        help="Open or attach without launching the local logbook preview",
+    )
+    lb_open.add_argument("--port", type=int, default=7861)
+    lb_open.add_argument("--no-browser", action="store_true")
 
     lb_cell = logbook_sub.add_parser(
         "cell", help="Append a typed notebook-style cell to a logbook page"
@@ -1837,21 +1844,22 @@ def _handle_logbook(args):
                         "exists. To retitle it, edit the '# ...' heading in "
                         f"{lb.logbook_root(proj) / 'pages' / 'index.md'}."
                     )
-                return
-            if args.space_id:
+            elif args.space_id:
                 proj = lb.clone_logbook(args.space_id)
                 if proj is not None:
                     print(
                         f"Cloned logbook from {args.space_id} into "
                         f"{lb.logbook_root(proj)}"
                     )
-                    return
-            proj = lb.create_logbook(
-                args.title or os.path.basename(os.getcwd()), space_id=args.space_id
-            )
-            print(f"Opened logbook at {lb.logbook_root(proj)}")
-            if args.space_id:
-                print(f"Will publish to: {args.space_id}")
+            if proj is None:
+                proj = lb.create_logbook(
+                    args.title or os.path.basename(os.getcwd()), space_id=args.space_id
+                )
+                print(f"Opened logbook at {lb.logbook_root(proj)}")
+                if args.space_id:
+                    print(f"Will publish to: {args.space_id}")
+            if not args.no_serve:
+                lb.serve(port=args.port, open_browser=not args.no_browser)
         elif action == "run":
             proj = lb.require_project_dir()
             command = list(args.command or [])

--- a/trackio/frontend_templates/logbook/logbook.js
+++ b/trackio/frontend_templates/logbook/logbook.js
@@ -4,6 +4,7 @@
   let MANIFEST = null;
   const PAGE_CACHE = {};
   const UNFURL_CACHE = {};
+  const LIVE_RELOAD_MS = 1500;
 
   function esc(s) {
     return String(s)
@@ -1149,13 +1150,29 @@
       .classList.toggle("active", slug === MANIFEST.root.slug);
   }
 
-  async function loadPage(slug) {
+  function clearPageCache() {
+    Object.keys(PAGE_CACHE).forEach((key) => {
+      delete PAGE_CACHE[key];
+    });
+  }
+
+  function isLocalPreview() {
+    return ["localhost", "127.0.0.1", "::1"].includes(location.hostname);
+  }
+
+  async function fetchManifest() {
+    const suffix = isLocalPreview() ? `?t=${Date.now()}` : "";
+    return await (await fetch("./logbook.json" + suffix, { cache: "no-store" })).json();
+  }
+
+  async function loadPage(slug, opts = {}) {
     const node = findNode(MANIFEST.root, slug) || MANIFEST.root;
     const page = document.getElementById("page");
     page.innerHTML = "";
     if (!PAGE_CACHE[node.file]) {
       try {
-        const r = await fetch("./" + node.file);
+        const suffix = isLocalPreview() ? `?rev=${encodeURIComponent(MANIFEST.revision || "")}` : "";
+        const r = await fetch("./" + node.file + suffix, { cache: "no-store" });
         PAGE_CACHE[node.file] = await r.text();
       } catch (e) {
         PAGE_CACHE[node.file] = "# " + node.title + "\n\n_Could not load page._";
@@ -1173,8 +1190,10 @@
     }
     renderRail(PAGE_CACHE[node.file]);
     highlight(node.slug);
-    document.getElementById("content").scrollTo(0, 0);
-    window.scrollTo(0, 0);
+    if (!opts.preserveScroll) {
+      document.getElementById("content").scrollTo(0, 0);
+      window.scrollTo(0, 0);
+    }
   }
 
   function setupResourceHover() {
@@ -1235,9 +1254,25 @@
     return div;
   }
 
-  function route() {
+  function route(opts = {}) {
     const slug = (location.hash || "").replace(/^#\//, "") || MANIFEST.root.slug;
-    loadPage(slug);
+    loadPage(slug, opts);
+  }
+
+  function startLiveReload() {
+    if (!isLocalPreview()) return;
+    setInterval(async () => {
+      try {
+        const next = await fetchManifest();
+        if (!next || next.revision === MANIFEST.revision) return;
+        MANIFEST = next;
+        clearPageCache();
+        document.title = MANIFEST.title + " · Trackio Logbook";
+        document.getElementById("book-title").textContent = MANIFEST.title;
+        buildTree();
+        route({ preserveScroll: true });
+      } catch (e) {}
+    }, LIVE_RELOAD_MS);
   }
 
   function setupConnect() {
@@ -1326,7 +1361,7 @@
   }
 
   async function init() {
-    MANIFEST = await (await fetch("./logbook.json")).json();
+    MANIFEST = await fetchManifest();
     document.title = MANIFEST.title + " · Trackio Logbook";
     document.getElementById("book-title").textContent = MANIFEST.title;
     document.getElementById("book-head").addEventListener("click", () => {
@@ -1337,6 +1372,7 @@
     setupResourceHover();
     window.addEventListener("hashchange", route);
     route();
+    startLiveReload();
   }
 
   init();

--- a/trackio/logbook.py
+++ b/trackio/logbook.py
@@ -1507,6 +1507,67 @@ def _highlight_command(text: str) -> str:
     return f"\033[1m\033[38;5;208m{text}\033[0m"
 
 
+def _find_preview_port(port: int) -> int:
+    import socket  # noqa: PLC0415
+
+    if port == 0:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            sock.bind(("127.0.0.1", 0))
+            return int(sock.getsockname()[1])
+    for candidate in range(port, port + TRY_NUM_PORTS):
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            try:
+                sock.bind(("127.0.0.1", candidate))
+            except OSError:
+                continue
+            return candidate
+    raise LogbookError(
+        f"Cannot find empty port in range: {port}-{port + TRY_NUM_PORTS - 1}. "
+        "Pass --port to choose another starting port."
+    )
+
+
+def start_preview(
+    proj: Path, port: int = 7861, open_browser: bool = True
+) -> str:
+    import webbrowser  # noqa: PLC0415
+
+    write_site_files(proj)
+    actual_port = _find_preview_port(port)
+    root = logbook_root(proj)
+    log_path = root / ".serve.log"
+    cmd = [
+        sys.executable,
+        "-m",
+        "trackio.cli",
+        "logbook",
+        "serve",
+        str(proj.parent),
+        "--port",
+        str(actual_port),
+        "--no-browser",
+    ]
+    log = log_path.open("a", encoding="utf-8")
+    subprocess.Popen(
+        cmd,
+        cwd=str(proj.parent),
+        stdin=subprocess.DEVNULL,
+        stdout=log,
+        stderr=subprocess.STDOUT,
+        start_new_session=True,
+    )
+    url = f"http://localhost:{actual_port}/"
+    print(_highlight_command(f"* Trackio logbook launched at: {url}"))
+    print(f"  Server logs: {log_path}")
+    if open_browser:
+        try:
+            webbrowser.open(url)
+        except Exception:
+            pass
+    return url
+
+
 def serve(
     path: str | Path | None = None, port: int = 7861, open_browser: bool = True
 ) -> None:

--- a/trackio/logbook.py
+++ b/trackio/logbook.py
@@ -383,7 +383,9 @@ def _ensure_viewer_files(proj: Path) -> None:
     for fname in VIEWER_FILES:
         dest = root / fname
         src = VIEWER_DIR / fname
-        if not dest.exists() and src.is_file():
+        if not src.is_file():
+            continue
+        if not dest.exists() or dest.read_bytes() != src.read_bytes():
             shutil.copy2(src, dest)
 
 
@@ -395,6 +397,8 @@ def write_site_files(proj: Path) -> dict:
     _ensure_viewer_files(proj)
     manifest = build_manifest(proj)
     manifest["agent_view_tokens"] = _estimate_tokens(read_logbook(proj, manifest))
+    manifest["revision"] = str(time.time_ns())
+    manifest["updated_at"] = _now_iso()
     root = logbook_root(proj)
     index_html = root / "index.html"
     if index_html.is_file():

--- a/trackio/logbook.py
+++ b/trackio/logbook.py
@@ -1528,9 +1528,7 @@ def _find_preview_port(port: int) -> int:
     )
 
 
-def start_preview(
-    proj: Path, port: int = 7861, open_browser: bool = True
-) -> str:
+def start_preview(proj: Path, port: int = 7861, open_browser: bool = True) -> str:
     import webbrowser  # noqa: PLC0415
 
     write_site_files(proj)


### PR DESCRIPTION
## Summary
- make `trackio logbook open` launch the local logbook preview by default, with `--no-serve` to keep the old non-serving behavior
- start that preview in a detached background process so agents can continue after `logbook open`
- write preview server logs to `.trackio/logbook/.serve.log` instead of streaming request logs into the agent terminal
- add manifest revisions and refresh generated viewer assets when site files are rewritten
- add local-preview polling so the logbook page reloads changed pages as agents add cells/runs/pages

## Validation
- skipped full tests per request; user will test locally
- `python -m py_compile trackio/logbook.py trackio/cli.py`
- smoke checked earlier that `trackio logbook open --port 0 --no-browser` returns after launching a localhost preview
