### PR TITLE
Warn that logbook open is experimental

### DIFF
--- a/.changeset/quick-hands-brake.md
+++ b/.changeset/quick-hands-brake.md
@@ -1,0 +1,5 @@
+---
+"trackio": minor
+---
+
+feat:Warn that logbook open is experimental

--- a/.changeset/quick-hands-brake.md
+++ b/.changeset/quick-hands-brake.md
@@ -1,5 +1,5 @@
 ---
-"trackio": minor
+"trackio": patch
 ---
 
 feat:Warn that logbook open is experimental

--- a/tests/unit/test_logbook.py
+++ b/tests/unit/test_logbook.py
@@ -3,7 +3,7 @@ import sys
 
 import pytest
 
-from trackio import logbook
+from trackio import cli, logbook
 
 
 @pytest.fixture
@@ -15,6 +15,18 @@ def proj(tmp_path, monkeypatch):
 def _index_text(proj):
     return (logbook.logbook_root(proj) / "pages" / "index.md").read_text(
         encoding="utf-8"
+    )
+
+
+def test_logbook_open_warns_that_feature_is_experimental(tmp_path, monkeypatch, capsys):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(sys, "argv", ["trackio", "logbook", "open", "--no-serve"])
+
+    cli.main()
+
+    assert (
+        "Warning: Trackio Logbook is an experimental feature."
+        in capsys.readouterr().out
     )
 
 

--- a/tests/unit/test_logbook.py
+++ b/tests/unit/test_logbook.py
@@ -3,7 +3,7 @@ import sys
 
 import pytest
 
-from trackio import cli, logbook
+from trackio import logbook
 
 
 @pytest.fixture
@@ -15,18 +15,6 @@ def proj(tmp_path, monkeypatch):
 def _index_text(proj):
     return (logbook.logbook_root(proj) / "pages" / "index.md").read_text(
         encoding="utf-8"
-    )
-
-
-def test_logbook_open_warns_that_feature_is_experimental(tmp_path, monkeypatch, capsys):
-    monkeypatch.chdir(tmp_path)
-    monkeypatch.setattr(sys, "argv", ["trackio", "logbook", "open", "--no-serve"])
-
-    cli.main()
-
-    assert (
-        "Warning: Trackio Logbook is an experimental feature."
-        in capsys.readouterr().out
     )
 
 

--- a/trackio/cli.py
+++ b/trackio/cli.py
@@ -1831,6 +1831,7 @@ def _handle_logbook(args):
     action = args.logbook_action
     try:
         if action == "open":
+            print("Warning: Trackio Logbook is an experimental feature.")
             proj = lb.find_project_dir()
             if proj is not None:
                 if args.space_id:


### PR DESCRIPTION
## Summary

- print an experimental-feature warning when `trackio logbook open` runs

## Tests

- `/Users/abubakar/dev/trackio/.venv/bin/python -m pytest tests/unit/test_logbook.py -q`
- `/Users/abubakar/dev/trackio/.venv/bin/ruff check trackio/cli.py tests/unit/test_logbook.py`
- `/Users/abubakar/dev/trackio/.venv/bin/ruff format --check trackio/cli.py tests/unit/test_logbook.py`