### PR TITLE
Logbook: share button on figures + `logbook pin` CLI

### DIFF
--- a/.changeset/mean-results-wave.md
+++ b/.changeset/mean-results-wave.md
@@ -1,5 +1,5 @@
 ---
-"trackio": minor
+"trackio": patch
 ---
 
 feat:Logbook: share button on figures + `logbook pin` CLI

--- a/.changeset/mean-results-wave.md
+++ b/.changeset/mean-results-wave.md
@@ -1,0 +1,5 @@
+---
+"trackio": minor
+---
+
+feat:Logbook: share button on figures + `logbook pin` CLI

--- a/trackio/cli.py
+++ b/trackio/cli.py
@@ -1189,6 +1189,22 @@ def main():
         help="Make the logbook and any promoted dashboards/buckets private",
     )
 
+    lb_pin = logbook_sub.add_parser(
+        "pin",
+        help="Pin (or unpin) a cell so it surfaces on the logbook intro",
+    )
+    lb_pin.add_argument(
+        "cell_id",
+        nargs="?",
+        help="Cell id to pin (default: the most recent cell on the target page)",
+    )
+    lb_pin.add_argument(
+        "--page", help="Page title or slug to scope the search / pick the last cell from"
+    )
+    lb_pin.add_argument(
+        "--unpin", action="store_true", help="Unpin the cell instead of pinning it"
+    )
+
     logbook_sub.add_parser(
         "sync", help="Push local edits to the Space now (after the first publish)"
     )
@@ -1953,6 +1969,23 @@ def _handle_logbook(args):
             proj = lb.require_project_dir()
             page_slug = lb.ensure_page(proj, args.title)
             print(f"Selected page '{page_slug}' as default.{_sync_suffix(lb, proj)}")
+            lb.trigger_autosync(proj)
+        elif action == "pin":
+            proj = lb.require_project_dir()
+            cell_id = args.cell_id or lb.last_cell_id(proj, page=args.page)
+            if not cell_id:
+                error_exit(
+                    "No cell to pin. Pass a cell id, or add a cell first "
+                    "(optionally scope with --page)."
+                )
+            res = lb.set_cell_pinned(
+                proj, cell_id, pinned=not args.unpin, page=args.page
+            )
+            verb = "Unpinned" if args.unpin else "Pinned"
+            print(
+                f"{verb} cell {cell_id} on page "
+                f"'{res['page']}'.{_sync_suffix(lb, proj)}"
+            )
             lb.trigger_autosync(proj)
         elif action == "read":
             proj = lb.resolve_read_source(args.path)

--- a/trackio/cli.py
+++ b/trackio/cli.py
@@ -1199,7 +1199,8 @@ def main():
         help="Cell id to pin (default: the most recent cell on the target page)",
     )
     lb_pin.add_argument(
-        "--page", help="Page title or slug to scope the search / pick the last cell from"
+        "--page",
+        help="Page title or slug to scope the search / pick the last cell from",
     )
     lb_pin.add_argument(
         "--unpin", action="store_true", help="Unpin the cell instead of pinning it"

--- a/trackio/frontend_templates/logbook/logbook.css
+++ b/trackio/frontend_templates/logbook/logbook.css
@@ -527,6 +527,71 @@ body {
   border-radius: 8px;
   padding: 12px 14px;
 }
+/* ---- figure share ---- */
+.cell-share {
+  position: relative;
+  display: inline-flex;
+  flex: 0 0 auto;
+}
+.cell-share-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  padding: 0;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: var(--code-bg);
+  color: var(--muted);
+  cursor: pointer;
+  transition: color 0.15s, border-color 0.15s, background 0.15s;
+}
+.cell-share-btn:hover {
+  color: var(--accent-strong);
+  border-color: rgba(249, 115, 22, 0.35);
+  background: var(--accent-soft);
+}
+.cell-share-btn svg {
+  width: 14px;
+  height: 14px;
+}
+.cell-share-menu {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  z-index: 30;
+  display: flex;
+  flex-direction: column;
+  min-width: 152px;
+  padding: 4px;
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  box-shadow: 0 8px 24px rgba(31, 41, 55, 0.14);
+}
+.cell-share-menu[hidden] {
+  display: none;
+}
+.cell-share-item {
+  display: block;
+  width: 100%;
+  text-align: left;
+  font-family: var(--sans);
+  font-size: 13px;
+  color: var(--ink);
+  background: none;
+  border: none;
+  border-radius: 6px;
+  padding: 7px 10px;
+  cursor: pointer;
+  text-decoration: none;
+  transition: background 0.12s, color 0.12s;
+}
+.cell-share-item:hover {
+  background: var(--accent-soft);
+  color: var(--accent-strong);
+}
 /* ---- copyable snippets ---- */
 .snippet {
   position: relative;

--- a/trackio/frontend_templates/logbook/logbook.js
+++ b/trackio/frontend_templates/logbook/logbook.js
@@ -276,8 +276,14 @@
       renderCodeCell(body, bodyEl, artifacts);
     } else if (meta.type === "figure") {
       cell.dataset.resUrl = `trackio-figure://${(meta.title || "Figure").trim()}`;
+      // Only offer sharing when the figure is backed by a real image URL — the
+      // shared post links straight to that image. A data-URI / relative / HTML
+      // figure has no shareable link, so no icon (a link to the whole logbook
+      // adds little value).
+      const imgUrl = figureImageLink(body);
       const metaEl = head.querySelector(".cell-meta");
-      if (metaEl) metaEl.insertBefore(buildShareControl(meta), metaEl.firstChild);
+      if (imgUrl && metaEl)
+        metaEl.insertBefore(buildShareControl(meta, imgUrl), metaEl.firstChild);
       renderFigureCell(body, bodyEl, head);
     } else if (meta.type === "artifact") {
       renderMarkdownPlain(body, bodyEl);
@@ -463,12 +469,24 @@
     '<circle cx="18" cy="19" r="3"/><line x1="8.6" y1="13.5" x2="15.4" y2="17.5"/>' +
     '<line x1="15.4" y1="6.5" x2="8.6" y2="10.5"/></svg>';
 
-  // Share control for a figure cell: an icon button that opens a small menu
-  // (X / LinkedIn / Copy link). Sits at the front of `.cell-meta`, so it lands
-  // between the Figure/Raw toggle and the date when raw data exists, and right
-  // before the date otherwise. Shares the current page URL (deep-links to the
-  // page a figure lives on); the figure title becomes the share text.
-  function buildShareControl(meta) {
+  // The first real image URL (http/https) inside a figure cell's HTML, or null.
+  // A data-URI, relative path, or non-image HTML figure has no shareable link.
+  function figureImageLink(body) {
+    const parts = parseFences(body);
+    const htmlPart = parts.find((part) => part.lang === "html");
+    if (!htmlPart) return null;
+    const m = htmlPart.text.match(
+      /<img\b[^>]*\bsrc\s*=\s*["']?(https?:\/\/[^"'\s>]+)/i
+    );
+    return m ? m[1] : null;
+  }
+
+  // Share control for an image-backed figure cell: an icon button that opens a
+  // small menu (X / LinkedIn / Copy image link). Sits at the front of
+  // `.cell-meta`, so it lands between the Figure/Raw toggle and the date when
+  // raw data exists, and right before the date otherwise. The shared post links
+  // straight to `imageUrl`; the figure title becomes the share text.
+  function buildShareControl(meta, imageUrl) {
     const wrap = document.createElement("span");
     wrap.className = "cell-share";
     const btn = document.createElement("button");
@@ -493,11 +511,11 @@
     const copyBtn = document.createElement("button");
     copyBtn.type = "button";
     copyBtn.className = "cell-share-item";
-    copyBtn.textContent = "Copy link";
+    copyBtn.textContent = "Copy image link";
     menu.append(xLink, liLink, copyBtn);
     wrap.append(btn, menu);
 
-    const shareUrl = () => window.location.href;
+    const shareUrl = () => imageUrl;
     const shareText = (meta.title || "Figure").trim();
     const close = () => {
       menu.hidden = true;
@@ -525,7 +543,7 @@
         copyBtn.textContent = "Copy failed";
       }
       setTimeout(() => {
-        copyBtn.textContent = "Copy link";
+        copyBtn.textContent = "Copy image link";
         close();
       }, 1200);
     });

--- a/trackio/frontend_templates/logbook/logbook.js
+++ b/trackio/frontend_templates/logbook/logbook.js
@@ -276,6 +276,8 @@
       renderCodeCell(body, bodyEl, artifacts);
     } else if (meta.type === "figure") {
       cell.dataset.resUrl = `trackio-figure://${(meta.title || "Figure").trim()}`;
+      const metaEl = head.querySelector(".cell-meta");
+      if (metaEl) metaEl.insertBefore(buildShareControl(meta), metaEl.firstChild);
       renderFigureCell(body, bodyEl, head);
     } else if (meta.type === "artifact") {
       renderMarkdownPlain(body, bodyEl);
@@ -452,6 +454,87 @@
     }
     container.appendChild(figWrap);
     container.appendChild(rawView);
+  }
+
+  const SHARE_ICON =
+    '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" ' +
+    'stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">' +
+    '<circle cx="18" cy="5" r="3"/><circle cx="6" cy="12" r="3"/>' +
+    '<circle cx="18" cy="19" r="3"/><line x1="8.6" y1="13.5" x2="15.4" y2="17.5"/>' +
+    '<line x1="15.4" y1="6.5" x2="8.6" y2="10.5"/></svg>';
+
+  // Share control for a figure cell: an icon button that opens a small menu
+  // (X / LinkedIn / Copy link). Sits at the front of `.cell-meta`, so it lands
+  // between the Figure/Raw toggle and the date when raw data exists, and right
+  // before the date otherwise. Shares the current page URL (deep-links to the
+  // page a figure lives on); the figure title becomes the share text.
+  function buildShareControl(meta) {
+    const wrap = document.createElement("span");
+    wrap.className = "cell-share";
+    const btn = document.createElement("button");
+    btn.type = "button";
+    btn.className = "cell-share-btn";
+    btn.setAttribute("aria-label", "Share figure");
+    btn.title = "Share";
+    btn.innerHTML = SHARE_ICON;
+    const menu = document.createElement("div");
+    menu.className = "cell-share-menu";
+    menu.hidden = true;
+    const xLink = document.createElement("a");
+    xLink.className = "cell-share-item";
+    xLink.target = "_blank";
+    xLink.rel = "noopener";
+    xLink.textContent = "Share on X";
+    const liLink = document.createElement("a");
+    liLink.className = "cell-share-item";
+    liLink.target = "_blank";
+    liLink.rel = "noopener";
+    liLink.textContent = "Share on LinkedIn";
+    const copyBtn = document.createElement("button");
+    copyBtn.type = "button";
+    copyBtn.className = "cell-share-item";
+    copyBtn.textContent = "Copy link";
+    menu.append(xLink, liLink, copyBtn);
+    wrap.append(btn, menu);
+
+    const shareUrl = () => window.location.href;
+    const shareText = (meta.title || "Figure").trim();
+    const close = () => {
+      menu.hidden = true;
+    };
+
+    btn.addEventListener("click", (e) => {
+      e.stopPropagation();
+      const url = shareUrl();
+      xLink.href =
+        "https://twitter.com/intent/tweet?text=" +
+        encodeURIComponent(shareText) +
+        "&url=" +
+        encodeURIComponent(url);
+      liLink.href =
+        "https://www.linkedin.com/sharing/share-offsite/?url=" +
+        encodeURIComponent(url);
+      menu.hidden = !menu.hidden;
+    });
+    copyBtn.addEventListener("click", async (e) => {
+      e.stopPropagation();
+      try {
+        await navigator.clipboard.writeText(shareUrl());
+        copyBtn.textContent = "Copied!";
+      } catch (_) {
+        copyBtn.textContent = "Copy failed";
+      }
+      setTimeout(() => {
+        copyBtn.textContent = "Copy link";
+        close();
+      }, 1200);
+    });
+    xLink.addEventListener("click", close);
+    liLink.addEventListener("click", close);
+    document.addEventListener("click", (e) => {
+      if (!wrap.contains(e.target)) close();
+    });
+    return wrap;
   }
 
   function extractUrls(text) {

--- a/trackio/logbook.py
+++ b/trackio/logbook.py
@@ -1061,6 +1061,77 @@ def read_cell(
     raise LogbookError(f"No cell with id '{cell_id}' in this logbook.")
 
 
+def _resolve_slug(proj: Path, page: str) -> str:
+    """Resolve a page slug or title to its slug."""
+    want = _slugify(page)
+    for node in _walk(build_manifest(proj)["root"]):
+        if page in (node["slug"], node["title"]) or node["slug"] == want:
+            return node["slug"]
+    raise LogbookError(f"No page matching '{page}' in this logbook.")
+
+
+def last_cell_id(proj: Path, page: str | None = None) -> str | None:
+    """Id of the most recent cell on `page` (or the current default page)."""
+    slug = _resolve_slug(proj, page) if page else read_metadata(proj).get("last_page")
+    if not slug:
+        return None
+    path = _page_file_for_slug(proj, slug)
+    if path is None or not path.exists():
+        return None
+    cells = _parse_cells_from_text(path.read_text(encoding="utf-8"), slug, "")
+    return cells[-1]["id"] if cells else None
+
+
+def set_cell_pinned(
+    proj: Path, cell_id: str, *, pinned: bool = True, page: str | None = None
+) -> dict:
+    """Pin or unpin a cell by id.
+
+    Pinned cells surface in a deck on the logbook intro (the frontend reads the
+    `pinned` flag from each cell's metadata). Rewrites the owning page in place.
+    """
+    root = logbook_root(proj)
+    scope = _resolve_slug(proj, page) if page else None
+    for node in _walk(build_manifest(proj)["root"]):
+        if scope and node["slug"] != scope:
+            continue
+        path = root / node["file"]
+        text = path.read_text(encoding="utf-8")
+        state = {"hit": False, "title": None}
+
+        def _repl(m):
+            try:
+                meta = json.loads(m.group(2))
+            except json.JSONDecodeError:
+                return m.group(0)
+            if meta.get("id") != cell_id:
+                return m.group(0)
+            state["hit"] = True
+            state["title"] = meta.get("title")
+            if pinned:
+                meta["pinned"] = True
+                meta.setdefault("pinned_at", _now_iso())
+            else:
+                meta.pop("pinned", None)
+                meta.pop("pinned_at", None)
+            marker = (
+                "<!-- trackio-cell\n" + json.dumps(meta, ensure_ascii=False) + "\n-->"
+            )
+            return f"{m.group(1)}---\n{marker}\n{m.group(3)}"
+
+        new_text = CELL_RE.sub(_repl, text)
+        if state["hit"]:
+            path.write_text(new_text, encoding="utf-8")
+            write_site_files(proj)
+            return {
+                "page": node["slug"],
+                "page_title": node["title"],
+                "title": state["title"],
+                "pinned": pinned,
+            }
+    raise LogbookError(f"No cell with id '{cell_id}' in this logbook.")
+
+
 # ---- auto-note (called from trackio.finish / log_artifact) ----
 
 


### PR DESCRIPTION
## What

Two logbook improvements.

### 1. Share button on image-backed figure cells
Figures that are backed by a **real image URL** (an `<img>` with an `http(s)` src — e.g. a bucket-hosted plot) get a **share icon** in their header, placed at the front of `.cell-meta`: it lands **between the Figure/Raw toggle and the date** when raw data exists, and **right before the date** otherwise.

Clicking opens a small popover — **Share on X**, **Share on LinkedIn**, **Copy image link** — and the shared post links **straight to the image URL** (title becomes the share text). Styled to match the existing Figure/Raw pill (rounded, `--code-bg`, `--accent-soft` hover, subtle card + shadow).

The icon is shown **only** when such an image link exists. A data-URI, relative-path, or non-image HTML figure (Plotly, tables, …) has no shareable link, so no icon appears — a bare link to the whole logbook adds little value. (Note: X/LinkedIn share endpoints only accept a URL, so sharing the image = linking to it; there's no media upload via web intents.)

### 2. `trackio logbook pin` CLI
Pinning a cell previously required hand-editing the cell metadata. New command:

```
trackio logbook pin [cell_id] [--page PAGE] [--unpin]
```

Sets/clears the `pinned` flag the frontend uses to surface cells in the intro deck. `cell_id` defaults to the most recent cell on the target (or current default) page. Backed by new `set_cell_pinned()` + `last_cell_id()` in `logbook.py`.

## Testing
- Logbook test suite passes (`pytest -k logbook` → 38 passed); full suite green except pre-existing GPU-hardware tests (no GPU on this machine).
- `pin`/`--unpin`, explicit id, and `--page` resolution verified end-to-end; unknown id raises a clean `LogbookError`.
- Image-link detection unit-tested (http img ✓, data-URI ✗, relative ✗, HTML chart ✗, quoted+query ✓, bucket URL ✓).
- Rendered in an isolated logbook: data-URI/HTML figures show **no** icon; a hosted-image figure shows the icon with the X link pointing at the image URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)