### PR TITLE
Fix poster hotspot navigation after iframe load

### DIFF
--- a/.changeset/grumpy-pandas-care.md
+++ b/.changeset/grumpy-pandas-care.md
@@ -1,0 +1,5 @@
+---
+"trackio": patch
+---
+
+feat:Fix poster hotspot navigation after iframe load

--- a/trackio/frontend_templates/logbook/logbook.js
+++ b/trackio/frontend_templates/logbook/logbook.js
@@ -466,7 +466,13 @@
   // from their iframe. Only accept messages from figure frames we created, and
   // only route to pages that are present in this logbook's manifest.
   function registerFigureNavigation(frame) {
-    FIGURE_FRAME_WINDOWS.add(frame.contentWindow);
+    const registerFrameWindow = () => {
+      if (frame.contentWindow) FIGURE_FRAME_WINDOWS.add(frame.contentWindow);
+    };
+    // `srcdoc` replaces the initial about:blank document. Register after that
+    // navigation as well, so messages come from the live figure document.
+    frame.addEventListener("load", registerFrameWindow);
+    registerFrameWindow();
     if (FIGURE_NAVIGATION_READY) return;
     FIGURE_NAVIGATION_READY = true;
     window.addEventListener("message", (event) => {


### PR DESCRIPTION
## Short description

Registers the live `srcdoc` iframe window after it loads, so interactive poster hotspots can navigate their parent Trackio logbook.

## AI Disclosure

- [x] I used AI to implement and review this fix.

## Type of Change

- [x] Bug fix

## Related Issues

Closes: 

## Testing and linting

- Manual local logbook demo
- `node --check trackio/frontend_templates/logbook/logbook.js`