### PR TITLE
Fix logbook Markdown escaping and figure hotspot navigation

### DIFF
--- a/.changeset/brown-cups-return.md
+++ b/.changeset/brown-cups-return.md
@@ -1,0 +1,5 @@
+---
+"trackio": minor
+---
+
+feat:Fix logbook Markdown escaping and figure hotspot navigation

--- a/.changeset/brown-cups-return.md
+++ b/.changeset/brown-cups-return.md
@@ -1,5 +1,5 @@
 ---
-"trackio": minor
+"trackio": patch
 ---
 
 feat:Fix logbook Markdown escaping and figure hotspot navigation

--- a/tests/ui/test_logbook_viewer.py
+++ b/tests/ui/test_logbook_viewer.py
@@ -108,3 +108,41 @@ def test_dashboard_cell_uses_the_main_cell_header(tmp_path, monkeypatch):
         finally:
             server.shutdown()
             thread.join()
+
+
+def test_figure_hotspot_navigates_to_its_logbook_page(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    proj = logbook.create_logbook("Interactive figure logbook")
+    target = logbook.ensure_page(proj, "Claim evidence")
+    conclusion = logbook.ensure_page(proj, "Conclusion")
+    logbook.add_markdown_cell(proj, target, "Evidence lives here.")
+    logbook.add_figure_cell(
+        proj,
+        conclusion,
+        html=(
+            "<button onclick=\"parent.postMessage({type:'trackio-logbook:navigate',"
+            f"target:'{target}'}} , '*')\">Open details</button>"
+        ),
+    )
+    logbook.write_site_files(proj)
+
+    handler = functools.partial(
+        _QuietHandler, directory=str(logbook.logbook_root(proj))
+    )
+    socketserver.ThreadingTCPServer.allow_reuse_address = True
+    with socketserver.ThreadingTCPServer(("127.0.0.1", 0), handler) as server:
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        try:
+            with sync_playwright() as playwright:
+                browser = playwright.chromium.launch()
+                page = browser.new_page(viewport={"width": 1440, "height": 900})
+                page.goto(f"http://127.0.0.1:{server.server_address[1]}/#/conclusion")
+                page.frame_locator("iframe.figure-frame").get_by_role(
+                    "button", name="Open details"
+                ).click()
+                expect(page).to_have_url(re.compile(r"#/claim-evidence$"))
+                browser.close()
+        finally:
+            server.shutdown()
+            thread.join()

--- a/trackio/cli.py
+++ b/trackio/cli.py
@@ -1055,7 +1055,10 @@ def main():
     lb_cell_sub = lb_cell.add_subparsers(dest="cell_type", required=True)
 
     lb_cell_md = lb_cell_sub.add_parser("markdown", help="Append a markdown cell")
-    lb_cell_md.add_argument("body", help="Markdown body")
+    lb_cell_md.add_argument(
+        "body",
+        help="Markdown body (literal \\n escape sequences are converted to line breaks)",
+    )
     lb_cell_md.add_argument("--title", help="Cell title")
     lb_cell_md.add_argument("--page", help="Page title or slug")
     lb_cell_art = lb_cell_sub.add_parser(
@@ -1924,7 +1927,11 @@ def _handle_logbook(args):
             proj = lb.require_project_dir()
             slug = _logbook_cell_target(lb, proj, args)
             if args.cell_type == "markdown":
-                lb.add_markdown_cell(proj, slug, args.body, title=args.title)
+                # Agent/tool callers often send a single argument containing
+                # escaped newlines. Treat those as Markdown line breaks while
+                # preserving normal shell-provided newlines unchanged.
+                body = args.body.replace("\\r\\n", "\n").replace("\\n", "\n")
+                lb.add_markdown_cell(proj, slug, body, title=args.title)
             elif args.cell_type == "artifact":
                 lb.add_artifact_cell(
                     proj,

--- a/trackio/frontend_templates/logbook/logbook.js
+++ b/trackio/frontend_templates/logbook/logbook.js
@@ -2089,6 +2089,31 @@
     highlight(slug);
   }
 
+  function navigateToLogbookSlug(target) {
+    const slug = String(target || "").replace(/^#?\//, "").trim();
+    if (!slug || !findNode(MANIFEST.root, slug)) return;
+    const hash = "#/" + slug;
+    if (location.hash === hash) {
+      scrollToHash({ behavior: "smooth" });
+    } else {
+      location.hash = hash;
+    }
+  }
+
+  function setupFigureNavigation() {
+    window.addEventListener("message", (event) => {
+      const data = event.data;
+      if (!data || data.type !== "trackio-logbook:navigate") return;
+      // Only accept messages from one of this logbook's sandboxed figure
+      // iframes, rather than from an arbitrary same-origin page.
+      const isFigureFrame = Array.from(
+        document.querySelectorAll("iframe.figure-frame")
+      ).some((frame) => frame.contentWindow === event.source);
+      if (!isFigureFrame) return;
+      navigateToLogbookSlug(data.target);
+    });
+  }
+
   let SCROLL_FRAME = 0;
   function updateActiveSection() {
     cancelAnimationFrame(SCROLL_FRAME);
@@ -2225,6 +2250,7 @@
     buildTree();
     setupConnect();
     setupResourceHover();
+    setupFigureNavigation();
     window.addEventListener("hashchange", () => scrollToHash());
     window.addEventListener("scroll", updateActiveSection, { passive: true });
     await renderLogbook();

--- a/trackio/frontend_templates/logbook/logbook.js
+++ b/trackio/frontend_templates/logbook/logbook.js
@@ -365,20 +365,34 @@
     frame.style.transform = "none";
     frame.style.width = "100%";
     frame.style.height = "auto";
+    frame.style.position = "";
+    frame.style.left = "";
+    frame.style.top = "";
     const avail = wrap.clientWidth;
+    const isFullscreen =
+      document.fullscreenElement === wrap ||
+      document.webkitFullscreenElement === wrap;
+    const availHeight = isFullscreen ? wrap.clientHeight : Infinity;
     const cw = Math.max(doc.body.scrollWidth, doc.documentElement.scrollWidth, 1);
     const ch = Math.max(doc.body.scrollHeight, doc.documentElement.scrollHeight, 1);
-    if (avail && cw > avail + 1) {
-      const scale = avail / cw;
+    const scale = Math.min(avail / cw, availHeight / ch);
+    if (avail && scale < 1 - 1e-3) {
       frame.style.width = `${cw}px`;
       frame.style.height = `${ch}px`;
       frame.style.transformOrigin = "top left";
       frame.style.transform = `scale(${scale})`;
-      wrap.style.height = `${Math.ceil(ch * scale)}px`;
+      if (isFullscreen) {
+        frame.style.position = "absolute";
+        frame.style.left = `${Math.max(0, (avail - cw * scale) / 2)}px`;
+        frame.style.top = `${Math.max(0, (availHeight - ch * scale) / 2)}px`;
+        wrap.style.height = "100%";
+      } else {
+        wrap.style.height = `${Math.ceil(ch * scale)}px`;
+      }
     } else {
       frame.style.width = "100%";
       frame.style.height = `${ch}px`;
-      wrap.style.height = `${ch}px`;
+      wrap.style.height = isFullscreen ? "100%" : `${ch}px`;
     }
   }
 


### PR DESCRIPTION
## Summary
- expand literal `\n` sequences passed to the Markdown CLI into line breaks
- handle validated `trackio-logbook:navigate` messages from figure iframes
- add browser coverage for a poster hotspot routing to a logbook page

## Validation
- `pytest -q tests/ui/test_logbook_viewer.py tests/unit/test_logbook.py`