### PR TITLE
Embed image files directly in logbook figure cells

### DIFF
--- a/.changeset/logbook-figure-image-path.md
+++ b/.changeset/logbook-figure-image-path.md
@@ -1,0 +1,13 @@
+---
+"trackio": patch
+---
+
+feat: let `logbook cell figure` embed image files directly
+
+`trackio logbook cell figure` now accepts an image path via a new `--image`
+flag, and `--html <file>` transparently embeds the file when it points at an
+image. Previously the only way to add a PNG/JPG figure was to hand-encode it
+into an `<img>` data-URI, and passing an image path to `--html` crashed with a
+`UnicodeDecodeError` (the binary file was read as UTF-8 text). Images are
+embedded as responsive base64 data URIs. The Python API `add_figure_cell` gains
+a matching `image=` parameter.

--- a/tests/unit/test_logbook.py
+++ b/tests/unit/test_logbook.py
@@ -1,3 +1,4 @@
+import base64
 import json
 import re
 import sys
@@ -124,6 +125,55 @@ def test_cells_roundtrip_through_read(proj):
     fig = logbook.read_cell(proj, figure_cell["id"], include_raw=True)
     assert fig["raw"] == '{"x": 1}'
     assert fig["has_html"]
+
+
+# A minimal valid 1x1 PNG.
+_PNG_BYTES = base64.b64decode(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk"
+    "+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+)
+
+
+def test_figure_html_from_image_embeds_data_uri(tmp_path):
+    png = tmp_path / "plot.png"
+    png.write_bytes(_PNG_BYTES)
+    html = logbook.figure_html_from_image(png)
+    assert html.startswith('<img src="data:image/png;base64,')
+    assert "max-width:100%" in html
+    assert 'alt="plot"' in html
+
+
+def test_figure_html_from_image_rejects_unsupported_type(tmp_path):
+    bad = tmp_path / "notes.txt"
+    bad.write_text("hello")
+    with pytest.raises(logbook.LogbookError, match="Unsupported image type"):
+        logbook.figure_html_from_image(bad)
+
+
+def test_figure_html_from_image_missing_file(tmp_path):
+    with pytest.raises(logbook.LogbookError, match="not found"):
+        logbook.figure_html_from_image(tmp_path / "absent.png")
+
+
+def test_add_figure_cell_accepts_image_path(proj, tmp_path):
+    slug = logbook.ensure_page(proj, "Figs")
+    png = tmp_path / "chart.png"
+    png.write_bytes(_PNG_BYTES)
+    logbook.add_figure_cell(proj, slug, image=png, title="Chart")
+
+    outline = logbook.read_page_outline(proj, "Figs")
+    figure_cell = outline["cells"][0]
+    assert figure_cell["type"] == "figure"
+    fig = logbook.read_cell(proj, figure_cell["id"], include_html=True)
+    assert fig["has_html"]
+    assert "data:image/png;base64," in fig["html"]
+
+
+def test_is_figure_image_path():
+    assert logbook.is_figure_image_path("a/b/plot.PNG")
+    assert logbook.is_figure_image_path("chart.svg")
+    assert not logbook.is_figure_image_path("page.html")
+    assert not logbook.is_figure_image_path("notes.txt")
 
 
 def test_read_head_tail_options(proj):

--- a/trackio/cli.py
+++ b/trackio/cli.py
@@ -1086,8 +1086,13 @@ def main():
     lb_cell_figure = lb_cell_sub.add_parser("figure", help="Append a figure cell")
     lb_cell_figure.add_argument("--title", help="Cell title")
     lb_cell_figure.add_argument("--page", help="Page title or slug")
-    lb_cell_figure.add_argument("--html", help="Path to HTML, or inline HTML text")
+    lb_cell_figure.add_argument(
+        "--html", help="Path to an HTML or image file, or inline HTML text"
+    )
     lb_cell_figure.add_argument("--html-text", help="Inline HTML text")
+    lb_cell_figure.add_argument(
+        "--image", help="Path to an image file (PNG, JPG, GIF, WEBP, SVG, ...)"
+    )
     lb_cell_figure.add_argument("--raw", help="Path/URL/text for raw data")
     lb_cell_figure.add_argument("--raw-text", help="Inline raw data")
 
@@ -1951,7 +1956,19 @@ def _handle_logbook(args):
                     language=args.language,
                 )
             elif args.cell_type == "figure":
-                html = _read_logbook_payload(args.html, args.html_text)
+                if args.image:
+                    html = lb.figure_html_from_image(args.image)
+                elif (
+                    args.html
+                    and args.html_text is None
+                    and Path(args.html).is_file()
+                    and lb.is_figure_image_path(args.html)
+                ):
+                    # `--html plot.png` — embed the image instead of trying to
+                    # read a binary file as UTF-8 text.
+                    html = lb.figure_html_from_image(args.html)
+                else:
+                    html = _read_logbook_payload(args.html, args.html_text)
                 raw = _read_logbook_payload(args.raw, args.raw_text)
                 lb.add_figure_cell(
                     proj,

--- a/trackio/logbook.py
+++ b/trackio/logbook.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import base64
 import html
 import json
 import os
@@ -1411,15 +1412,59 @@ def add_path_artifact_cell(
     )
 
 
+FIGURE_IMAGE_MIME_BY_SUFFIX = {
+    ".png": "image/png",
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".gif": "image/gif",
+    ".webp": "image/webp",
+    ".bmp": "image/bmp",
+    ".avif": "image/avif",
+    ".svg": "image/svg+xml",
+}
+
+
+def is_figure_image_path(path: str | Path) -> bool:
+    """Whether ``path`` points at an image file trackio can embed in a figure."""
+    return Path(path).suffix.lower() in FIGURE_IMAGE_MIME_BY_SUFFIX
+
+
+def figure_html_from_image(path: str | Path) -> str:
+    """Build an ``<img>`` tag with a base64 data URI from a local image file.
+
+    Lets figure cells accept an image path (e.g. a matplotlib PNG) directly,
+    instead of requiring the caller to hand-encode the image into HTML.
+    """
+    path = Path(path)
+    mime = FIGURE_IMAGE_MIME_BY_SUFFIX.get(path.suffix.lower())
+    if mime is None:
+        supported = ", ".join(sorted(FIGURE_IMAGE_MIME_BY_SUFFIX))
+        raise LogbookError(
+            f"Unsupported image type '{path.suffix or path.name}'. "
+            f"Supported image extensions: {supported}."
+        )
+    if not path.is_file():
+        raise LogbookError(f"Image file not found: {path}")
+    encoded = base64.b64encode(path.read_bytes()).decode("ascii")
+    alt = html.escape(path.stem)
+    return (
+        f'<img src="data:{mime};base64,{encoded}" alt="{alt}" '
+        'style="max-width:100%;height:auto;" />'
+    )
+
+
 def add_figure_cell(
     proj: Path,
     page_slug: str,
     html: str | None = None,
     raw: str | None = None,
     title: str | None = None,
+    image: str | Path | None = None,
 ) -> None:
+    if image:
+        html = figure_html_from_image(image)
     if not html:
-        raise LogbookError("Figure cells require HTML content.")
+        raise LogbookError("Figure cells require HTML content or an image.")
     if len(html) > 1_000_000:
         print(
             f"Note: figure HTML is {len(html) / 1_000_000:.1f} MB and is stored "


### PR DESCRIPTION
## Problem

`trackio logbook cell figure` had no way to add an image file directly. The `--html` argument reads the given path as UTF-8 text, so pointing it at a PNG/JPG crashed:

```
$ trackio logbook cell figure --html plot.png
UnicodeDecodeError: 'utf-8' codec can't decode byte 0x89 in position 0: invalid start byte
```

(`0x89` is the PNG magic byte.) The only workaround was to hand-encode the image into an `<img>` data-URI and pass that as inline HTML — awkward, and a sharp edge that anyone logging a matplotlib figure hits immediately.

## Fix

- New `--image PATH` flag on `logbook cell figure` that embeds a local image as a responsive base64 `<img>` data URI (`max-width:100%;height:auto`).
- `--html <file>` now transparently embeds the file when it points at an image (by extension), instead of crashing — so the intuitive `--html plot.png` just works.
- Python API: `logbook.add_figure_cell(..., image=...)` gains a matching parameter, plus reusable helpers `figure_html_from_image()` and `is_figure_image_path()`.
- Supported: `.png .jpg .jpeg .gif .webp .bmp .avif .svg`. Unsupported extensions / missing files raise a clear `LogbookError`.

## Testing

- Added unit tests in `tests/unit/test_logbook.py` covering the image→HTML helper (data URI + responsive style + alt text), the `image=` path on `add_figure_cell`, unsupported-type and missing-file errors, and `is_figure_image_path`.
- Verified end-to-end via the CLI that both `--image plot.png` and `--html plot.png` now produce a figure cell with an embedded `data:image/png;base64,...` payload.
- `ruff check` / `ruff format --check` clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)