### PR TITLE
Fix dashboard auto-note page selection

### DIFF
--- a/.changeset/bright-books-rest.md
+++ b/.changeset/bright-books-rest.md
@@ -1,0 +1,5 @@
+---
+"trackio": patch
+---
+
+Fix automatic dashboard cells to use the active logbook page instead of creating a page named after the Trackio project.

--- a/tests/unit/test_logbook.py
+++ b/tests/unit/test_logbook.py
@@ -403,12 +403,22 @@ def test_add_dashboard_cell_space(proj):
 
 
 def test_auto_note_dashboard_dedupes(proj):
+    page = logbook.ensure_page(proj, "Training results")
     logbook.auto_note_dashboard("mnist")
     logbook.auto_note_dashboard("mnist")
     logbook.auto_note_dashboard("mnist", space_id="me/mnist")
-    assert len(_dashboard_cells(proj, "mnist")) == 1
+    assert len(_dashboard_cells(proj, page)) == 1
     logbook.auto_note_dashboard("cifar")
-    assert len(_dashboard_cells(proj, "cifar")) == 1
+    assert len(_dashboard_cells(proj, page)) == 2
+    assert logbook._page_file_for_slug(proj, "mnist") is None
+    assert logbook._page_file_for_slug(proj, "cifar") is None
+
+
+def test_auto_note_dashboard_without_active_page_is_a_noop(proj):
+    logbook.auto_note_dashboard("mnist")
+
+    assert logbook._page_file_for_slug(proj, "mnist") is None
+    assert "local_dashboards" not in logbook.read_metadata(proj)
 
 
 def test_auto_note_dashboard_disabled_or_no_logbook(proj, monkeypatch, tmp_path):
@@ -425,14 +435,16 @@ def test_auto_note_dashboard_disabled_or_no_logbook(proj, monkeypatch, tmp_path)
 def test_init_creates_dashboard_cell_immediately(temp_dir, proj):
     import trackio
 
+    page = logbook.ensure_page(proj, "Training results")
     trackio.init(project="p1", name="r1")
-    assert len(_dashboard_cells(proj, "p1")) == 1
+    assert len(_dashboard_cells(proj, page)) == 1
     trackio.finish()
     trackio.init(project="p1", name="r2")
     trackio.finish()
-    outline = logbook.read_page_outline(proj, "p1")
+    outline = logbook.read_page_outline(proj, page)
     assert len([c for c in outline["cells"] if c["type"] == "dashboard"]) == 1
     assert not [c for c in outline["cells"] if (c["title"] or "").startswith("Run:")]
+    assert logbook._page_file_for_slug(proj, "p1") is None
 
 
 def test_promote_pushes_path_artifact_to_bucket_preserving_relative_path(

--- a/trackio/logbook.py
+++ b/trackio/logbook.py
@@ -1521,7 +1521,7 @@ def auto_note_dashboard(project: str, space_id: str | None = None) -> None:
     if proj is None:
         return
     try:
-        slug = ensure_page(proj, project)
+        slug = resolve_page(proj)
         if _page_has_dashboard_cell(proj, slug, project):
             return
         add_dashboard_cell(proj, slug, project, space_id=space_id)


### PR DESCRIPTION
## Summary

- append automatically discovered dashboards to the active logbook page
- stop creating pages named after Trackio projects
- preserve per-project dashboard deduplication on the active page
- no-op safely when no page has been selected yet

## Tests

- `.venv/bin/python -m pytest tests/unit/test_logbook.py -q` (42 passed)
- `.venv/bin/ruff check trackio/logbook.py tests/unit/test_logbook.py`
- `git diff --check`