### PR TITLE
ICML logbook template validation, scaffold, and index hub summary

### DIFF
--- a/tests/ui/test_logbook_viewer.py
+++ b/tests/ui/test_logbook_viewer.py
@@ -110,6 +110,63 @@ def test_dashboard_cell_uses_the_main_cell_header(tmp_path, monkeypatch):
             thread.join()
 
 
+def test_logbook_index_hub_summary(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    proj = logbook.create_logbook("Reproduction: Hub summary test")
+    index = logbook.logbook_root(proj) / "pages" / "index.md"
+    index.write_text(
+        "# Reproduction: Hub summary test\n\n"
+        "[OpenReview paper](https://openreview.net/forum?id=abc123XYZ1)\n\n"
+        "## Pages\n\n| Page |\n| --- |\n",
+        encoding="utf-8",
+    )
+    claim = logbook.ensure_page(proj, "Claim 1: Demo")
+    logbook.add_markdown_cell(
+        proj,
+        claim,
+        "Models: https://huggingface.co/org/model-a and "
+        "https://huggingface.co/datasets/org/data-b\n"
+        "Code: https://github.com/org/repro-repo",
+    )
+    logbook.write_site_files(proj)
+
+    handler = functools.partial(
+        _QuietHandler, directory=str(logbook.logbook_root(proj))
+    )
+    socketserver.ThreadingTCPServer.allow_reuse_address = True
+    with socketserver.ThreadingTCPServer(("127.0.0.1", 0), handler) as server:
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        try:
+            with sync_playwright() as playwright:
+                browser = playwright.chromium.launch()
+                page = browser.new_page(viewport={"width": 1440, "height": 900})
+                page.goto(f"http://127.0.0.1:{server.server_address[1]}/")
+
+                summary = page.locator(".logbook-hub-summary")
+                expect(summary).to_have_count(1)
+                expect(summary.locator(".hub-summary-heading").nth(0)).to_have_text(
+                    "Hugging Face artifacts"
+                )
+                expect(summary.get_by_role("link", name="org/model-a")).to_have_attribute(
+                    "href", "https://huggingface.co/org/model-a"
+                )
+                expect(summary.get_by_role("link", name="org/data-b")).to_have_attribute(
+                    "href", "https://huggingface.co/datasets/org/data-b"
+                )
+                expect(summary.locator(".hub-summary-heading").nth(1)).to_have_text(
+                    "Code"
+                )
+                expect(
+                    summary.get_by_role("link", name="github.com/org/repro-repo")
+                ).to_have_attribute("href", "https://github.com/org/repro-repo")
+                expect(page.locator(".logbook-stats")).to_have_count(0)
+                browser.close()
+        finally:
+            server.shutdown()
+            thread.join()
+
+
 def test_figure_hotspot_navigates_to_its_logbook_page(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     proj = logbook.create_logbook("Interactive figure logbook")

--- a/tests/unit/test_logbook.py
+++ b/tests/unit/test_logbook.py
@@ -2,6 +2,7 @@ import base64
 import json
 import re
 import sys
+from pathlib import Path
 
 import pytest
 
@@ -667,3 +668,68 @@ def test_project_from_url_blocks_path_traversal(monkeypatch):
     assert (root / "pages" / "index.md").is_file()
     escaped = (root / ".." / ".." / "trackio-evil-traversal.md").resolve()
     assert not escaped.exists()
+
+
+def test_repro_slug_from_title():
+    slug = logbook.repro_slug_from_title(
+        "Adversarially Robust Control of CVaR via Rockafellar-Uryasev Conformal Inference"
+    )
+    assert slug.startswith("repro-adversarially-robust-control")
+    assert logbook._looks_like_openreview_repo("Vhesstbfg6")
+    assert logbook._looks_like_openreview_repo("repro-Vhesstbfg6")
+    assert not logbook._looks_like_openreview_repo(slug)
+
+
+def test_scaffold_icml_logbook_structure(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    info = logbook.scaffold_icml_logbook(
+        title="Demo Paper Title",
+        orid="abc123XYZ1",
+        claims=["Headline accuracy", "Ablations"],
+        openreview_url="https://openreview.net/forum?id=abc123XYZ1",
+    )
+    proj = Path(info["proj"])
+    metadata = logbook.read_metadata(proj)
+    assert metadata["tags"] == ["icml2026-repro", "paper-abc123XYZ1"]
+    index = (logbook.logbook_root(proj) / "pages" / "index.md").read_text(
+        encoding="utf-8"
+    )
+    assert index.startswith("# Reproduction: Demo Paper Title")
+    assert "openreview.net/forum?id=abc123XYZ1" in index
+    toc = logbook._link_order(logbook.logbook_root(proj) / "pages" / "index.md")
+    assert toc[0] == "executive-summary"
+    assert toc[-1] == "conclusion"
+    assert all(s.startswith("claim-") for s in toc[1:-1])
+
+
+def test_validate_icml_logbook_passes_scaffold(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    info = logbook.scaffold_icml_logbook(
+        title="Validate Me",
+        orid="abc123XYZ1",
+        claims=["Claim text"],
+    )
+    proj = Path(info["proj"])
+    metadata = logbook.read_metadata(proj)
+    metadata["space_id"] = f"user/{info['slug']}"
+    logbook.write_metadata(proj, metadata)
+    result = logbook.validate_logbook(
+        proj, profile="icml2026", space_id=metadata["space_id"]
+    )
+    structural_errors = [
+        e
+        for e in result["errors"]
+        if "Conclusion page needs a reproduction bundle" not in e
+    ]
+    assert structural_errors == []
+
+
+def test_validate_icml_logbook_rejects_openreview_slug(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    logbook.scaffold_icml_logbook(title="Bad Slug", orid="abc123XYZ1")
+    proj = logbook.require_project_dir()
+    result = logbook.validate_logbook(
+        proj, profile="icml2026", space_id="user/Vhesstbfg6"
+    )
+    assert not result["ok"]
+    assert any("repro-" in err for err in result["errors"])

--- a/trackio/cli.py
+++ b/trackio/cli.py
@@ -1,4 +1,5 @@
 import argparse
+import json
 import os
 import re
 import sys
@@ -1031,7 +1032,7 @@ def main():
     logbook_sub = logbook_parser.add_subparsers(
         dest="logbook_action",
         required=True,
-        metavar="{open,cell,run,page,read,serve,publish,sync}",
+        metavar="{open,cell,run,page,read,serve,publish,sync,validate,scaffold}",
     )
 
     lb_open = logbook_sub.add_parser(
@@ -1195,6 +1196,51 @@ def main():
         "--private",
         action="store_true",
         help="Make the logbook and any promoted dashboards/buckets private",
+    )
+    lb_pub.add_argument(
+        "--force",
+        action="store_true",
+        help="Publish even when ICML validation fails (icml2026-repro tag)",
+    )
+
+    lb_validate = logbook_sub.add_parser(
+        "validate", help="Check logbook structure before publishing"
+    )
+    lb_validate.add_argument(
+        "--profile",
+        default="icml2026",
+        help="Validation profile (default: icml2026)",
+    )
+    lb_validate.add_argument(
+        "space_id",
+        nargs="?",
+        help="Optional HF Space id to validate the publish slug",
+    )
+
+    lb_scaffold = logbook_sub.add_parser(
+        "scaffold", help="Create a canonical ICML reproduction logbook template"
+    )
+    lb_scaffold.add_argument("--title", required=True, help="Paper title")
+    lb_scaffold.add_argument("--orid", required=True, help="OpenReview forum id")
+    lb_scaffold.add_argument("--arxiv", help="arXiv id (for HF paper link)")
+    lb_scaffold.add_argument("--openreview-url", help="Full OpenReview paper URL")
+    lb_scaffold.add_argument(
+        "--hf-indexed",
+        action="store_true",
+        help="Paper is indexed on huggingface.co/papers",
+    )
+    lb_scaffold.add_argument(
+        "--claims-json",
+        help='JSON array of claim strings, e.g. \'["headline accuracy", "..."]\'',
+    )
+    lb_scaffold.add_argument(
+        "--username",
+        help="HF username for metadata.space_id (username/repro-<slug>)",
+    )
+    lb_scaffold.add_argument(
+        "--profile",
+        default="icml2026",
+        help="Scaffold profile (default: icml2026)",
     )
 
     lb_pin = logbook_sub.add_parser(
@@ -2061,12 +2107,55 @@ def _handle_logbook(args):
         elif action == "serve":
             lb.serve(path=args.path, port=args.port, open_browser=not args.no_browser)
         elif action == "publish":
-            url = lb.publish(space_id=args.space_id, private=args.private)
+            url = lb.publish(
+                space_id=args.space_id,
+                private=args.private,
+                force=getattr(args, "force", False),
+            )
             print(f"Published: {url}")
             space_id = lb.read_metadata(lb.require_project_dir()).get("space_id")
             if space_id:
                 subdomain = re.sub(r"[^a-z0-9]+", "-", space_id.lower()).strip("-")
                 print(f"Rendered at: https://{subdomain}.static.hf.space/")
+        elif action == "validate":
+            proj = lb.require_project_dir()
+            result = lb.validate_logbook(
+                proj, profile=args.profile, space_id=args.space_id
+            )
+            for warning in result["warnings"]:
+                print(f"warning: {warning}")
+            if result["errors"]:
+                for err in result["errors"]:
+                    print(f"error: {err}")
+                error_exit("Logbook validation failed.")
+            print("Logbook validation passed.")
+        elif action == "scaffold":
+            if args.profile != "icml2026":
+                error_exit(f"Unknown scaffold profile: {args.profile}")
+            claims = None
+            if args.claims_json:
+                try:
+                    claims = json.loads(args.claims_json)
+                except json.JSONDecodeError as e:
+                    error_exit(f"Invalid --claims-json: {e}")
+                if not isinstance(claims, list):
+                    error_exit("--claims-json must be a JSON array of strings.")
+            info = lb.scaffold_icml_logbook(
+                title=args.title,
+                orid=args.orid,
+                claims=claims,
+                arxiv_id=args.arxiv,
+                openreview_url=args.openreview_url,
+                hf_indexed=args.hf_indexed,
+                username=args.username,
+            )
+            print(f"Scaffolded logbook: {info['title']}")
+            print(f"Publish target: {info['space_id']}")
+            print(
+                "Next: reproduce claims, validate, then publish:\n"
+                f"  trackio logbook validate --profile icml2026 {info['space_id']}\n"
+                f"  trackio logbook publish {info['space_id']}"
+            )
         elif action == "sync":
             proj = lb.require_project_dir()
             if not lb.is_autosync(proj):

--- a/trackio/frontend_templates/logbook/logbook.css
+++ b/trackio/frontend_templates/logbook/logbook.css
@@ -1095,7 +1095,74 @@ table.board tr.linked-row:hover a {
   color: var(--muted);
 }
 
-/* ---- logbook summary stats ---- */
+/* ---- logbook hub summary (index) ---- */
+.logbook-hub-summary {
+  margin: 0 0 28px;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+.hub-summary-block {
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: var(--radius);
+  padding: 14px 18px;
+}
+.hub-summary-heading {
+  margin: 0 0 10px;
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+.hub-summary-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 8px 12px;
+  margin: 6px 0;
+  font-size: 14px;
+  line-height: 1.45;
+}
+.hub-summary-count {
+  flex: 0 0 auto;
+  min-width: 7.5em;
+  font-family: var(--mono);
+  font-weight: 600;
+  color: var(--accent-strong);
+}
+.hub-summary-links a {
+  color: var(--link);
+  text-decoration: none;
+}
+.hub-summary-links a:hover {
+  text-decoration: underline;
+}
+.hub-summary-local {
+  color: var(--muted);
+  font-family: var(--mono);
+  font-size: 13px;
+}
+.hub-summary-code a {
+  display: inline-block;
+  margin-right: 12px;
+  color: var(--link);
+  text-decoration: none;
+  font-family: var(--mono);
+  font-size: 13px;
+}
+.hub-summary-code a:hover {
+  text-decoration: underline;
+}
+.hub-summary-empty {
+  margin: 0;
+  font-size: 13px;
+  color: var(--muted);
+  line-height: 1.5;
+}
+
+/* ---- logbook summary stats (legacy) ---- */
 .logbook-stats {
   display: flex;
   flex-wrap: wrap;

--- a/trackio/frontend_templates/logbook/logbook.js
+++ b/trackio/frontend_templates/logbook/logbook.js
@@ -1692,7 +1692,7 @@
         } else {
           body.prepend(hint);
         }
-        hint.after(buildLogbookStats(markdown));
+        hint.after(buildLogbookHubSummary(markdown));
         bookIntroBody = body;
       }
       layout.appendChild(body);
@@ -1714,7 +1714,7 @@
         (el) =>
           el.tagName !== "H1" &&
           !el.classList.contains("agent-hint") &&
-          !el.classList.contains("logbook-stats") &&
+          !el.classList.contains("logbook-hub-summary") &&
           !el.classList.contains("pinned-notes")
       );
       if (section && !section.classList.contains("has-pinned-notes") && !hasExtra) {
@@ -1750,9 +1750,6 @@
       });
     });
   }
-
-  let STATS_TOKEN = 0;
-  let STATS_LISTENERS = false;
 
   function fmtBytes(n) {
     if (n == null || isNaN(n)) return null;
@@ -1873,180 +1870,164 @@
     };
   }
 
-  function closeStatPopovers() {
-    document
-      .querySelectorAll(".stat-popover")
-      .forEach((p) => (p.hidden = true));
-    document
-      .querySelectorAll(".stat-tile.open")
-      .forEach((t) => t.classList.remove("open"));
-  }
-
-  function ensureStatListeners() {
-    if (STATS_LISTENERS) return;
-    STATS_LISTENERS = true;
-    document.addEventListener("click", closeStatPopovers);
-    document.addEventListener("keydown", (e) => {
-      if (e.key === "Escape") closeStatPopovers();
-    });
-  }
-
-  function stateHtml(remote, url) {
-    return remote
-      ? `<a class="stat-row-state open" href="${esc(url)}" target="_blank" rel="noopener" title="Open in a new tab">Open ↗</a>`
-      : `<span class="stat-row-state">publish to share</span>`;
-  }
-
-  function scrollToResource(resUrl) {
-    closeStatPopovers();
-    if (!resUrl) return;
-    const el = document.querySelector(
-      `#page .page-body [data-res-url="${CSS.escape(resUrl)}"]:not(.stat-row)`
+  function scanMarkdownUrls(md) {
+    return extractUrls(
+      md.replace(/(`{3,4}|~{3,4})(html|raw)[^\n]*\n[\s\S]*?\n\1/g, " ")
     );
-    if (!el) return;
-    el.scrollIntoView({ behavior: "smooth", block: "center" });
-    el.classList.add("res-flash");
-    setTimeout(() => el.classList.remove("res-flash"), 1500);
   }
 
-  function dashRowHtml(d) {
-    const inner =
-      `<span class="stat-row-ico">${DASHBOARD_ICON_IMG}</span>` +
-      `<div class="stat-row-main"><div class="stat-row-title">${esc(d.project)}</div>` +
-      `<div class="stat-row-meta">${stateHtml(!d.local, d.url)}</div></div>`;
-    return `<div class="stat-row" data-res-url="${esc(d.resUrl)}" title="Jump to it in the logbook">${inner}</div>`;
-  }
-
-  function artRowHtml(a) {
-    const remote = !a.local && !!a.url;
-    const parts = [a.type, a.size].filter(Boolean).map(esc);
-    const meta = parts.length
-      ? `${parts.join(" · ")} · ${stateHtml(remote, a.url)}`
-      : stateHtml(remote, a.url);
-    const inner =
-      `<span class="stat-row-ico">${ARTIFACT_ICON_IMG}</span>` +
-      `<div class="stat-row-main"><div class="stat-row-title">${esc(a.name)}</div>` +
-      `<div class="stat-row-meta">${meta}</div></div>`;
-    return `<div class="stat-row" data-res-url="${esc(a.resUrl)}" title="Jump to it in the logbook">${inner}</div>`;
-  }
-
-  function statTile(icon, alt, singular, plural, head, rowFn) {
-    const tile = document.createElement("button");
-    tile.type = "button";
-    tile.className = "stat-tile";
-    const render = (items) => {
-      const count = items.length;
-      const label = count === 1 ? singular : plural;
-      const caret = count > 0 ? `<span class="stat-caret">▾</span>` : "";
-      tile.innerHTML =
-        `<img class="stat-icon" src="${icon}" alt="${esc(alt)}" />` +
-        `<div class="stat-text"><div class="stat-num">${count}</div>` +
-        `<div class="stat-label">${esc(label)}</div></div>` +
-        caret;
-      tile.disabled = count === 0;
-      if (count > 0) {
-        const pop = document.createElement("div");
-        pop.className = "stat-popover";
-        pop.hidden = true;
-        pop.innerHTML =
-          `<div class="stat-pop-head">${esc(head)}</div>` +
-          items.map(rowFn).join("");
-        pop.addEventListener("click", (e) => {
-          if (e.target.closest("a.stat-row-state")) {
-            e.stopPropagation();
-            return;
-          }
-          e.stopPropagation();
-          const row = e.target.closest(".stat-row");
-          if (row) scrollToResource(row.dataset.resUrl);
-        });
-        tile.appendChild(pop);
-      }
+  function collectAllLogbookHubResources(markdownList) {
+    const groups = {
+      model: new Map(),
+      dataset: new Map(),
+      space: new Map(),
+      job: new Map(),
+      bucket: new Map(),
+      repo: new Map(),
     };
-    tile.addEventListener("click", (e) => {
-      if (tile.disabled) return;
-      e.stopPropagation();
-      const pop = tile.querySelector(".stat-popover");
-      if (!pop) return;
-      const isOpen = !pop.hidden;
-      closeStatPopovers();
-      if (!isOpen) {
-        pop.hidden = false;
-        tile.classList.add("open");
+    markdownList.forEach((md) => {
+      scanMarkdownUrls(md).forEach((url) => {
+        const item = classifyResource(url);
+        if (!item || item.kind === "paper" || item.kind === "dashboard") return;
+        if (item.kind === "repo") {
+          if (!groups.repo.has(item.url)) groups.repo.set(item.url, item);
+          return;
+        }
+        if (item.kind === "artifact") {
+          if (!groups.bucket.has(url)) {
+            groups.bucket.set(url, { id: item.id, url, local: false });
+          }
+          return;
+        }
+        const bucket = groups[item.kind];
+        if (bucket && !bucket.has(item.url)) bucket.set(item.url, item);
+      });
+      cellDashboardItems(md).forEach((it) => {
+        if (!it.url || groups.space.has(it.url)) return;
+        groups.space.set(it.url, {
+          kind: "space",
+          id: spaceIdFromUrl(it.url),
+          url: it.url,
+          local: false,
+        });
+      });
+      const re = new RegExp(LB_CELL_RE.source, "g");
+      let m;
+      while ((m = re.exec(md))) {
+        if (parseCellMeta(m[2]).type !== "artifact") continue;
+        const body = m[3];
+        const info = artifactInfoFromCell(parseCellMeta(m[2]), body);
+        if (!info.name || groups.bucket.has(info.resUrl)) continue;
+        const full =
+          body.match(/https:\/\/huggingface\.co\/buckets\/[^\s<>)"'`]+(?:#\S+)?/)?.[0] ||
+          info.url ||
+          info.resUrl;
+        groups.bucket.set(info.resUrl, {
+          id: info.name,
+          url: full,
+          local: info.local,
+        });
       }
     });
-    return { tile, render };
+    return groups;
   }
 
-  function buildLogbookStats(markdownList) {
-    const token = ++STATS_TOKEN;
-    ensureStatListeners();
-    const { dashboards, artifacts } = collectLogbookResources(markdownList);
+  function hubCountLabel(count, singular, plural) {
+    return `${count} ${count === 1 ? singular : plural}`;
+  }
 
-    const el = document.createElement("div");
-    el.className = "logbook-stats";
-    const dash = statTile(
-      "./trackio-logo-light.png",
-      "Trackio",
-      "Trackio Dashboard",
-      "Trackio Dashboards",
-      "Dashboards created in this logbook",
-      dashRowHtml
-    );
-    const art = statTile(
-      "./bucket-icon.svg",
-      "Bucket",
-      "Artifact",
-      "Artifacts",
-      "Artifacts created in this logbook",
-      artRowHtml
-    );
-    dash.render(dashboards);
-    art.render(artifacts);
-    el.appendChild(dash.tile);
-    el.appendChild(art.tile);
-
-    const scanText = markdownList
-      .map((md) =>
-        md.replace(/(`{3,4}|~{3,4})(html|raw)[^\n]*\n[\s\S]*?\n\1/g, " ")
-      )
-      .join("\n");
-    const seen = new Set(
-      dashboards.map((d) =>
-        d.local ? `local:${d.project}` : `space:${spaceIdFromUrl(d.url)}`
-      )
-    );
-    const remoteSpaces = new Map();
-    extractUrls(scanText).forEach((url) => {
-      const item = classifyResource(url);
-      if (item && item.kind === "space" && !item.local) {
-        remoteSpaces.set(item.url, item);
+  function hubSummaryRow(countLabel, items) {
+    const row = document.createElement("div");
+    row.className = "hub-summary-row";
+    const label = document.createElement("span");
+    label.className = "hub-summary-count";
+    label.textContent = countLabel;
+    const links = document.createElement("span");
+    links.className = "hub-summary-links";
+    items.forEach((item, index) => {
+      if (index) links.appendChild(document.createTextNode(" · "));
+      if (item.local) {
+        const span = document.createElement("span");
+        span.className = "hub-summary-local";
+        span.textContent = item.id;
+        links.appendChild(span);
+      } else {
+        const a = document.createElement("a");
+        a.href = item.url;
+        a.target = "_blank";
+        a.rel = "noopener";
+        a.textContent = item.id;
+        links.appendChild(a);
       }
     });
-    remoteSpaces.forEach((s) => {
-      const key = `space:${s.id}`;
-      if (seen.has(key)) return;
-      getJSON(`https://huggingface.co/api/spaces/${s.id}`)
-        .then((d) => {
-          if (STATS_TOKEN !== token) return;
-          const tags = (d && d.tags) || [];
-          if (
-            !seen.has(key) &&
-            tags.some((t) => String(t).toLowerCase() === "trackio")
-          ) {
-            seen.add(key);
-            dashboards.push({
-              project: s.id,
-              local: false,
-              url: s.url,
-              resUrl: s.url,
-            });
-            dashboards.sort((a, b) => a.project.localeCompare(b.project));
-            dash.render(dashboards);
-          }
-        })
-        .catch(() => {});
+    row.appendChild(label);
+    row.appendChild(links);
+    return row;
+  }
+
+  function buildLogbookHubSummary(markdownList) {
+    const groups = collectAllLogbookHubResources(markdownList);
+    const el = document.createElement("div");
+    el.className = "logbook-hub-summary";
+
+    const hfKinds = [
+      ["model", "model", "models"],
+      ["dataset", "dataset", "datasets"],
+      ["space", "Space", "Spaces"],
+      ["job", "job", "jobs"],
+      ["bucket", "bucket", "buckets"],
+    ];
+    let hfHasAny = false;
+    const hfBlock = document.createElement("div");
+    hfBlock.className = "hub-summary-block";
+    const hfTitle = document.createElement("h2");
+    hfTitle.className = "hub-summary-heading";
+    hfTitle.textContent = "Hugging Face artifacts";
+    hfBlock.appendChild(hfTitle);
+
+    hfKinds.forEach(([key, singular, plural]) => {
+      const map = groups[key];
+      if (!map || !map.size) return;
+      hfHasAny = true;
+      hfBlock.appendChild(
+        hubSummaryRow(
+          hubCountLabel(map.size, singular, plural),
+          Array.from(map.values())
+        )
+      );
     });
+
+    if (hfHasAny) el.appendChild(hfBlock);
+
+    if (groups.repo.size) {
+      const codeBlock = document.createElement("div");
+      codeBlock.className = "hub-summary-block";
+      const codeTitle = document.createElement("h2");
+      codeTitle.className = "hub-summary-heading";
+      codeTitle.textContent = "Code";
+      codeBlock.appendChild(codeTitle);
+      const row = document.createElement("div");
+      row.className = "hub-summary-row hub-summary-code";
+      groups.repo.forEach((item) => {
+        const a = document.createElement("a");
+        a.href = item.url;
+        a.target = "_blank";
+        a.rel = "noopener";
+        a.textContent = item.id;
+        row.appendChild(a);
+      });
+      codeBlock.appendChild(row);
+      el.appendChild(codeBlock);
+    }
+
+    if (!hfHasAny && !groups.repo.size) {
+      const hint = document.createElement("p");
+      hint.className = "hub-summary-empty";
+      hint.textContent =
+        "Link Hugging Face models, datasets, Jobs, Buckets, and GitHub repos in logbook cells — they appear here automatically.";
+      el.appendChild(hint);
+    }
+
     return el;
   }
 

--- a/trackio/logbook.py
+++ b/trackio/logbook.py
@@ -2103,8 +2103,368 @@ def _promote_local_deps(proj: Path, ns: str, private: bool) -> None:
     write_metadata(proj, metadata)
 
 
+HF_REPO_NAME_MAX = 96
+OPENREVIEW_ID_RE = re.compile(r"^[A-Za-z0-9]{8,12}$")
+HF_PAPER_URL_RE = re.compile(r"https://huggingface\.co/papers/\S+")
+OPENREVIEW_URL_RE = re.compile(r"https://openreview\.net/forum\?id=\S+")
+HUB_URL_RE = re.compile(
+    r"https://huggingface\.co/(models|datasets|spaces|jobs|buckets)/[^\s<>\"'`]+"
+)
+GITHUB_REPO_RE = re.compile(r"https://github\.com/[^\s<>\"'`]+")
+
+
+def repro_slug_from_title(title: str, *, max_len: int = HF_REPO_NAME_MAX) -> str:
+    clean = re.sub(r"^Reproduction:\s*", "", title.strip(), flags=re.I).strip()
+    slug = f"repro-{_slugify(clean)}"
+    if len(slug) <= max_len:
+        return slug
+    return slug[:max_len].rstrip("-")
+
+
+def _repo_name_from_space_id(space_id: str | None) -> str | None:
+    if not space_id or "/" not in space_id:
+        return None
+    return space_id.partition("/")[2]
+
+
+def _looks_like_openreview_repo(name: str) -> bool:
+    if OPENREVIEW_ID_RE.fullmatch(name):
+        return True
+    if name.startswith("repro-"):
+        suffix = name[6:]
+        if OPENREVIEW_ID_RE.fullmatch(suffix):
+            return True
+    return False
+
+
+def _index_markdown(proj: Path) -> str:
+    return (_pages_dir(proj) / "index.md").read_text(encoding="utf-8")
+
+
+def _collect_hub_resources(text: str) -> tuple[bool, bool]:
+    has_hub = bool(HUB_URL_RE.search(text))
+    has_github = bool(GITHUB_REPO_RE.search(text))
+    return has_hub, has_github
+
+
+def validate_logbook(
+    proj: Path | None = None,
+    *,
+    profile: str | None = None,
+    space_id: str | None = None,
+) -> dict:
+    """Validate logbook structure. Returns {ok, errors, warnings}."""
+    proj = proj or require_project_dir()
+    errors: list[str] = []
+    warnings: list[str] = []
+
+    if profile != "icml2026":
+        if profile:
+            errors.append(f"Unknown validation profile: {profile}")
+        return {"ok": not errors, "errors": errors, "warnings": warnings}
+
+    metadata = read_metadata(proj)
+    tags = metadata.get("tags") or []
+    if "icml2026-repro" not in tags:
+        errors.append('metadata.json tags must include "icml2026-repro".')
+    paper_tags = [t for t in tags if t.startswith("paper-")]
+    if not paper_tags:
+        errors.append(
+            'metadata.json tags must include "paper-<openreview-id>".'
+        )
+    elif len(paper_tags) > 1:
+        warnings.append(
+            f'Multiple paper-* tags found ({", ".join(paper_tags)}); '
+            "expected exactly one."
+        )
+
+    repo = _repo_name_from_space_id(space_id or metadata.get("space_id"))
+    if not repo:
+        errors.append(
+            "No Space slug set. Pass space_id or set metadata.space_id to "
+            "username/repro-<slugified-paper-title> before publishing."
+        )
+    elif not repo.startswith("repro-"):
+        errors.append(
+            f'Space repo name must start with "repro-" (got "{repo}"). '
+            "Never publish with an OpenReview id as the slug."
+        )
+    elif _looks_like_openreview_repo(repo):
+        errors.append(
+            f'Space slug "{repo}" looks like an OpenReview id, not a '
+            "title-derived repro-<paper-title> slug."
+        )
+    elif len(repo) <= len("repro-") + 8:
+        warnings.append(
+            f'Space slug "{repo}" is very short; use the full slugified '
+            "paper title, not an abbreviation."
+        )
+
+    index_text = _index_markdown(proj)
+    index_prose = _index_prose(index_text)
+    title = _title_of(_pages_dir(proj) / "index.md", "")
+    if not re.match(r"^Reproduction:\s+.+\S", title, re.I):
+        errors.append(
+            'Index heading must be "# Reproduction: <paper title>" '
+            f'(got "{title or "(empty)"}").'
+        )
+    if not HF_PAPER_URL_RE.search(index_prose) and not OPENREVIEW_URL_RE.search(
+        index_prose
+    ):
+        errors.append(
+            "Index page must link to the HF paper page or OpenReview "
+            "(https://huggingface.co/papers/… or https://openreview.net/forum?id=…)."
+        )
+
+    toc_slugs = _link_order(_pages_dir(proj) / "index.md")
+    manifest = build_manifest(proj)
+    disk_slugs = [
+        node["slug"]
+        for node in _walk(manifest["root"])
+        if node["slug"] != ROOT_SLUG
+    ]
+    if set(disk_slugs) != set(toc_slugs):
+        errors.append(
+            "Page list on the index must match sidebar pages exactly "
+            "(no extra or missing pages)."
+        )
+    if not toc_slugs:
+        errors.append(
+            "Index Pages table is empty. Add Executive summary, Claim pages, "
+            "and Conclusion."
+        )
+    else:
+        if toc_slugs[0] != "executive-summary":
+            errors.append(
+                'First sidebar page must be "Executive summary" '
+                f'(slug executive-summary; got "{toc_slugs[0]}").'
+            )
+        if toc_slugs[-1] != "conclusion":
+            errors.append(
+                f'Last sidebar page must be "Conclusion" (got "{toc_slugs[-1]}").'
+            )
+        claim_slugs = toc_slugs[1:-1]
+        if not claim_slugs:
+            errors.append(
+                "Add at least one Claim page between Executive summary and Conclusion."
+            )
+        for slug in claim_slugs:
+            if not re.match(r"^claim-\d+", slug):
+                errors.append(
+                    f'Claim page slug must start with "claim-" (got "{slug}").'
+                )
+
+    root = logbook_root(proj)
+    exec_node = _node_for_slug(manifest, "executive-summary")
+    if exec_node is None:
+        errors.append('Missing page "Executive summary".')
+    else:
+        exec_cells = _parse_cells_from_text(
+            (root / exec_node["file"]).read_text(encoding="utf-8"),
+            exec_node["slug"],
+            exec_node["title"],
+        )
+        pinned_md = [
+            c
+            for c in exec_cells
+            if c["type"] == "markdown"
+            and c["metadata"].get("pinned")
+            and (c["title"] or "").strip().lower() == "executive summary"
+        ]
+        if not pinned_md:
+            errors.append(
+                'Executive summary page needs a pinned markdown cell titled '
+                '"Executive summary".'
+            )
+        pinned_poster = [
+            c
+            for c in exec_cells
+            if c["type"] == "figure"
+            and c["metadata"].get("pinned")
+            and "poster_embed.html" in c["body"]
+        ]
+        if not pinned_poster:
+            errors.append(
+                "Executive summary page needs a pinned figure cell referencing "
+                "poster_embed.html (Chenruishuo/posterly poster)."
+            )
+
+    concl_node = _node_for_slug(manifest, "conclusion")
+    if concl_node is None:
+        errors.append('Missing page "Conclusion".')
+    else:
+        concl_cells = _parse_cells_from_text(
+            (root / concl_node["file"]).read_text(encoding="utf-8"),
+            concl_node["slug"],
+            concl_node["title"],
+        )
+        bundle_cells = [c for c in concl_cells if c["type"] == "artifact"]
+        if not bundle_cells:
+            errors.append(
+                'Conclusion page needs a reproduction bundle artifact cell '
+                "(trackio logbook cell artifact … --page Conclusion)."
+            )
+
+    all_text = []
+    for node in _walk(manifest["root"]):
+        all_text.append((root / node["file"]).read_text(encoding="utf-8"))
+    combined = "\n".join(all_text)
+    has_hub, has_github = _collect_hub_resources(combined)
+    has_bucket_artifact = any(
+        c["type"] == "artifact"
+        for node in _walk(manifest["root"])
+        for c in _parse_cells_from_text(
+            (root / node["file"]).read_text(encoding="utf-8"),
+            node["slug"],
+            node["title"],
+        )
+    )
+    if not has_hub and not has_github and not has_bucket_artifact:
+        warnings.append(
+            "No Hugging Face asset URLs, GitHub repos, or artifact cells found "
+            "logbook-wide — the index summary will be empty until you link them."
+        )
+
+    return {"ok": not errors, "errors": errors, "warnings": warnings}
+
+
+def scaffold_icml_logbook(
+    *,
+    title: str,
+    orid: str,
+    claims: list[str] | None = None,
+    arxiv_id: str | None = None,
+    openreview_url: str | None = None,
+    hf_indexed: bool = False,
+    username: str | None = None,
+) -> dict:
+    paper_title = re.sub(r"^Reproduction:\s*", "", title.strip(), flags=re.I).strip()
+    logbook_title = f"Reproduction: {paper_title}"
+    slug = repro_slug_from_title(paper_title)
+    space_id = f"{username}/{slug}" if username else None
+
+    if find_project_dir() and (logbook_root(find_project_dir()) / "pages" / "index.md").exists():
+        raise LogbookError(
+            "A logbook already exists in this directory. Remove .trackio/logbook first."
+        )
+
+    proj = create_logbook(title=logbook_title, space_id=space_id)
+    orid = orid.strip()
+    if not orid:
+        raise LogbookError("OpenReview id (--orid) is required.")
+
+    paper_link = (
+        f"[HF paper page](https://huggingface.co/papers/{arxiv_id.strip()})"
+        if hf_indexed and arxiv_id
+        else f"[OpenReview paper]({(openreview_url or f'https://openreview.net/forum?id={orid}').strip()})"
+    )
+    claim_specs: list[tuple[str, str]] = []
+    for i, claim in enumerate(claims or [], start=1):
+        claim_text = str(claim).strip()
+        if not claim_text:
+            continue
+        if not re.match(r"^Claim\s+\d+\s*:", claim_text, re.I):
+            claim_text = f"Claim {i}: {claim_text}"
+        claim_specs.append((claim_text, ensure_page(proj, claim_text)))
+
+    index_lines = [
+        f"# {logbook_title}",
+        "",
+        paper_link,
+        "",
+        TOC_HEADING,
+        "",
+        TOC_HEADER,
+        TOC_SEP,
+    ]
+    exec_slug = ensure_page(proj, "Executive summary")
+    index_lines.append(f"| [Executive summary](#/{exec_slug}) |")
+    for claim_title, claim_slug in claim_specs:
+        index_lines.append(f"| [{claim_title}](#/{claim_slug}) |")
+    concl_slug = ensure_page(proj, "Conclusion")
+    index_lines.append(f"| [Conclusion](#/{concl_slug}) |")
+    index_lines.append("")
+    (_pages_dir(proj) / "index.md").write_text("\n".join(index_lines), encoding="utf-8")
+
+    metadata = read_metadata(proj)
+    metadata["tags"] = ["icml2026-repro", f"paper-{orid}"]
+    paper_meta = {}
+    if arxiv_id:
+        paper_meta["arxiv_id"] = arxiv_id.strip()
+    if paper_meta:
+        metadata["paper"] = paper_meta
+    if space_id:
+        metadata["space_id"] = space_id
+    write_metadata(proj, metadata)
+
+    summary_body = (
+        "Write a 3–5 sentence outcome-first summary here.\n\n"
+        "## Scope & cost\n\n"
+        "| Item | Value |\n"
+        "| --- | --- |\n"
+        "| GPU / compute | |\n"
+        "| Wall time | |\n"
+        "| Feasibility | |\n"
+    )
+    add_markdown_cell(proj, exec_slug, summary_body, title="Executive summary")
+    exec_summary_id = last_cell_id(proj, page=exec_slug)
+    if exec_summary_id:
+        set_cell_pinned(proj, exec_summary_id, pinned=True, page=exec_slug)
+
+    add_figure_cell(
+        proj,
+        exec_slug,
+        html=(
+            "<p>Build a reproduction poster with "
+            '<a href="https://github.com/Chenruishuo/posterly">Chenruishuo/posterly</a> '
+            "and replace this cell with <code>poster_embed.html</code>.</p>"
+        ),
+        title="Reproduction poster (poster_embed.html)",
+    )
+    poster_id = last_cell_id(proj, page=exec_slug)
+    if poster_id:
+        set_cell_pinned(proj, poster_id, pinned=True, page=exec_slug)
+
+    add_markdown_cell(
+        proj,
+        concl_slug,
+        (
+            "Add a reproduction bundle artifact cell here after running:\n\n"
+            "```bash\n"
+            f"trackio.log_artifact(\"./repro_{_slugify(paper_title)}/\", "
+            f'name="repro-bundle", type="dataset")\n'
+            f"trackio logbook cell artifact {slug}/repro-bundle:v0 "
+            '--page "Conclusion" --title "Reproduction bundle" --type dataset\n'
+            "```"
+        ),
+        title="Reproduction bundle",
+    )
+
+    for claim_title, claim_slug in claim_specs:
+        add_markdown_cell(
+            proj,
+            claim_slug,
+            f"Document setup, runs, and results for **{claim_title}**.",
+            title=claim_title,
+        )
+
+    write_site_files(proj)
+    publish_target = space_id or f"<username>/{slug}"
+    return {
+        "proj": str(proj),
+        "title": logbook_title,
+        "slug": slug,
+        "space_id": publish_target,
+        "pages": [exec_slug] + [s for _, s in claim_specs] + [concl_slug],
+    }
+
+
 def publish(
-    space_id: str | None = None, hf_token: str | None = None, private: bool = False
+    space_id: str | None = None,
+    hf_token: str | None = None,
+    private: bool = False,
+    *,
+    force: bool = False,
 ) -> str:
     proj = require_project_dir()
     metadata = read_metadata(proj)
@@ -2113,6 +2473,18 @@ def publish(
         raise LogbookError(
             "No Space id. Provide one: trackio logbook publish <username/space>"
         )
+    tags = metadata.get("tags") or []
+    if "icml2026-repro" in tags and not force:
+        result = validate_logbook(proj, profile="icml2026", space_id=space_id)
+        for warning in result["warnings"]:
+            print(f"  · warning: {warning}", file=sys.stderr)
+        if not result["ok"]:
+            for err in result["errors"]:
+                print(f"  · error: {err}", file=sys.stderr)
+            raise LogbookError(
+                "ICML logbook validation failed. Fix the errors above or "
+                "publish with --force to override."
+            )
     prior = {key: metadata.get(key) for key in ("space_id", "autosync", "private")}
     metadata["space_id"] = space_id
     metadata["autosync"] = True


### PR DESCRIPTION
## Summary
- Replace misleading index "Trackio Dashboards / Artifacts" stat tiles with logbook-wide **Hugging Face artifacts** and **Code** summary blocks on the index page.
- Add `trackio logbook validate --profile icml2026` and `trackio logbook scaffold --profile icml2026` for the ICML 2026 reproduction challenge canonical template.
- Gate `trackio logbook publish` when `icml2026-repro` is tagged (override with `--force`).

## Test plan
- [x] `pytest tests/unit/test_logbook.py::test_repro_slug_from_title`
- [x] `pytest tests/unit/test_logbook.py::test_scaffold_icml_logbook_structure`
- [x] `pytest tests/unit/test_logbook.py::test_validate_icml_logbook_passes_scaffold`
- [x] `pytest tests/unit/test_logbook.py::test_validate_icml_logbook_rejects_openreview_slug`
- [ ] `pytest tests/ui/test_logbook_viewer.py::test_logbook_index_hub_summary` (Playwright)


Made with [Cursor](https://cursor.com)