### PR TITLE
Fix logbook viewer overflow and Hub references

### DIFF
--- a/.changeset/calm-plums-scroll.md
+++ b/.changeset/calm-plums-scroll.md
@@ -1,0 +1,5 @@
+---
+"trackio": patch
+---
+
+Fix logbook code overflow, CLI command truncation, Hub link contrast, resource ID validation, and live visibility detection for referenced trace datasets and Buckets.

--- a/tests/ui/test_logbook_viewer.py
+++ b/tests/ui/test_logbook_viewer.py
@@ -226,3 +226,175 @@ def test_empty_trace_and_workspace_views_explain_how_they_fill(tmp_path, monkeyp
         finally:
             server.shutdown()
             thread.join()
+
+
+def test_logbook_code_overflow_cli_ellipsis_and_copy(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    proj = logbook.create_logbook("Overflow logbook")
+    slug = logbook.ensure_page(proj, "Long code")
+    code_text = "\n".join(f"print({index})" for index in range(120))
+    logbook.add_code_cell(proj, slug, "", code_text=code_text, language="python")
+    logbook.write_site_files(proj)
+
+    handler = functools.partial(
+        _QuietHandler, directory=str(logbook.logbook_root(proj))
+    )
+    socketserver.ThreadingTCPServer.allow_reuse_address = True
+    with socketserver.ThreadingTCPServer(("127.0.0.1", 0), handler) as server:
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        try:
+            with sync_playwright() as playwright:
+                browser = playwright.chromium.launch()
+                page = browser.new_page(viewport={"width": 430, "height": 900})
+                page.add_init_script(
+                    """
+                    Object.defineProperty(navigator, "clipboard", {
+                      configurable: true,
+                      value: { writeText: async (text) => { window.__copied = text; } }
+                    });
+                    """
+                )
+                page.goto(
+                    f"http://127.0.0.1:{server.server_address[1]}/#/view/code/{slug}"
+                )
+
+                input_code = page.locator(".jp-in-body pre.hl")
+                expect(input_code).to_be_visible()
+                overflow = input_code.evaluate(
+                    """el => ({
+                      scrollHeight: el.scrollHeight,
+                      clientHeight: el.clientHeight,
+                      overflowY: getComputedStyle(el).overflowY
+                    })"""
+                )
+                assert overflow["scrollHeight"] > overflow["clientHeight"]
+                assert overflow["overflowY"] == "auto"
+
+                command = page.locator(".agent-hint code")
+                full_command = command.text_content()
+                page.locator(".agent-hint .copy").click()
+                expect(page.locator(".agent-hint .copy")).to_have_text("✓")
+                assert page.evaluate("window.__copied") == full_command
+
+                command.evaluate("(el) => { el.textContent += 'x'.repeat(240); }")
+                truncation = command.evaluate(
+                    """el => ({
+                      scrollWidth: el.scrollWidth,
+                      clientWidth: el.clientWidth,
+                      overflow: getComputedStyle(el).overflow,
+                      textOverflow: getComputedStyle(el).textOverflow,
+                      whiteSpace: getComputedStyle(el).whiteSpace
+                    })"""
+                )
+                assert truncation["scrollWidth"] > truncation["clientWidth"]
+                assert truncation["overflow"] == "hidden"
+                assert truncation["textOverflow"] == "ellipsis"
+                assert truncation["whiteSpace"] == "nowrap"
+                browser.close()
+        finally:
+            server.shutdown()
+            thread.join()
+
+
+def test_public_repo_visibility_and_hub_ref_filtering(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    proj = logbook.create_logbook("Referenced stores")
+    logbook.write_site_files(proj)
+    root = logbook.logbook_root(proj)
+
+    manifest_path = root / "logbook.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["traces_ref"] = {
+        "repo_id": "me/trace-data",
+        "repo_type": "dataset",
+        "repo_url": "https://huggingface.co/datasets/me/trace-data",
+        "private": True,
+    }
+    manifest["workspace_ref"] = {
+        "repo_id": "me/workspace-files",
+        "repo_type": "bucket",
+        "repo_url": "https://huggingface.co/buckets/me/workspace-files",
+        "private": True,
+    }
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    workspace_path = root / "workspace.json"
+    workspace = json.loads(workspace_path.read_text(encoding="utf-8"))
+    workspace["hub_refs"] = [
+        {
+            "url": "https://huggingface.co/jobs/me/{job_id}",
+            "type": "Jobs",
+            "label": "me/{job_id}",
+        },
+        {
+            "url": "https://huggingface.co/datasets/{DATASET_ID}",
+            "type": "Datasets",
+            "label": "{DATASET_ID}",
+        },
+        {
+            "url": "https://huggingface.co/spaces/{args.trackio_space}",
+            "type": "Spaces",
+            "label": "{args.trackio_space}",
+        },
+    ]
+    workspace_path.write_text(json.dumps(workspace), encoding="utf-8")
+
+    handler = functools.partial(_QuietHandler, directory=str(root))
+    socketserver.ThreadingTCPServer.allow_reuse_address = True
+    with socketserver.ThreadingTCPServer(("127.0.0.1", 0), handler) as server:
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        try:
+            with sync_playwright() as playwright:
+                browser = playwright.chromium.launch()
+                page = browser.new_page(viewport={"width": 1440, "height": 900})
+                public_metadata = json.dumps({"private": False})
+                page.route(
+                    "https://huggingface.co/api/datasets/me/trace-data",
+                    lambda route: route.fulfill(
+                        status=200,
+                        content_type="application/json",
+                        body=public_metadata,
+                    ),
+                )
+                page.route(
+                    "https://huggingface.co/api/buckets/me/workspace-files",
+                    lambda route: route.fulfill(
+                        status=200,
+                        content_type="application/json",
+                        body=public_metadata,
+                    ),
+                )
+                base_url = f"http://127.0.0.1:{server.server_address[1]}/"
+
+                page.goto(base_url + "#/view/workspace")
+                expect(page.locator(".repo-ref-card")).to_contain_text(
+                    "published to a public repository"
+                )
+                expect(
+                    page.locator('.workspace-hub-link[href$="/datasets/me/trace-data"]')
+                ).to_have_count(1)
+                expect(
+                    page.locator(
+                        '.workspace-hub-link[href$="/buckets/me/workspace-files"]'
+                    )
+                ).to_have_count(1)
+                expect(page.locator(".workspace-hub-link", has_text="{")).to_have_count(
+                    0
+                )
+
+                page.goto(base_url + "#/view/trace")
+                expect(page.locator(".repo-ref-card")).to_contain_text(
+                    "published to a public repository"
+                )
+                hub_link = page.get_by_role("link", name="Open on the Hub")
+                expect(hub_link).to_be_visible()
+                assert (
+                    hub_link.evaluate("el => getComputedStyle(el).color")
+                    == "rgb(255, 255, 255)"
+                )
+                browser.close()
+        finally:
+            server.shutdown()
+            thread.join()

--- a/tests/unit/test_logbook.py
+++ b/tests/unit/test_logbook.py
@@ -894,6 +894,31 @@ def test_scan_hub_refs_classifies_urls(proj):
     assert not any(ref["type"] == "Models" and ref["label"] == "me" for ref in refs)
 
 
+def test_scan_hub_refs_rejects_template_placeholders(proj):
+    slug = logbook.ensure_page(proj, "Template links")
+    logbook.add_markdown_cell(
+        proj,
+        slug,
+        " ".join(
+            [
+                "https://huggingface.co/jobs/me/{job_id}",
+                "https://huggingface.co/datasets/{DATASET_ID}",
+                "https://huggingface.co/datasets/{args.results_repo}",
+                "https://huggingface.co/spaces/{args.trackio_space}",
+                "https://huggingface.co/datasets/me/valid_data",
+            ]
+        ),
+    )
+
+    assert logbook.scan_hub_refs(proj) == [
+        {
+            "url": "https://huggingface.co/datasets/me/valid_data",
+            "type": "Datasets",
+            "label": "me/valid_data",
+        }
+    ]
+
+
 def test_scrub_text_redacts_common_secrets():
     from trackio import logbook_trace
 

--- a/trackio/frontend_templates/logbook/logbook.css
+++ b/trackio/frontend_templates/logbook/logbook.css
@@ -720,6 +720,8 @@ body[data-view="workspace"] #sidebar-foot {
   border-radius: 0;
   background: none;
   padding: 12px 16px 12px 0;
+  overflow-y: auto;
+  max-height: 26em;
 }
 .jp-in-body .code-accordion {
   margin: 0;
@@ -1128,6 +1130,8 @@ table.board tr.linked-row:hover a {
   color: var(--muted);
 }
 .agent-hint code {
+  flex: 1 1 18rem;
+  min-width: 0;
   background: var(--code-bg);
   padding: 2px 9px;
   border-radius: 6px;
@@ -1135,6 +1139,9 @@ table.board tr.linked-row:hover a {
   font-size: 12px;
   font-weight: 500;
   color: var(--ink);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 .agent-hint .copy {
   flex: 0 0 auto;
@@ -1552,7 +1559,7 @@ table.board tr.linked-row:hover a {
   font-family: var(--mono);
   font-size: 12px;
 }
-.repo-ref-link {
+#page .repo-ref-link {
   display: inline-block;
   margin-top: 18px;
   padding: 8px 14px;
@@ -1562,7 +1569,9 @@ table.board tr.linked-row:hover a {
   font-weight: 600;
   text-decoration: none;
 }
-.repo-ref-link:hover {
+#page .repo-ref-link:hover,
+#page .repo-ref-link:focus-visible {
+  color: #fff;
   filter: brightness(0.95);
 }
 .view-eyebrow {

--- a/trackio/frontend_templates/logbook/logbook.js
+++ b/trackio/frontend_templates/logbook/logbook.js
@@ -1065,6 +1065,23 @@
     return url.split(marker)[1].split(/[?#]/)[0].replace(/\/$/, "");
   }
 
+  function validHfSegment(value) {
+    return Boolean(
+      value &&
+      value.length <= 96 &&
+      /^[A-Za-z0-9_.-]+$/.test(value) &&
+      !/^[.-]|[.-]$|--|\.\./.test(value)
+    );
+  }
+
+  function validHfRepoId(parts) {
+    return (
+      parts.length === 2 &&
+      parts.join("/").length <= 96 &&
+      parts.every(validHfSegment)
+    );
+  }
+
   function classifyResource(url) {
     if (IMG_URL.test(url)) {
       return null;
@@ -1094,29 +1111,39 @@
         local: true,
       };
     }
-    if ((m = url.match(/huggingface\.co\/buckets\/[^#\s]+#(.+)/))) {
-      return { kind: "artifact", id: decodeURIComponent(m[1]), url };
+    if ((m = url.match(/huggingface\.co\/buckets\/([^/#\s]+\/[^/#\s]+)#(.+)/))) {
+      if (!validHfRepoId(m[1].split("/"))) return null;
+      return { kind: "artifact", id: decodeURIComponent(m[2]), url };
     }
-    if (/huggingface\.co\/datasets\/[^/]+\/[^/]+/.test(url)) {
-      return { kind: "dataset", id: hfId(url, "/datasets/"), url };
+    if (/huggingface\.co\/datasets\//.test(url)) {
+      const parts = hfId(url, "/datasets/").split("/").slice(0, 2);
+      if (!validHfRepoId(parts)) return null;
+      return { kind: "dataset", id: parts.join("/"), url };
     }
-    if (/huggingface\.co\/spaces\/[^/]+\/[^/]+/.test(url)) {
-      return { kind: "space", id: hfId(url, "/spaces/"), url };
+    if (/huggingface\.co\/spaces\//.test(url)) {
+      const parts = hfId(url, "/spaces/").split("/").slice(0, 2);
+      if (!validHfRepoId(parts)) return null;
+      return { kind: "space", id: parts.join("/"), url };
     }
     if (/huggingface\.co\/jobs\//.test(url)) {
-      const parts = hfId(url, "/jobs/").split("/");
-      const jid = parts[1] || "";
+      const parts = hfId(url, "/jobs/").split("/").slice(0, 2);
+      if (!validHfRepoId(parts)) return null;
+      const jid = parts[1];
       return {
         kind: "job",
-        id: parts[0] + (jid ? ` · ${jid.slice(0, 12)}${jid.length > 12 ? "…" : ""}` : ""),
+        id: parts[0] + ` · ${jid.slice(0, 12)}${jid.length > 12 ? "…" : ""}`,
         url,
       };
     }
     if (/huggingface\.co\/buckets\//.test(url)) {
-      return { kind: "bucket", id: hfId(url, "/buckets/"), url };
+      const parts = hfId(url, "/buckets/").split("/").slice(0, 2);
+      if (!validHfRepoId(parts)) return null;
+      return { kind: "bucket", id: parts.join("/"), url };
     }
     if (/huggingface\.co\/papers\//.test(url)) {
-      return { kind: "paper", id: `Paper ${hfId(url, "/papers/")}`, url };
+      const id = hfId(url, "/papers/").split("/")[0];
+      if (!validHfSegment(id)) return null;
+      return { kind: "paper", id: `Paper ${id}`, url };
     }
     if ((m = url.match(/arxiv\.org\/(?:abs|pdf)\/([^?#\s]+)/))) {
       return { kind: "paper", id: `arXiv:${m[1].replace(/\.pdf$/, "")}`, url };
@@ -1126,7 +1153,7 @@
     }
     if ((m = url.match(/huggingface\.co\/([^?#]+)/))) {
       const rest = m[1].replace(/\/$/, "");
-      if (/^[^/]+\/[^/]+$/.test(rest) && !HF_NON_MODEL_PREFIX.test(rest)) {
+      if (validHfRepoId(rest.split("/")) && !HF_NON_MODEL_PREFIX.test(rest)) {
         return { kind: "model", id: rest, url };
       }
     }
@@ -2027,16 +2054,22 @@
   }
 
   async function probeRepoAccessible(ref) {
-    if (!ref) return false;
-    if (ref.private === true) return false;
-    if (ref.repo_type === "dataset" && ref.repo_id) {
-      const meta = await getJSON(
-        "https://huggingface.co/api/datasets/" + ref.repo_id
-      );
-      return meta !== null;
+    if (!ref || !ref.repo_id) return false;
+    let url = "";
+    if (ref.repo_type === "dataset") {
+      url = "https://huggingface.co/api/datasets/" + ref.repo_id;
+    } else if (ref.repo_type === "bucket") {
+      url = "https://huggingface.co/api/buckets/" + ref.repo_id;
     }
-    // HF Buckets have no simple anonymous listing API; trust the manifest flag.
-    return ref.private === false;
+    if (!url) return ref.private === false;
+    try {
+      const response = await fetch(url, { cache: "no-store" });
+      if (!response.ok) return false;
+      const metadata = await response.json();
+      return metadata.private !== true;
+    } catch (error) {
+      return false;
+    }
   }
 
   async function renderRepoReference(ref, kind, page, renderId) {
@@ -2049,10 +2082,6 @@
           `These ${noun} live in a private repository. ` +
           "Open it on the Hub to view them.",
       });
-    if (ref.private === true) {
-      page.appendChild(linkOnly());
-      return;
-    }
     const accessible = await probeRepoAccessible(ref);
     if (renderId !== RENDER_SEQUENCE) return;
     if (!accessible) {
@@ -2329,8 +2358,49 @@
     "Papers",
   ];
 
+  function hubRefFromRepoRef(ref) {
+    if (!ref || !ref.repo_id || !ref.repo_url) return null;
+    if (ref.repo_type === "dataset") {
+      return { url: ref.repo_url, type: "Datasets", label: ref.repo_id };
+    }
+    if (ref.repo_type === "bucket") {
+      return { url: ref.repo_url, type: "Buckets", label: ref.repo_id };
+    }
+    return null;
+  }
+
+  async function publicAssociatedHubRefs() {
+    const refs = [MANIFEST.traces_ref, MANIFEST.workspace_ref].filter(Boolean);
+    const publicStates = await Promise.all(refs.map(probeRepoAccessible));
+    return refs
+      .filter((ref, index) => publicStates[index])
+      .map(hubRefFromRepoRef)
+      .filter(Boolean);
+  }
+
+  function mergeHubRefs(...groups) {
+    const merged = [];
+    const seen = new Set();
+    groups.flat().forEach((ref) => {
+      if (!validHubRef(ref)) return;
+      const key = `${ref.type || "Other"}:${ref.label || ref.url}`;
+      if (seen.has(key)) return;
+      seen.add(key);
+      merged.push(ref);
+    });
+    return merged;
+  }
+
+  function validHubRef(ref) {
+    if (!ref || !ref.url) return false;
+    if (classifyResource(ref.url)) return true;
+    const match = ref.url.match(/huggingface\.co\/collections\/([^/?#]+\/[^/?#]+)/);
+    return Boolean(match && validHfRepoId(match[1].split("/")));
+  }
+
   function renderHubRefs(refs) {
-    if (!Array.isArray(refs) || !refs.length) return null;
+    const validRefs = Array.isArray(refs) ? refs.filter(validHubRef) : [];
+    if (!validRefs.length) return null;
     const section = document.createElement("section");
     section.className = "workspace-hub";
     const heading = document.createElement("h2");
@@ -2344,8 +2414,7 @@
     heading.appendChild(document.createTextNode("Hugging Face artifacts"));
     section.appendChild(heading);
     const byType = new Map();
-    refs.forEach((ref) => {
-      if (!ref || !ref.url) return;
+    validRefs.forEach((ref) => {
       const type = ref.type || "Other";
       if (!byType.has(type)) byType.set(type, []);
       byType.get(type).push(ref);
@@ -2392,8 +2461,7 @@
     const entries = [];
     if (files && files.length) entries.push({ id: "ws-files", label: "Files" });
     const counts = new Map();
-    (Array.isArray(hubRefs) ? hubRefs : []).forEach((ref) => {
-      if (!ref || !ref.url) return;
+    (Array.isArray(hubRefs) ? hubRefs : []).filter(validHubRef).forEach((ref) => {
       const type = ref.type || "Other";
       counts.set(type, (counts.get(type) || 0) + 1);
     });
@@ -2457,6 +2525,9 @@
     }
     if (renderId !== RENDER_SEQUENCE) return;
     page.innerHTML = "";
+    const associatedHubRefs = await publicAssociatedHubRefs();
+    if (renderId !== RENDER_SEQUENCE) return;
+    const hubRefs = mergeHubRefs(workspace.hub_refs || [], associatedHubRefs);
     const shell = document.createElement("div");
     shell.className = "workspace-shell";
     const header = document.createElement("header");
@@ -2500,10 +2571,10 @@
         )
       );
     }
-    const hub = renderHubRefs(workspace.hub_refs);
+    const hub = renderHubRefs(hubRefs);
     if (hub) shell.appendChild(hub);
     page.appendChild(shell);
-    buildWorkspaceSidebar(workspaceSidebarEntries(files, workspace.hub_refs));
+    buildWorkspaceSidebar(workspaceSidebarEntries(files, hubRefs));
     window.scrollTo({ top: 0, behavior: "auto" });
   }
 

--- a/trackio/logbook.py
+++ b/trackio/logbook.py
@@ -69,6 +69,7 @@ CELL_RE = re.compile(
 
 # ---- Hugging Face artifact detection (workspace "Hugging Face artifacts") ----
 _HF_URL_RE = re.compile(r"https://huggingface\.co/[^\s)\"'`<>\]]+")
+_HF_ID_SEGMENT_RE = re.compile(r"^[A-Za-z0-9_.-]+$")
 # Path prefixes on huggingface.co that are NOT bare model repos.
 _HF_RESERVED_PREFIXES = {
     "datasets",
@@ -389,6 +390,26 @@ def _walk(node: dict):
         yield from _walk(child)
 
 
+def _valid_hf_segment(value: str) -> bool:
+    return bool(
+        value
+        and len(value) <= 96
+        and _HF_ID_SEGMENT_RE.fullmatch(value)
+        and not value.startswith(("-", "."))
+        and not value.endswith(("-", "."))
+        and "--" not in value
+        and ".." not in value
+    )
+
+
+def _valid_hf_repo_id(segments: list[str]) -> bool:
+    return (
+        len(segments) == 2
+        and len("/".join(segments)) <= 96
+        and all(_valid_hf_segment(segment) for segment in segments)
+    )
+
+
 def _classify_hf_url(url: str) -> dict | None:
     """Classify a huggingface.co URL into a Hugging Face artifact reference.
 
@@ -406,24 +427,41 @@ def _classify_hf_url(url: str) -> dict | None:
         return None
     head = segments[0].lower()
     if head == "jobs":
-        typ, label = "Jobs", "/".join(segments[1:]) or core
+        identity = segments[1:3]
+        if not _valid_hf_repo_id(identity):
+            return None
+        typ, label = "Jobs", "/".join(identity)
     elif head == "datasets":
-        typ, label = "Datasets", "/".join(segments[1:3]) or core
+        identity = segments[1:3]
+        if not _valid_hf_repo_id(identity):
+            return None
+        typ, label = "Datasets", "/".join(identity)
     elif head == "spaces":
-        typ, label = "Spaces", "/".join(segments[1:3]) or core
+        identity = segments[1:3]
+        if not _valid_hf_repo_id(identity):
+            return None
+        typ, label = "Spaces", "/".join(identity)
     elif head == "buckets" or (
         head == "api" and len(segments) > 1 and segments[1].lower() == "buckets"
     ):
         rest = segments[2:] if head == "api" else segments[1:]
-        typ, label = "Buckets", "/".join(rest[:2]) or core
+        identity = rest[:2]
+        if not _valid_hf_repo_id(identity):
+            return None
+        typ, label = "Buckets", "/".join(identity)
     elif head == "collections":
-        typ, label = "Collections", "/".join(segments[1:3]) or core
+        identity = segments[1:3]
+        if not _valid_hf_repo_id(identity):
+            return None
+        typ, label = "Collections", "/".join(identity)
     elif head == "papers":
-        typ, label = "Papers", "/".join(segments[1:]) or core
+        identity = segments[1:2]
+        if not _valid_hf_segment(identity[0] if identity else ""):
+            return None
+        typ, label = "Papers", identity[0]
     elif head in _HF_RESERVED_PREFIXES:
         return None
-    elif len(segments) == 2:
-        # Conservative: only a bare `owner/name` path is treated as a model.
+    elif len(segments) == 2 and _valid_hf_repo_id(segments):
         typ, label = "Models", "/".join(segments)
     else:
         return None


### PR DESCRIPTION
## Summary

- constrain long logbook input code blocks with the same vertical scrolling behavior as outputs
- truncate overlong CLI read commands visually while preserving the full clipboard value
- restore readable white text and focus styling on the Open on the Hub button
- reject malformed Hugging Face resource IDs, including template placeholders, during scanning and when rendering stale manifests
- recheck trace dataset and Bucket visibility against Hub APIs so stores made public after publication appear in Workspace and no longer use stale private-state messaging

## Root causes

Input blocks lacked the output block height constraints. The CLI hint could not shrink. A generic link rule overrode the Hub button text color. Resource scanning accepted incomplete template paths. The viewer also trusted publication-time private flags and did not probe public Buckets.

## Validation

- 64 logbook unit tests passed
- 7 Playwright logbook UI tests passed
- Ruff import checks and formatting passed
- JavaScript syntax check passed

A broader pytest run was started but intentionally not awaited; the focused logbook suites are green.