### PR TITLE
Improve logbook layout and public repository views

### DIFF
--- a/.changeset/mean-wolves-mate.md
+++ b/.changeset/mean-wolves-mate.md
@@ -1,5 +1,5 @@
 ---
-"trackio": minor
+"trackio": patch
 ---
 
 feat:Improve logbook layout and public repository views

--- a/.changeset/mean-wolves-mate.md
+++ b/.changeset/mean-wolves-mate.md
@@ -1,0 +1,5 @@
+---
+"trackio": minor
+---
+
+feat:Improve logbook layout and public repository views

--- a/examples/mock-trackio-logbook-session.py
+++ b/examples/mock-trackio-logbook-session.py
@@ -72,6 +72,49 @@ def write_file(path: Path, text: str) -> None:
     path.write_text(textwrap.dedent(text).strip() + "\n", encoding="utf-8")
 
 
+def accuracy_comparison_figure() -> tuple[str, str]:
+    """Return a dependency-free SVG figure and its underlying data."""
+    data = [
+        {"method": "Direct answer", "exact_match": 29.7},
+        {"method": "Chain of thought", "exact_match": 41.4},
+        {"method": "Self-consistency", "exact_match": 56.3},
+    ]
+    html = """
+    <figure style="margin:0;padding:8px 4px;font-family:system-ui,sans-serif;color:#1f2937">
+      <figcaption style="margin:0 0 12px;font-size:14px;font-weight:650">
+        Exact-match accuracy by prompting method
+      </figcaption>
+      <svg viewBox="0 0 760 280" role="img"
+           aria-label="Horizontal bar chart comparing exact-match accuracy"
+           style="display:block;width:100%;height:auto">
+        <g fill="none" stroke="#e5e7eb" stroke-width="1">
+          <path d="M190 28V238M350 28V238M510 28V238M670 28V238" />
+        </g>
+        <g fill="#6b7280" font-size="12" text-anchor="middle">
+          <text x="190" y="260">0%</text>
+          <text x="350" y="260">20%</text>
+          <text x="510" y="260">40%</text>
+          <text x="670" y="260">60%</text>
+        </g>
+        <g font-size="14">
+          <text x="174" y="69" text-anchor="end" fill="#4b5563">Direct answer</text>
+          <rect x="190" y="45" width="237.6" height="36" rx="6" fill="#fed7aa" />
+          <text x="438" y="69" fill="#9a3412" font-weight="650">29.7%</text>
+
+          <text x="174" y="139" text-anchor="end" fill="#4b5563">Chain of thought</text>
+          <rect x="190" y="115" width="331.2" height="36" rx="6" fill="#fb923c" />
+          <text x="532" y="139" fill="#9a3412" font-weight="650">41.4%</text>
+
+          <text x="174" y="209" text-anchor="end" fill="#4b5563">Self-consistency</text>
+          <rect x="190" y="185" width="450.4" height="36" rx="6" fill="#ea580c" />
+          <text x="651" y="209" fill="#9a3412" font-weight="650">56.3%</text>
+        </g>
+      </svg>
+    </figure>
+    """
+    return textwrap.dedent(html).strip(), json.dumps(data, indent=2)
+
+
 def seed_repro_files(workspace: Path) -> None:
     write_file(
         workspace / "configs" / "baseline.json",
@@ -750,6 +793,14 @@ def build_logbook(workspace: Path) -> None:
             '{"samples_per_problem": 20, "temperature": 0.7, "vote": "majority"}\n'
             "````",
             title="Sampling tradeoff",
+        )
+        figure_html, figure_data = accuracy_comparison_figure()
+        logbook.add_figure_cell(
+            proj,
+            self_consistency,
+            html=figure_html,
+            raw=figure_data,
+            title="Accuracy comparison",
         )
 
         error_analysis = logbook.ensure_page(proj, "Error analysis")

--- a/tests/ui/test_logbook_viewer.py
+++ b/tests/ui/test_logbook_viewer.py
@@ -53,6 +53,11 @@ def test_logbook_renders_pages_as_single_document(tmp_path, monkeypatch):
                 expect(page.locator("#tree a")).to_have_count(2)
                 expect(page.locator(".context-rail")).to_have_count(0)
 
+                content_box = page.locator("#page").bounding_box()
+                assert content_box is not None
+                assert content_box["x"] == 320
+                assert 1440 - content_box["x"] - content_box["width"] == 320
+
                 page.get_by_role("link", name="Second experiment").first.click()
                 expect(page).to_have_url(re.compile(r"#/view/code/second-experiment$"))
                 expect(page.locator("#tree a.active")).to_have_text(
@@ -310,6 +315,7 @@ def test_public_repo_visibility_and_hub_ref_filtering(tmp_path, monkeypatch):
         "repo_type": "dataset",
         "repo_url": "https://huggingface.co/datasets/me/trace-data",
         "private": True,
+        "viewer_path": "trackio/index.json",
     }
     manifest["workspace_ref"] = {
         "repo_id": "me/workspace-files",
@@ -366,12 +372,107 @@ def test_public_repo_visibility_and_hub_ref_filtering(tmp_path, monkeypatch):
                         body=public_metadata,
                     ),
                 )
+                page.route(
+                    "https://huggingface.co/api/buckets/me/workspace-files/tree",
+                    lambda route: route.fulfill(
+                        status=200,
+                        content_type="application/json",
+                        body=json.dumps(
+                            [
+                                {
+                                    "type": "file",
+                                    "path": "workspace/results/metrics.csv",
+                                    "size": 128,
+                                    "mtime": "2026-07-21T10:00:00Z",
+                                },
+                                {
+                                    "type": "file",
+                                    "path": "logbook-files/results/metrics.csv",
+                                    "size": 128,
+                                    "mtime": "2026-07-21T10:00:00Z",
+                                },
+                            ]
+                        ),
+                    ),
+                )
+                page.route(
+                    "https://huggingface.co/datasets/me/trace-data/resolve/main/trackio/index.json",
+                    lambda route: route.fulfill(
+                        status=200,
+                        content_type="application/json",
+                        body=json.dumps(
+                            {
+                                "schema_version": 1,
+                                "sessions": [
+                                    {
+                                        "id": "remote-session",
+                                        "title": "Published reproduction session",
+                                        "index_file": "traces/remote-session/index.json",
+                                    }
+                                ],
+                            }
+                        ),
+                    ),
+                )
+                page.route(
+                    "https://huggingface.co/datasets/me/trace-data/resolve/main/trackio/traces/remote-session/index.json",
+                    lambda route: route.fulfill(
+                        status=200,
+                        content_type="application/json",
+                        body=json.dumps(
+                            {
+                                "id": "remote-session",
+                                "title": "Published reproduction session",
+                                "event_count": 1,
+                                "started_at": "2026-07-21T10:00:00Z",
+                                "ended_at": "2026-07-21T10:00:01Z",
+                                "duration_ms": 1000,
+                                "chunks": [
+                                    {
+                                        "file": "traces/remote-session/events-0000.json",
+                                        "count": 1,
+                                    }
+                                ],
+                            }
+                        ),
+                    ),
+                )
+                page.route(
+                    "https://huggingface.co/datasets/me/trace-data/resolve/main/trackio/traces/remote-session/events-0000.json",
+                    lambda route: route.fulfill(
+                        status=200,
+                        content_type="application/json",
+                        body=json.dumps(
+                            {
+                                "events": [
+                                    {
+                                        "kind": "message",
+                                        "sequence": 1,
+                                        "title": "Assistant",
+                                        "text": "Loaded from the public trace dataset.",
+                                    }
+                                ]
+                            }
+                        ),
+                    ),
+                )
                 base_url = f"http://127.0.0.1:{server.server_address[1]}/"
 
                 page.goto(base_url + "#/view/workspace")
-                expect(page.locator(".repo-ref-card")).to_contain_text(
-                    "published to a public repository"
+                expect(page.locator(".repo-ref-card")).to_have_count(0)
+                expect(page.locator(".workspace-file")).to_have_count(1)
+                expect(page.locator(".workspace-file")).to_contain_text("metrics.csv")
+                expect(page.locator(".workspace-header")).to_contain_text(
+                    "1 files · 128 B"
                 )
+                expect(page.locator("#tree .tree-label")).to_have_text("Artifacts")
+                expect(page.locator("#tree a").first).to_have_text("Workspace files")
+                expect(page.locator("#tree")).not_to_contain_text("§")
+                expect(
+                    page.get_by_role(
+                        "heading", name="Linked Hugging Face artifacts", exact=True
+                    )
+                ).to_be_visible()
                 expect(
                     page.locator('.workspace-hub-link[href$="/datasets/me/trace-data"]')
                 ).to_have_count(1)
@@ -385,14 +486,16 @@ def test_public_repo_visibility_and_hub_ref_filtering(tmp_path, monkeypatch):
                 )
 
                 page.goto(base_url + "#/view/trace")
-                expect(page.locator(".repo-ref-card")).to_contain_text(
-                    "published to a public repository"
+                expect(page.locator(".repo-ref-card")).to_have_count(0)
+                expect(page.locator(".trace-session-title")).to_have_text(
+                    "Published reproduction session"
                 )
-                hub_link = page.get_by_role("link", name="Open on the Hub")
-                expect(hub_link).to_be_visible()
-                assert (
-                    hub_link.evaluate("el => getComputedStyle(el).color")
-                    == "rgb(255, 255, 255)"
+                expect(page.locator(".trace-entry")).to_contain_text(
+                    "Loaded from the public trace dataset."
+                )
+                expect(page.locator("#tree .tree-label")).to_have_text("Sessions")
+                expect(page.locator("#tree a")).to_have_text(
+                    "Published reproduction session"
                 )
                 browser.close()
         finally:

--- a/tests/ui/test_logbook_viewer.py
+++ b/tests/ui/test_logbook_viewer.py
@@ -55,9 +55,11 @@ def test_logbook_renders_pages_as_single_document(tmp_path, monkeypatch):
 
                 content_box = page.locator("#page").bounding_box()
                 assert content_box is not None
-                client_width = page.evaluate("document.documentElement.clientWidth")
+                paper_box = page.locator("#content").bounding_box()
+                assert paper_box is not None
+                paper_right = paper_box["x"] + paper_box["width"]
                 assert content_box["x"] == 320
-                assert client_width - content_box["x"] - content_box["width"] == 320
+                assert paper_right - content_box["x"] - content_box["width"] == 320
 
                 page.get_by_role("link", name="Second experiment").first.click()
                 expect(page).to_have_url(re.compile(r"#/view/code/second-experiment$"))

--- a/tests/ui/test_logbook_viewer.py
+++ b/tests/ui/test_logbook_viewer.py
@@ -55,8 +55,9 @@ def test_logbook_renders_pages_as_single_document(tmp_path, monkeypatch):
 
                 content_box = page.locator("#page").bounding_box()
                 assert content_box is not None
+                client_width = page.evaluate("document.documentElement.clientWidth")
                 assert content_box["x"] == 320
-                assert 1440 - content_box["x"] - content_box["width"] == 320
+                assert client_width - content_box["x"] - content_box["width"] == 320
 
                 page.get_by_role("link", name="Second experiment").first.click()
                 expect(page).to_have_url(re.compile(r"#/view/code/second-experiment$"))

--- a/tests/ui/test_logbook_viewer.py
+++ b/tests/ui/test_logbook_viewer.py
@@ -498,6 +498,7 @@ def test_public_repo_visibility_and_hub_ref_filtering(tmp_path, monkeypatch):
                 expect(page.locator("#tree a")).to_have_text(
                     "Published reproduction session"
                 )
+                assert page.evaluate("window.scrollY") == 0
                 browser.close()
         finally:
             server.shutdown()

--- a/tests/unit/test_logbook.py
+++ b/tests/unit/test_logbook.py
@@ -95,6 +95,29 @@ def test_preview_manifest_refreshes_active_trace_and_workspace(proj, tmp_path):
     assert workspace["files"][0]["path"] == "checkpoint.safetensors"
 
 
+def test_trace_dataset_export_includes_web_viewer_bundle(proj, tmp_path):
+    from trackio import logbook_trace
+
+    trace_path = tmp_path / "public-session.jsonl"
+    trace_path.write_text(
+        json.dumps({"role": "user", "content": "Published trace"}) + "\n",
+        encoding="utf-8",
+    )
+    logbook.attach_trace(proj, trace_path, title="Public session")
+
+    export_dir, count = logbook_trace.prepare_agent_trace_dataset(proj)
+
+    assert count == 1
+    viewer_index = json.loads(
+        (export_dir / "trackio" / "index.json").read_text(encoding="utf-8")
+    )
+    assert viewer_index["sessions"][0]["title"] == "Public session"
+    session_index = export_dir / "trackio" / viewer_index["sessions"][0]["index_file"]
+    assert session_index.is_file()
+    session = json.loads(session_index.read_text(encoding="utf-8"))
+    assert (export_dir / "trackio" / session["chunks"][0]["file"]).is_file()
+
+
 def test_logbook_run_path_artifact_appears_without_trace(proj, tmp_path):
     checkpoint = tmp_path / "run-output.ckpt"
     checkpoint.write_bytes(b"checkpoint")

--- a/trackio/frontend_templates/logbook/logbook.css
+++ b/trackio/frontend_templates/logbook/logbook.css
@@ -12,6 +12,8 @@
   --grid-line: rgba(31, 41, 55, 0.02);
   --code-bg: #f3f4f6;
   --radius: 12px;
+  --sidebar-width: 280px;
+  --content-gutter: 40px;
   --serif: ui-serif, "Iowan Old Style", "Palatino Linotype", Georgia, serif;
   --sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial,
     sans-serif;
@@ -55,8 +57,8 @@ body[data-view="workspace"] #sidebar-foot {
 
 /* ---- sidebar (composition-book cover) ---- */
 #sidebar {
-  width: 280px;
-  flex: 0 0 280px;
+  width: var(--sidebar-width);
+  flex: 0 0 var(--sidebar-width);
   background: #17181c;
   color: #e7e7ea;
   position: sticky;
@@ -161,7 +163,13 @@ body[data-view="workspace"] #sidebar-foot {
 #content {
   flex: 1;
   min-width: 0;
-  padding: 24px 40px 120px;
+  padding: 24px
+    clamp(
+      var(--content-gutter),
+      calc(100vw - 960px),
+      calc(var(--sidebar-width) + var(--content-gutter))
+    )
+    120px var(--content-gutter);
   background-color: var(--paper);
   background-image:
     linear-gradient(var(--grid-line) 1px, transparent 1px),

--- a/trackio/frontend_templates/logbook/logbook.js
+++ b/trackio/frontend_templates/logbook/logbook.js
@@ -2218,7 +2218,7 @@
     const activeSessionId = route.sessionId || sessions[0].id;
     await ensureTraceSessionLoaded(activeSessionId);
     if (renderId !== RENDER_SEQUENCE) return;
-    scrollToTraceSession(activeSessionId);
+    scrollToTraceSession(route.sessionId);
   }
 
   function svgIcon(kind) {
@@ -2773,7 +2773,7 @@
       const sessions = MANIFEST.traces || [];
       const activeSessionId = route.sessionId || (sessions[0] || {}).id;
       ensureTraceSessionLoaded(activeSessionId);
-      scrollToTraceSession(activeSessionId);
+      scrollToTraceSession(route.sessionId);
       return;
     }
     renderCurrentView();

--- a/trackio/frontend_templates/logbook/logbook.js
+++ b/trackio/frontend_templates/logbook/logbook.js
@@ -1300,10 +1300,10 @@
     });
   }
 
-  function buildTraceTree(activeSessionId) {
+  function buildTraceTree(activeSessionId, traceSessions = MANIFEST.traces || []) {
     const tree = document.getElementById("tree");
     tree.innerHTML = "";
-    const sessions = MANIFEST.traces || [];
+    const sessions = traceSessions;
     if (!sessions.length) return;
     const label = document.createElement("div");
     label.className = "tree-label";
@@ -1386,6 +1386,34 @@
     const data = await response.json();
     if (cacheResult) DATA_CACHE[file] = data;
     return data;
+  }
+
+  async function fetchRemoteData(url, cacheResult = true) {
+    if (cacheResult && DATA_CACHE[url]) return DATA_CACHE[url];
+    const response = await fetch(url, { cache: "no-store" });
+    if (!response.ok) throw new Error(`Could not load ${url}`);
+    const data = await response.json();
+    if (cacheResult) DATA_CACHE[url] = data;
+    return data;
+  }
+
+  function encodeRepoPath(path) {
+    return String(path || "")
+      .split("/")
+      .map((part) => encodeURIComponent(part))
+      .join("/");
+  }
+
+  function repoFileUrl(ref, path) {
+    const revision = encodeURIComponent(ref.revision || "main");
+    const encodedPath = encodeRepoPath(path);
+    if (ref.repo_type === "dataset") {
+      return `https://huggingface.co/datasets/${ref.repo_id}/resolve/${revision}/${encodedPath}`;
+    }
+    if (ref.repo_type === "bucket") {
+      return `https://huggingface.co/buckets/${ref.repo_id}/resolve/${encodedPath}`;
+    }
+    return "";
   }
 
   function allNodes() {
@@ -1873,7 +1901,7 @@
     return "/view/trace/" + id;
   }
 
-  function buildTraceSession(session, index) {
+  function buildTraceSession(session, index, loadTraceData = fetchData) {
     const sec = document.createElement("section");
     sec.className = "trace-session";
     sec.id = traceSessionAnchor(session.id);
@@ -1968,7 +1996,7 @@
       try {
         // Event chunks can be large. Do not retain the parsed JSON in DATA_CACHE;
         // the rendered DOM is the only long-lived copy.
-        const chunk = await fetchData(descriptor.file, false);
+        const chunk = await loadTraceData(descriptor.file, false);
         const events = chunk.events || [];
         events.forEach((event) => {
           if (
@@ -2097,25 +2125,64 @@
     );
   }
 
+  async function loadPublicTraceSource(ref) {
+    const viewerPath = String(ref.viewer_path || "trackio/index.json")
+      .split("/")
+      .filter((part) => part && part !== "." && part !== "..")
+      .join("/");
+    const slash = viewerPath.lastIndexOf("/");
+    const root = slash >= 0 ? viewerPath.slice(0, slash + 1) : "";
+    const index = await fetchRemoteData(repoFileUrl(ref, viewerPath));
+    const sessions = Array.isArray(index.sessions) ? index.sessions : [];
+    if (!sessions.length) throw new Error("The trace dataset has no sessions");
+    return {
+      sessions,
+      loadData: (file, cacheResult = true) =>
+        fetchRemoteData(repoFileUrl(ref, root + file), cacheResult),
+    };
+  }
+
   async function renderTrace(route, renderId) {
     const page = document.getElementById("page");
     page.innerHTML = "";
     page.className = "trace-page";
-    const sessions = MANIFEST.traces || [];
+    let sessions = MANIFEST.traces || [];
+    let loadTraceData = fetchData;
     if (!sessions.length) {
       updateViewTabs({ view: "trace" });
       if (MANIFEST.traces_ref && MANIFEST.traces_ref.repo_url) {
-        await renderRepoReference(MANIFEST.traces_ref, "traces", page, renderId);
+        const accessible = await probeRepoAccessible(MANIFEST.traces_ref);
+        if (renderId !== RENDER_SEQUENCE) return;
+        if (accessible) {
+          try {
+            const remote = await loadPublicTraceSource(MANIFEST.traces_ref);
+            sessions = remote.sessions;
+            loadTraceData = remote.loadData;
+            buildTraceTree(route.sessionId, sessions);
+          } catch (error) {
+            page.appendChild(
+              repoRefCard(MANIFEST.traces_ref, {
+                title: "Agent traces",
+                message:
+                  "These agent traces are published to a public repository on the Hub, but the web timeline could not be loaded.",
+              })
+            );
+            return;
+          }
+        } else {
+          await renderRepoReference(MANIFEST.traces_ref, "traces", page, renderId);
+          return;
+        }
+      } else {
+        page.appendChild(
+          emptyView(
+            "No agent sessions attached yet",
+            "Attach the active session once and Trackio will keep its trace refreshed here while you work. The session stays local until you explicitly publish it.",
+            "trackio logbook attach trace <session.jsonl>"
+          )
+        );
         return;
       }
-      page.appendChild(
-        emptyView(
-          "No agent sessions attached yet",
-          "Attach the active session once and Trackio will keep its trace refreshed here while you work. The session stays local until you explicitly publish it.",
-          "trackio logbook attach trace <session.jsonl>"
-        )
-      );
-      return;
     }
     updateViewTabs({ view: "trace" });
 
@@ -2127,7 +2194,7 @@
     try {
       loaded = await Promise.all(
         sessions.map(async (session) => {
-          const index = await fetchData(session.index_file);
+          const index = await loadTraceData(session.index_file);
           return { session, index };
         })
       );
@@ -2145,7 +2212,7 @@
     const shell = document.createElement("div");
     shell.className = "trace-shell";
     loaded.forEach(({ session, index }) => {
-      shell.appendChild(buildTraceSession(session, index));
+      shell.appendChild(buildTraceSession(session, index, loadTraceData));
     });
     page.appendChild(shell);
     const activeSessionId = route.sessionId || sessions[0].id;
@@ -2411,7 +2478,7 @@
     hubLogo.alt = "";
     hubLogo.setAttribute("aria-hidden", "true");
     heading.appendChild(hubLogo);
-    heading.appendChild(document.createTextNode("Hugging Face artifacts"));
+    heading.appendChild(document.createTextNode("Linked Hugging Face artifacts"));
     section.appendChild(heading);
     const byType = new Map();
     validRefs.forEach((ref) => {
@@ -2459,7 +2526,9 @@
 
   function workspaceSidebarEntries(files, hubRefs) {
     const entries = [];
-    if (files && files.length) entries.push({ id: "ws-files", label: "Files" });
+    if (files && files.length) {
+      entries.push({ id: "ws-files", label: "Workspace files" });
+    }
     const counts = new Map();
     (Array.isArray(hubRefs) ? hubRefs : []).filter(validHubRef).forEach((ref) => {
       const type = ref.type || "Other";
@@ -2481,18 +2550,14 @@
     if (!entries || !entries.length) return;
     const label = document.createElement("div");
     label.className = "tree-label";
-    label.textContent = "Sections";
+    label.textContent = "Artifacts";
     tree.appendChild(label);
     entries.forEach((entry) => {
       const a = document.createElement("a");
       a.href = "#/view/workspace";
       a.className = "depth-0";
       a.dataset.section = entry.id;
-      const mark = document.createElement("span");
-      mark.className = "tree-mark";
-      mark.textContent = "§";
-      a.appendChild(mark);
-      a.appendChild(document.createTextNode(" " + entry.label));
+      a.textContent = entry.label;
       a.addEventListener("click", (event) => {
         event.preventDefault();
         const target = document.getElementById(entry.id);
@@ -2504,6 +2569,83 @@
       });
       tree.appendChild(a);
     });
+  }
+
+  function workspaceTypeFromPath(path) {
+    const dot = path.lastIndexOf(".");
+    const ext = dot >= 0 ? path.slice(dot).toLowerCase() : "";
+    if (
+      [
+        ".pt",
+        ".pth",
+        ".ckpt",
+        ".safetensors",
+        ".gguf",
+        ".onnx",
+        ".pkl",
+        ".joblib",
+        ".h5",
+        ".tflite",
+        ".pb",
+      ].includes(ext)
+    ) {
+      return "model";
+    }
+    if (
+      [
+        ".npz",
+        ".npy",
+        ".parquet",
+        ".csv",
+        ".tsv",
+        ".arrow",
+        ".jsonl",
+        ".feather",
+        ".msgpack",
+      ].includes(ext)
+    ) {
+      return "dataset";
+    }
+    return ext.replace(/^\./, "") || "file";
+  }
+
+  async function loadPublicWorkspace(ref) {
+    if (!(await probeRepoAccessible(ref))) return null;
+    const response = await fetch(
+      `https://huggingface.co/api/buckets/${ref.repo_id}/tree`,
+      { cache: "no-store" }
+    );
+    if (!response.ok) throw new Error("Could not load the public Bucket");
+    const entries = await response.json();
+    const prefix = "workspace/";
+    const files = (Array.isArray(entries) ? entries : [])
+      .filter(
+        (item) =>
+          item &&
+          item.type === "file" &&
+          typeof item.path === "string" &&
+          item.path.startsWith(prefix)
+      )
+      .map((item) => {
+        const path = item.path.slice(prefix.length);
+        return {
+          path,
+          name: path.split("/").pop() || path,
+          type: workspaceTypeFromPath(path),
+          size: Number(item.size) || 0,
+          modified_at: item.mtime || item.uploadedAt || "",
+          sessions: [],
+          bucket_url: `${ref.repo_url}#${encodeRepoPath(item.path)}`,
+          download_url: repoFileUrl(ref, item.path),
+        };
+      });
+    return {
+      schema_version: 1,
+      bucket_id: ref.repo_id,
+      file_count: files.length,
+      total_size: files.reduce((sum, file) => sum + file.size, 0),
+      files,
+    };
   }
 
   async function renderWorkspace(renderId) {
@@ -2522,6 +2664,25 @@
       page.innerHTML = "";
       page.appendChild(emptyView("Workspace unavailable", "The workspace inventory could not be loaded."));
       return;
+    }
+    if (renderId !== RENDER_SEQUENCE) return;
+    if (
+      !(workspace.files || []).length &&
+      MANIFEST.workspace_ref &&
+      MANIFEST.workspace_ref.repo_url
+    ) {
+      try {
+        const remoteWorkspace = await loadPublicWorkspace(MANIFEST.workspace_ref);
+        if (remoteWorkspace && remoteWorkspace.files.length) {
+          workspace = {
+            ...workspace,
+            ...remoteWorkspace,
+            hub_refs: workspace.hub_refs || [],
+          };
+        }
+      } catch (error) {
+        // Keep the repository card below as a graceful fallback.
+      }
     }
     if (renderId !== RENDER_SEQUENCE) return;
     page.innerHTML = "";

--- a/trackio/logbook.py
+++ b/trackio/logbook.py
@@ -2626,6 +2626,7 @@ def _push(
             "repo_type": "dataset",
             "repo_url": f"https://huggingface.co/datasets/{trace_dataset}",
             "private": not repos_public,
+            "viewer_path": "trackio/index.json",
         }
 
     workspace_ref = None

--- a/trackio/logbook_trace.py
+++ b/trackio/logbook_trace.py
@@ -1442,6 +1442,20 @@ def prepare_agent_trace_dataset(proj: Path) -> tuple[Path, int]:
                 events.extend(chunk_data.get("events") or [])
             _write_sts_trace(destination, index, events)
         exported += 1
+
+    # Keep the Hub-native JSONL files at the dataset root for the Agent Traces
+    # viewer, and publish Trackio's normalized/chunked representation alongside
+    # them. A public logbook Space can load this bundle directly and render the
+    # same timeline as the local viewer without exposing it in the Space itself.
+    trace_source = proj / "logbook" / "traces"
+    trace_bundle = export_dir / "trackio"
+    trace_bundle.mkdir()
+    shutil.copy2(trace_source / "index.json", trace_bundle / "index.json")
+    bundled_sessions = trace_bundle / "traces"
+    bundled_sessions.mkdir()
+    for session_dir in trace_source.iterdir():
+        if session_dir.is_dir():
+            shutil.copytree(session_dir, bundled_sessions / session_dir.name)
     (export_dir / "README.md").write_text(
         "---\n"
         "viewer_mode: traces\n"


### PR DESCRIPTION
## What changed

- balance desktop logbook content with a matching right-side reading gutter
- render public Agent Trace datasets through the native timeline UI
- render public Workspace Buckets through the native file browser
- publish normalized trace-viewer bundles alongside Hub-native JSONL traces
- polish Workspace navigation labels and add a figure to the mock logbook example

## Why

Reference-only published logbooks detected public trace datasets and Buckets but only showed an “Open on the Hub” placeholder. The viewer now hydrates public repositories while keeping private or inaccessible repositories link-only.

## Validation

- `pytest -q tests/unit/test_logbook.py tests/ui/test_logbook_viewer.py` (72 passed)
- `ruff check trackio/logbook_trace.py trackio/logbook.py examples/mock-trackio-logbook-session.py tests/unit/test_logbook.py tests/ui/test_logbook_viewer.py`
- `node --check trackio/frontend_templates/logbook/logbook.js`
- generated and read `examples/mock-trackio-logbook-session.py` with its figure cell
- deployed and hash-verified the updated viewer assets in two real Logbook Spaces
