### PR TITLE
docs: document artifact tables in storage_schema.md

### DIFF
--- a/.changeset/witty-lamps-count.md
+++ b/.changeset/witty-lamps-count.md
@@ -1,0 +1,5 @@
+---
+"trackio": minor
+---
+
+docs: document the artifact tables in the storage schema page

--- a/.changeset/witty-lamps-count.md
+++ b/.changeset/witty-lamps-count.md
@@ -1,5 +1,5 @@
 ---
-"trackio": minor
+"trackio": patch
 ---
 
 docs: document the artifact tables in the storage schema page

--- a/docs/source/storage_schema.md
+++ b/docs/source/storage_schema.md
@@ -145,9 +145,9 @@ Indexes and constraints:
 | `artifact_id` | `INTEGER` | References `artifacts.id` |
 | `version` | `INTEGER` | Sequential version number starting at 0 |
 | `manifest_digest` | `TEXT` | SHA-256 hex digest of the canonical manifest JSON |
-| `manifest` | `TEXT` | JSON blob listing file entries with `path`, `digest`, `size`, and optional `ref` |
+| `manifest` | `TEXT` | JSON blob listing manifest entries with `path`, `digest`, `size`, and optional `ref` |
 | `metadata` | `TEXT` | Optional JSON metadata |
-| `size_bytes` | `INTEGER` | Total size of the version's files in bytes |
+| `size_bytes` | `INTEGER` | Total size of the version's manifest entries (sum of `size`) in bytes |
 | `producer_run_id` | `TEXT` | Optional identifier of the producing run |
 | `producer_run_name` | `TEXT` | Optional name of the producing run |
 | `created_at` | `TEXT` | ISO timestamp |

--- a/docs/source/storage_schema.md
+++ b/docs/source/storage_schema.md
@@ -123,6 +123,70 @@ Indexes:
 - `idx_alerts_timestamp` on `(timestamp)`
 - `idx_alerts_alert_id` unique partial index on `alert_id`
 
+### `artifacts`
+
+| Column | Type | Notes |
+|--------|------|-------|
+| `id` | `INTEGER` | Primary key |
+| `name` | `TEXT` | Artifact name |
+| `type` | `TEXT` | Free-form category such as `model` or `dataset` |
+| `description` | `TEXT` | Optional description |
+| `created_at` | `TEXT` | ISO timestamp |
+
+Indexes and constraints:
+
+- `UNIQUE(name)`
+
+### `artifact_versions`
+
+| Column | Type | Notes |
+|--------|------|-------|
+| `id` | `INTEGER` | Primary key |
+| `artifact_id` | `INTEGER` | References `artifacts.id` |
+| `version` | `INTEGER` | Sequential version number starting at 0 |
+| `manifest_digest` | `TEXT` | SHA-256 hex digest of the canonical manifest JSON |
+| `manifest` | `TEXT` | JSON blob listing file entries with `path`, `digest`, `size`, and optional `ref` |
+| `metadata` | `TEXT` | Optional JSON metadata |
+| `size_bytes` | `INTEGER` | Total size of the version's files in bytes |
+| `producer_run_id` | `TEXT` | Optional identifier of the producing run |
+| `producer_run_name` | `TEXT` | Optional name of the producing run |
+| `created_at` | `TEXT` | ISO timestamp |
+
+Indexes and constraints:
+
+- `UNIQUE(artifact_id, version)`
+- `UNIQUE(artifact_id, manifest_digest)`
+
+### `artifact_aliases`
+
+| Column | Type | Notes |
+|--------|------|-------|
+| `artifact_id` | `INTEGER` | References `artifacts.id` |
+| `alias` | `TEXT` | Alias name such as `latest` |
+| `artifact_version_id` | `INTEGER` | References `artifact_versions.id` |
+
+Indexes and constraints:
+
+- `PRIMARY KEY (artifact_id, alias)`
+
+### `run_artifact_links`
+
+| Column | Type | Notes |
+|--------|------|-------|
+| `id` | `INTEGER` | Primary key |
+| `run_id` | `TEXT` | Optional run identifier |
+| `run_name` | `TEXT` | Optional run name |
+| `artifact_version_id` | `INTEGER` | References `artifact_versions.id` |
+| `direction` | `TEXT` | `input` or `output` |
+| `created_at` | `TEXT` | ISO timestamp |
+
+Indexes and constraints:
+
+- `CHECK(direction IN ('input', 'output'))`
+- `idx_run_artifact_links_run` on `(run_id, run_name)`
+- `idx_run_artifact_links_version` on `(artifact_version_id)`
+- `idx_run_artifact_links_unique` unique index on `(run_id, artifact_version_id, direction)`
+
 ## How Metric Payloads Are Stored
 
 - User metrics are stored as JSON text in `metrics.metrics`.


### PR DESCRIPTION
## Short description

This PR documents the artifact tables in `docs/source/storage_schema.md`. The page documents the per-project SQLite schema table by table, but the four tables added in #586, #601, and #602 (`artifacts`, `artifact_versions`, `artifact_aliases`, `run_artifact_links`) were never added to it. This PR adds one section per table in the page's existing format, transcribed from the `CREATE TABLE` and `CREATE INDEX` statements in `SQLiteStorage.init_db()`, including the uniqueness constraints, the `direction` CHECK constraint, and the `idx_run_artifact_links_*` indexes. The parquet layout section already listed the artifact parquet exports, so it is unchanged.

While reading the page I noticed the `traces` table is likewise undocumented; happy to add it in this PR or in a follow-up if you'd like.

## AI Disclosure

- [x] I used AI (Claude) to draft this PR; the table sections were transcribed from `SQLiteStorage.init_db()` and self-reviewed against the code.
- [ ] I did not use AI

## Type of Change

- [ ] Bug fix
- [ ] New feature (non-breaking)
- [ ] New feature (breaking change)
- [x] Documentation update
- [ ] Test improvements

## Related Issues

None — gap noticed while reading the page; the tables come from #586/#601/#602.

Closes:

## Testing and linting

Docs-only change (plus the changeset file), no code changes, so there is nothing new for `pytest` or Ruff to cover. The new sections were checked against the `CREATE TABLE` and `CREATE INDEX` statements in `trackio/sqlite_storage.py`.
