### PR TITLE
Increase smoothing upper bound to 100

### DIFF
--- a/.changeset/green-rockets-invite.md
+++ b/.changeset/green-rockets-invite.md
@@ -1,0 +1,5 @@
+---
+"trackio": minor
+---
+
+feat:Increase smoothing upper bound to 100

--- a/.changeset/green-rockets-invite.md
+++ b/.changeset/green-rockets-invite.md
@@ -2,4 +2,4 @@
 "trackio": minor
 ---
 
-feat:Increase smoothing upper bound to 100
+feat: Increase smoothing upper bound to 100

--- a/trackio/frontend/src/components/GradioSlider.svelte
+++ b/trackio/frontend/src/components/GradioSlider.svelte
@@ -135,6 +135,8 @@
     font-size: 11px;
     color: var(--body-text-color-subdued, #9ca3af);
     min-width: 12px;
+    flex-shrink: 0;
+    white-space: nowrap;
     text-align: center;
   }
 </style>

--- a/trackio/frontend/src/components/Sidebar.svelte
+++ b/trackio/frontend/src/components/Sidebar.svelte
@@ -501,7 +501,7 @@
               label="Smoothing Factor (0 = no smoothing)"
               bind:value={smoothing}
               min={0}
-              max={20}
+              max={100}
               step={1}
             />
           </div>

--- a/trackio/frontend/src/lib/dataProcessing.js
+++ b/trackio/frontend/src/lib/dataProcessing.js
@@ -100,21 +100,31 @@ export function processRunData(
 function smoothData(rows, cols, windowSize) {
   const w = Math.max(3, Math.min(windowSize, rows.length));
   const half = Math.floor(w / 2);
+  const prefixSums = {};
+  const prefixCounts = {};
+  cols.forEach((col) => {
+    const sums = new Float64Array(rows.length + 1);
+    const counts = new Uint32Array(rows.length + 1);
+    for (let i = 0; i < rows.length; i++) {
+      const value = rows[i][col];
+      const isNumeric = value != null && typeof value === "number";
+      sums[i + 1] = sums[i] + (isNumeric ? value : 0);
+      counts[i + 1] = counts[i] + (isNumeric ? 1 : 0);
+    }
+    prefixSums[col] = sums;
+    prefixCounts[col] = counts;
+  });
   return rows.map((row, i) => {
     const smoothed = { ...row };
+    const start = Math.max(0, i - half);
+    const end = Math.min(rows.length, i + half + 1);
     cols.forEach((col) => {
       if (row[col] == null || typeof row[col] !== "number") return;
-      const start = Math.max(0, i - half);
-      const end = Math.min(rows.length, i + half + 1);
-      let sum = 0;
-      let count = 0;
-      for (let j = start; j < end; j++) {
-        if (rows[j][col] != null && typeof rows[j][col] === "number") {
-          sum += rows[j][col];
-          count++;
-        }
-      }
-      smoothed[col] = count > 0 ? sum / count : row[col];
+      const count = prefixCounts[col][end] - prefixCounts[col][start];
+      smoothed[col] =
+        count > 0
+          ? (prefixSums[col][end] - prefixSums[col][start]) / count
+          : row[col];
     });
     return smoothed;
   });


### PR DESCRIPTION
Raises the maximum value of the dashboard's smoothing slider from 20 to 100, as requested in #646.

Smoothing is implemented as a centered moving average in `trackio/frontend/src/lib/dataProcessing.js`, where the window size is already clamped to the number of data points (`Math.max(3, Math.min(windowSize, rows.length))`), so values up to 100 are safe even for short runs.


https://github.com/user-attachments/assets/e8c580ed-5731-4e3d-ad9e-a4e8cec33d84



Closes #646