### PR TITLE
Deprecate persisting data to HF Datasets in favor of Buckets

### DIFF
--- a/.changeset/purple-worms-remain.md
+++ b/.changeset/purple-worms-remain.md
@@ -1,0 +1,5 @@
+---
+"trackio": minor
+---
+
+feat:Deprecate persisting data to HF Datasets in favor of Buckets

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install ruff
+        pip install ruff==0.9.3
         
     - name: Check formatting with ruff
       run: |

--- a/docs/source/environment_variables.md
+++ b/docs/source/environment_variables.md
@@ -1,6 +1,6 @@
 # Environment Variables
 
-Trackio uses environment variables to configure various aspects of its behavior, particularly for deployment to Hugging Face Spaces and dataset persistence. This guide covers the main environment variables and their usage.
+Trackio uses environment variables to configure various aspects of its behavior, particularly for deployment to Hugging Face Spaces and data persistence. This guide covers the main environment variables and their usage.
 
 ## Core Environment Variables
 
@@ -171,6 +171,24 @@ export TRACKIO_WEBHOOK_MIN_LEVEL="warn"
 ```
 
 With `warn`, only `WARN` and `ERROR` alerts are sent to webhook URLs.
+
+### `TRACKIO_BUCKET_ID`
+
+The ID of the Hugging Face Bucket (e.g. `username/bucketname`) used to persist Trackio data when running on a Hugging Face Space. This is normally set automatically on the Space when it is created via `trackio.init(space_id=...)` or `trackio.sync(...)`; a bucket is auto-generated from the Space ID unless an explicit `bucket_id` is provided.
+
+```bash
+export TRACKIO_BUCKET_ID="username/my-trackio-bucket"
+```
+
+### `TRACKIO_DATASET_ID` (deprecated)
+
+> **Deprecated:** Persisting Trackio data to a Hugging Face Dataset (`dataset_id` / `TRACKIO_DATASET_ID`) is deprecated and will be removed in a future version of Trackio. Use a Hugging Face Bucket instead (`bucket_id` / `TRACKIO_BUCKET_ID`).
+
+The ID of the Hugging Face Dataset (e.g. `username/datasetname`) that a Trackio Space syncs its data to via a background commit scheduler. When set on a Space, Trackio emits a deprecation warning and continues to sync to the Dataset for now.
+
+```bash
+export TRACKIO_DATASET_ID="username/my-trackio-dataset"
+```
 
 ### `HF_TOKEN`
 

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -4,7 +4,7 @@
 <img width="75%" src="https://github.com/user-attachments/assets/6d6a41e7-fbc1-43ec-bda6-15f9ff4bd25c" />
 </p>
 
-`trackio` is a lightweight, free experiment tracking Python library built on top of Hugging Face Datasets and Spaces 🤗.
+`trackio` is a lightweight, free experiment tracking Python library built on top of Hugging Face Buckets and Spaces 🤗.
 
 ![Screen Recording 2025-07-28 at 5 26 32 PM](https://github.com/user-attachments/assets/f3eac49e-d8ee-4fc0-b1ca-aedfc6d6fae1)
 
@@ -15,7 +15,7 @@
   ```
 
 - **Local-first** design: dashboard runs locally by default. You can also log to a Hugging Face Space (`space_id`) for free or to a **self-hosted** Trackio server (`server_url`)
-- Persists logs locally, in a Hugging Face Dataset when using Spaces, or on the machine hosting your self-hosted server
+- Persists logs locally, in a Hugging Face Bucket when using Spaces, or on the machine hosting your self-hosted server. (Persisting to a Hugging Face Dataset via `dataset_id` / `TRACKIO_DATASET_ID` is deprecated and will be removed in a future version; use a Bucket via `bucket_id` / `TRACKIO_BUCKET_ID` instead.)
 - Visualize experiments with a Gradio dashboard locally, on Hugging Face Spaces, or on your own host when self-hosting
 - **LLM-friendly**: Designed for autonomous ML experiments with CLI commands and Python APIs that enable LLMs to easily log and query experiment data.
 - Everything here, including hosting on Hugging Face, is **free**!

--- a/docs/source/self_hosted_server.md
+++ b/docs/source/self_hosted_server.md
@@ -69,7 +69,7 @@ trackio.finish()
 
 Precedence: **`space_id` / `TRACKIO_SPACE_ID` always wins** over `server_url` / `TRACKIO_SERVER_URL` when both are set (in code or in the environment). Trackio then behaves as if only the Space were configured.
 
-Hugging Face–specific options such as `dataset_id` and `bucket_id` apply only when logging to a Space. When only `server_url` is in effect, configure persistence on the machine where the server runs (for example via `TRACKIO_DIR` on that host). See [Environment Variables](environment_variables.md).
+Hugging Face–specific options such as `dataset_id` (deprecated; use `bucket_id` instead) and `bucket_id` apply only when logging to a Space. When only `server_url` is in effect, configure persistence on the machine where the server runs (for example via `TRACKIO_DIR` on that host). See [Environment Variables](environment_variables.md).
 
 ## Related
 

--- a/docs/source/track.md
+++ b/docs/source/track.md
@@ -51,7 +51,7 @@ By default, metrics are stored locally and you open the dashboard on your machin
 - A **Hugging Face Space**, by passing `space_id` (or setting `TRACKIO_SPACE_ID`). Trackio can create or reuse the Space and sync data there.
 - A **self-hosted Trackio server** (HTTP or HTTPS), by passing `server_url` (or setting `TRACKIO_SERVER_URL`). Use the write-access URL from `trackio.show()` (optionally with `write_token` in the query), or a base URL plus `TRACKIO_WRITE_TOKEN`. The client authenticates with the same **write token** the dashboard uses (not your Hugging Face token).
 
-If both a Space and a self-hosted URL are configured (`space_id` / `TRACKIO_SPACE_ID` together with `server_url` / `TRACKIO_SERVER_URL`), **the Space takes precedence** and the self-hosted URL is ignored. Options such as `dataset_id` and `bucket_id` apply to Hugging Face deployments; when only `server_url` is in effect, configure storage on the host that runs the server (see [Environment Variables](environment_variables.md)).
+If both a Space and a self-hosted URL are configured (`space_id` / `TRACKIO_SPACE_ID` together with `server_url` / `TRACKIO_SERVER_URL`), **the Space takes precedence** and the self-hosted URL is ignored. Options such as `dataset_id` (deprecated; use `bucket_id` instead) and `bucket_id` apply to Hugging Face deployments; when only `server_url` is in effect, configure storage on the host that runs the server (see [Environment Variables](environment_variables.md)).
 
 For setup steps (running `trackio show`, binding to `0.0.0.0`, write tokens), see [Self-host the Server](self_hosted_server.md).
 

--- a/trackio/__init__.py
+++ b/trackio/__init__.py
@@ -287,7 +287,9 @@ def init(
         space_storage ([`~huggingface_hub.SpaceStorage`], *optional*):
             Choice of persistent storage tier.
         dataset_id (`str`, *optional*):
-            Deprecated. Use `bucket_id` instead.
+            Deprecated: persisting trackio data to a Hugging Face Dataset will be
+            removed in a future version of trackio. Use `bucket_id` (a Hugging
+            Face Bucket) instead.
         bucket_id (`str`, *optional*):
             The ID of the Hugging Face Bucket to use for metric persistence. By default,
             when a `space_id` is provided and `bucket_id` is not explicitly set, a

--- a/trackio/deploy.py
+++ b/trackio/deploy.py
@@ -39,6 +39,7 @@ from trackio.utils import (
     preprocess_space_and_dataset_ids,
     project_artifacts_dir,
     project_media_dir,
+    warn_dataset_persistence_deprecated,
 )
 
 SPACE_HOST_URL = "https://{user_name}-{space_name}.hf.space/"
@@ -349,6 +350,8 @@ def deploy_as_space(
         raise ValueError(
             "Cannot use bucket volume options together with dataset_id; use one persistence mode."
         )
+    if dataset_id is not None:
+        warn_dataset_persistence_deprecated()
 
     trackio_path = files("trackio")
 
@@ -503,7 +506,9 @@ def create_space_if_not_exists(
         space_storage ([`~huggingface_hub.SpaceStorage`], *optional*):
             Choice of persistent storage tier for the Space.
         dataset_id (`str`, *optional*):
-            Deprecated. Use `bucket_id` instead.
+            Deprecated: persisting trackio data to a Hugging Face Dataset will be
+            removed in a future version of trackio. Use `bucket_id` (a Hugging
+            Face Bucket) instead.
         bucket_id (`str`, *optional*):
             Full Hub bucket id (`namespace/name`) to attach via the Hub volumes API (platform mount).
             Sets `TRACKIO_DIR` to the mount path.
@@ -524,6 +529,8 @@ def create_space_if_not_exists(
         raise ValueError(
             f"Invalid bucket ID: {bucket_id}. Must be in the format: username/bucketname or orgname/bucketname."
         )
+    if dataset_id is not None:
+        warn_dataset_persistence_deprecated()
     try:
         huggingface_hub.repo_info(space_id, repo_type="space")
         print(
@@ -970,6 +977,8 @@ def deploy_as_static_space(
             "run entirely in the browser, so their snapshot data must be public. "
             "Use sdk='gradio' for a private dashboard."
         )
+    if dataset_id is not None:
+        warn_dataset_persistence_deprecated()
     hf_api = huggingface_hub.HfApi()
 
     try:
@@ -1103,7 +1112,9 @@ def sync(
             server. `"static"` freezes the Space: deploys a static Space that reads from an HF Bucket
             (no server needed).
         dataset_id (`str`, *optional*):
-            Deprecated. Use `bucket_id` instead.
+            Deprecated: persisting trackio data to a Hugging Face Dataset will be
+            removed in a future version of trackio. Use `bucket_id` (a Hugging
+            Face Bucket) instead.
         bucket_id (`str`, *optional*):
             The ID of the HF Bucket to sync to. By default, a bucket is auto-generated
             from the space_id.

--- a/trackio/imports.py
+++ b/trackio/imports.py
@@ -41,7 +41,9 @@ def import_csv(
             Space does not exist, it will be created. If the Space already exists, the
             project will be logged to it.
         dataset_id (`str`, *optional*):
-            Deprecated. Use `bucket_id` instead.
+            Deprecated: persisting trackio data to a Hugging Face Dataset will be
+            removed in a future version of trackio. Use `bucket_id` (a Hugging
+            Face Bucket) instead.
         private (`bool`, *optional*):
             Whether to make the Space private. If None (default), the repo will be
             public unless the organization's default is private. This value is ignored
@@ -188,7 +190,9 @@ def import_tf_events(
             Space does not exist, it will be created. If the Space already exists, the
             project will be logged to it.
         dataset_id (`str`, *optional*):
-            Deprecated. Use `bucket_id` instead.
+            Deprecated: persisting trackio data to a Hugging Face Dataset will be
+            removed in a future version of trackio. Use `bucket_id` (a Hugging
+            Face Bucket) instead.
         private (`bool`, *optional*):
             Whether to make the Space private. If None (default), the repo will be
             public unless the organization's default is private. This value is ignored

--- a/trackio/sqlite_storage.py
+++ b/trackio/sqlite_storage.py
@@ -44,6 +44,7 @@ from trackio.utils import (
     on_spaces,
     project_media_dir,
     serialize_values,
+    warn_dataset_persistence_deprecated,
 )
 
 DB_EXT = ".db"
@@ -1477,6 +1478,7 @@ class SQLiteStorage:
             dataset_id = os.environ.get("TRACKIO_DATASET_ID")
             space_repo_name = os.environ.get("SPACE_REPO_NAME")
             if dataset_id is not None and space_repo_name is not None:
+                warn_dataset_persistence_deprecated()
                 scheduler = CommitScheduler(
                     repo_id=dataset_id,
                     repo_type="dataset",
@@ -2746,6 +2748,7 @@ class SQLiteStorage:
         dataset_id = os.environ.get("TRACKIO_DATASET_ID")
         space_repo_name = os.environ.get("SPACE_REPO_NAME")
         if dataset_id is not None and space_repo_name is not None:
+            warn_dataset_persistence_deprecated()
             hfapi = hf.HfApi()
             if not TRACKIO_DIR.exists():
                 TRACKIO_DIR.mkdir(parents=True, exist_ok=True)

--- a/trackio/utils.py
+++ b/trackio/utils.py
@@ -29,6 +29,28 @@ def _emit_nonfatal_warning(message: str, *args, **kwargs) -> None:
         print(f"* Trackio warning: {message}")
 
 
+DATASET_PERSISTENCE_DEPRECATION_MESSAGE = (
+    "Persisting trackio data to a Hugging Face Dataset (`dataset_id` / "
+    "`TRACKIO_DATASET_ID`) is deprecated and will be removed in a future version "
+    "of trackio. Use a Hugging Face Bucket instead (`bucket_id` / "
+    "`TRACKIO_BUCKET_ID`)."
+)
+
+_dataset_persistence_deprecation_warned = False
+
+
+def warn_dataset_persistence_deprecated(stacklevel: int = 3) -> None:
+    global _dataset_persistence_deprecation_warned
+    if _dataset_persistence_deprecation_warned:
+        return
+    _dataset_persistence_deprecation_warned = True
+    _emit_nonfatal_warning(
+        DATASET_PERSISTENCE_DEPRECATION_MESSAGE,
+        FutureWarning,
+        stacklevel=stacklevel,
+    )
+
+
 def get_logo_urls() -> dict[str, str]:
     """Get logo URLs from environment variables or use defaults."""
     light_url = os.environ.get(
@@ -594,11 +616,7 @@ def preprocess_space_and_dataset_ids(
         username = _get_default_namespace()
         space_id = f"{username}/{space_id}"
     if dataset_id is not None:
-        warnings.warn(
-            "`dataset_id` is deprecated. Use `bucket_id` instead.",
-            DeprecationWarning,
-            stacklevel=3,
-        )
+        warn_dataset_persistence_deprecated(stacklevel=4)
     if dataset_id is not None and "/" not in dataset_id:
         username = _get_default_namespace()
         dataset_id = f"{username}/{dataset_id}"


### PR DESCRIPTION
## What this does

Persisting trackio data to a Hugging Face **Dataset** (`dataset_id` / `TRACKIO_DATASET_ID`) is now formally deprecated in favor of Hugging Face **Buckets** (`bucket_id` / `TRACKIO_BUCKET_ID`). The dataset path is **not removed** — behavior is completely unchanged — but engaging it now emits a `FutureWarning` (visible by default, at most once per process):

> Persisting trackio data to a Hugging Face Dataset (`dataset_id` / `TRACKIO_DATASET_ID`) is deprecated and will be removed in a future version of trackio. Use a Hugging Face Bucket instead (`bucket_id` / `TRACKIO_BUCKET_ID`).

## Entry points that now warn

The warning is centralized in `trackio.utils.warn_dataset_persistence_deprecated()` (guarded by a once-per-process flag) and fired from:

- `utils.preprocess_space_and_dataset_ids()` — covers every explicit `dataset_id=` argument: `trackio.init()`, `trackio.sync()`, `trackio.import_csv()`, and `trackio.import_tf_events()`. Replaces the previous quieter `DeprecationWarning` there.
- `deploy.deploy_as_space(dataset_id=...)`
- `deploy.create_space_if_not_exists(dataset_id=...)`
- `deploy.deploy_as_static_space(dataset_id=...)`
- `SQLiteStorage.get_scheduler()` — runtime path in a Space where `TRACKIO_DATASET_ID` + `SPACE_REPO_NAME` engage the git-backed `CommitScheduler`
- `SQLiteStorage` dataset restore path (downloading parquet files from the Dataset on Space startup)

The warning never fires on the default/bucket path (`bucket_id` / `TRACKIO_BUCKET_ID`), local-only logging, or self-hosted servers.