### PR TITLE
feat: log arbitrary html and plotly/matplotlib figures

### DIFF
--- a/.changeset/html-figure-logging.md
+++ b/.changeset/html-figure-logging.md
@@ -1,0 +1,5 @@
+---
+"trackio": minor
+---
+
+feat: Log arbitrary HTML and Plotly/Matplotlib figures via `trackio.Html`

--- a/docs/source/api.md
+++ b/docs/source/api.md
@@ -76,6 +76,10 @@
 
 [[autodoc]] Audio
 
+## Html
+
+[[autodoc]] Html
+
 ## Table
 
 [[autodoc]] Table

--- a/docs/source/track.md
+++ b/docs/source/track.md
@@ -215,6 +215,9 @@ trackio.log({"report": trackio.Html("<h1>Results</h1>")})
 Matplotlib and Plotly figures are converted to HTML:
 
 ```python
+import plotly.express as px
+
+fig = px.line(x=[1, 2, 3], y=[4, 5, 6])
 trackio.log({"plot": fig})
 ```
 

--- a/docs/source/track.md
+++ b/docs/source/track.md
@@ -204,6 +204,20 @@ Audio can be logged from a file path or a numpy array.
 - Values may be float or integer; floats are peak-normalized and converted to 16-bit PCM
 - `format` can be `"wav"` or `"mp3"` when logging from a numpy array (default `"wav"`)
 
+### Logging HTML and figures
+
+You can log HTML using the [`Html`] class.
+
+```python
+trackio.log({"report": trackio.Html("<h1>Results</h1>")})
+```
+
+Matplotlib and Plotly figures are converted to HTML:
+
+```python
+trackio.log({"plot": fig})
+```
+
 ### Logging system metrics
 
 Trackio can automatically log system metrics in the background. It supports both NVIDIA GPUs and Apple Silicon (M-series) Macs.

--- a/examples/fake-training-html.py
+++ b/examples/fake-training-html.py
@@ -1,0 +1,135 @@
+import io
+import math
+import random
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt
+import plotly.express as px
+import plotly.graph_objects as go
+from matplotlib.animation import FuncAnimation
+
+import trackio as wandb
+
+EPOCHS = 6
+
+
+def plotly_figure(losses):
+    return px.line(x=list(range(len(losses))), y=losses, title="Loss (plotly express)")
+
+
+def plotly_graph_objects_figure(losses, accuracies):
+    fig = go.Figure()
+    fig.add_trace(go.Scatter(y=losses, name="loss", mode="lines+markers"))
+    fig.add_trace(go.Scatter(y=accuracies, name="accuracy", mode="lines+markers"))
+    fig.update_layout(title="Loss vs. accuracy (plotly graph_objects)")
+    return fig
+
+
+def matplotlib_figure(losses):
+    fig, ax = plt.subplots()
+    ax.plot(losses, marker="o")
+    ax.set_title("Loss (matplotlib figure)")
+    ax.set_xlabel("epoch")
+    return fig
+
+
+def matplotlib_animation():
+    fig, ax = plt.subplots()
+    ax.set_xlim(0, 2 * math.pi)
+    ax.set_ylim(-1.1, 1.1)
+    (line,) = ax.plot([], [])
+
+    xs = [i * 2 * math.pi / 50 for i in range(51)]
+
+    def update(frame):
+        line.set_data(xs[:frame], [math.sin(x + frame / 5) for x in xs[:frame]])
+        return (line,)
+
+    return FuncAnimation(fig, update, frames=len(xs), blit=True)
+
+
+def custom_html(epoch, loss, accuracy):
+    return f"""
+    <h2>Epoch {epoch}</h2>
+    <table border="1" cellpadding="6" style="border-collapse:collapse">
+        <tr><th>metric</th><th>value</th></tr>
+        <tr><td>loss</td><td>{loss:.4f}</td></tr>
+        <tr><td>accuracy</td><td>{accuracy:.4f}</td></tr>
+    </table>
+    <p><em>Rendered from a raw HTML fragment.</em></p>
+    """
+
+
+def main():
+    project_name = f"html-logging-demo-{random.randint(10000, 99999)}"
+    wandb.init(project=project_name, name="html-run")
+
+    losses, accuracies = [], []
+
+    for epoch in range(EPOCHS):
+        loss = 2.0 * math.exp(-epoch / 3.0) + random.uniform(-0.05, 0.05)
+        accuracy = 1.0 - loss / 3.0
+        losses.append(loss)
+        accuracies.append(accuracy)
+
+        mpl_fig = matplotlib_figure(losses)
+
+        plt.figure()
+        plt.plot(accuracies, color="green")
+        plt.title("Accuracy (pyplot module)")
+
+        wandb.log(
+            {
+                "loss": loss,
+                "accuracy": accuracy,
+                "plotly_express": plotly_figure(losses),
+                "plotly_graph_objects": plotly_graph_objects_figure(losses, accuracies),
+                "matplotlib_figure": mpl_fig,
+                "pyplot_module": plt,
+                "custom_html": wandb.Html(
+                    custom_html(epoch, loss, accuracy), caption=f"epoch {epoch}"
+                ),
+            },
+            step=epoch,
+        )
+
+        plt.close("all")
+
+    anim = matplotlib_animation()
+    html_file = io.StringIO(
+        "<!doctype html><html><body>"
+        "<h2>From a file-like object</h2>"
+        "<p>This document was passed to <code>trackio.Html</code> as a stream.</p>"
+        "</body></html>"
+    )
+
+    wandb.log(
+        {
+            "matplotlib_animation": wandb.Html(anim, caption="sine wave animation"),
+            "html_from_stream": wandb.Html(html_file),
+            "full_document": wandb.Html(
+                "<!doctype html><html><head><style>"
+                "body{background:#111;color:#eee;font-family:monospace}"
+                "</style></head><body><h2>Full document</h2>"
+                "<p>Not wrapped by trackio, so these styles apply.</p>"
+                "</body></html>",
+                caption="full html document",
+            ),
+            "no_inject": wandb.Html(
+                "<h2>inject=False</h2><p>Logged as a bare fragment.</p>",
+                inject=False,
+                caption="fragment without wrapping",
+            ),
+        },
+        step=EPOCHS,
+    )
+
+    plt.close("all")
+    wandb.finish()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/fake-training.py
+++ b/examples/fake-training.py
@@ -95,8 +95,6 @@ for run in range(5):
                 "train/accuracy": round(train_accuracy, 4),
                 "train/rewards/reward1": random.random(),
                 "train/rewards/reward2": random.random(),
-                "train/rewards/reward3": random.random(),
-                "train/rewards/reward4": random.random(),
                 "val/loss": round(val_loss, 4),
                 "val/accuracy": round(val_accuracy, 4),
                 "grad_norm": grad_norm,

--- a/examples/fake-training.py
+++ b/examples/fake-training.py
@@ -95,6 +95,8 @@ for run in range(5):
                 "train/accuracy": round(train_accuracy, 4),
                 "train/rewards/reward1": random.random(),
                 "train/rewards/reward2": random.random(),
+                "train/rewards/reward3": random.random(),
+                "train/rewards/reward4": random.random(),
                 "val/loss": round(val_loss, 4),
                 "val/accuracy": round(val_accuracy, 4),
                 "grad_norm": grad_norm,

--- a/tests/unit/test_html.py
+++ b/tests/unit/test_html.py
@@ -13,95 +13,27 @@ FRAGMENT = "<h1>Hello</h1><p>Some text.</p>"
 FULL_DOCUMENT = "<!doctype html><html><body><p>full</p></body></html>"
 
 
-def test_html_alias():
-    assert Html is TrackioHtml
+def test_html_resolves_sources(tmp_path):
+    fragment = TrackioHtml(FRAGMENT)
+    assert fragment._html.lstrip().lower().startswith("<!doctype")
+    assert FRAGMENT in fragment._html
 
+    assert TrackioHtml(FRAGMENT, inject=False)._html == FRAGMENT
+    assert TrackioHtml(FULL_DOCUMENT)._html == FULL_DOCUMENT
 
-def test_html_save(temp_dir):
-    html = TrackioHtml(FRAGMENT)
-    html._save(PROJECT_NAME, "test_run", 0)
-
-    expected_rel_dir = Path(PROJECT_NAME) / "test_run" / "0"
-    assert str(html._get_relative_file_path()).startswith(str(expected_rel_dir))
-    absolute_path = html._get_absolute_file_path()
-    assert str(absolute_path).endswith(".html")
-    assert absolute_path.is_file()
-    assert FRAGMENT in absolute_path.read_text(encoding="utf-8")
-
-
-def test_html_serialization(temp_dir):
-    html = TrackioHtml(FRAGMENT, caption="a caption")
-    html._save(PROJECT_NAME, "test_run", 0)
-    value = html._to_dict()
-
-    assert value.get("_type") == TrackioHtml.TYPE
-    assert value.get("file_path") == str(html._get_relative_file_path())
-    assert value.get("caption") == "a caption"
-
-
-def test_html_inject_wraps_fragment():
-    html = TrackioHtml(FRAGMENT)
-    assert html._html.lstrip().lower().startswith("<!doctype")
-    assert FRAGMENT in html._html
-
-
-def test_html_inject_false_passes_through():
-    html = TrackioHtml(FRAGMENT, inject=False)
-    assert html._html == FRAGMENT
-
-
-def test_html_full_document_not_double_wrapped():
-    html = TrackioHtml(FULL_DOCUMENT)
-    assert html._html == FULL_DOCUMENT
-
-
-def test_html_reads_html_file(tmp_path):
     file_path = tmp_path / "report.html"
     file_path.write_text(FULL_DOCUMENT, encoding="utf-8")
+    assert TrackioHtml(str(file_path))._html == FULL_DOCUMENT
 
-    html = TrackioHtml(str(file_path))
-    assert html._html == FULL_DOCUMENT
+    assert TrackioHtml(io.StringIO(FULL_DOCUMENT))._html == FULL_DOCUMENT
+    assert TrackioHtml(io.BytesIO(FULL_DOCUMENT.encode("utf-8")))._html == FULL_DOCUMENT
 
-
-def test_html_from_text_file_like_object():
-    html = TrackioHtml(io.StringIO(FULL_DOCUMENT))
-    assert html._html == FULL_DOCUMENT
-
-
-def test_html_from_bytes_file_like_object():
-    html = TrackioHtml(io.BytesIO(FULL_DOCUMENT.encode("utf-8")))
-    assert html._html == FULL_DOCUMENT
-
-
-def test_html_from_file_like_object_not_at_start():
     stream = io.StringIO()
     stream.write(FULL_DOCUMENT)
-    html = TrackioHtml(stream)
-    assert html._html == FULL_DOCUMENT
+    assert TrackioHtml(stream)._html == FULL_DOCUMENT
 
-
-def test_html_invalid_type():
     with pytest.raises(ValueError):
         TrackioHtml(123)
-
-
-def test_html_string_with_null_byte_not_treated_as_path():
-    data = "weird\x00name.html"
-    html = TrackioHtml(data, inject=False)
-    assert html._html == data
-
-
-def test_data_is_not_path_ignored_but_warns():
-    with pytest.warns(UserWarning, match="data_is_not_path"):
-        html = TrackioHtml(FRAGMENT, data_is_not_path=True, inject=False)
-    assert html._html == FRAGMENT
-
-
-def test_is_loggable_figure_false_for_plain():
-    assert not TrackioHtml.is_loggable_figure("string")
-    assert not TrackioHtml.is_loggable_figure(1)
-    assert not TrackioHtml.is_loggable_figure({"a": 1})
-    assert not TrackioHtml.is_loggable_figure(TrackioHtml(FRAGMENT))
 
 
 def test_html_logging(temp_dir):
@@ -120,7 +52,13 @@ def test_html_logging(temp_dir):
     ]
     assert len(entries) == 1
     assert entries[0]["report"]["caption"] == "report"
-    assert entries[0]["report"]["file_path"].endswith(".html")
+
+    file_path = entries[0]["report"]["file_path"]
+    assert file_path.startswith(str(Path(PROJECT_NAME) / "run-html"))
+    assert file_path.endswith(".html")
+    saved = Path(temp_dir) / "media" / file_path
+    assert saved.is_file()
+    assert FRAGMENT in saved.read_text(encoding="utf-8")
 
 
 def test_matplotlib_figure_logging(temp_dir):
@@ -133,6 +71,7 @@ def test_matplotlib_figure_logging(temp_dir):
 
     assert TrackioHtml.is_loggable_figure(fig)
     assert TrackioHtml.is_loggable_figure(plt)
+    assert not TrackioHtml.is_loggable_figure(FRAGMENT)
 
     run = Run(
         url=None, project=PROJECT_NAME, client=None, name="run-mpl", space_id=None
@@ -149,23 +88,9 @@ def test_matplotlib_figure_logging(temp_dir):
         and entry["chart"].get("_type") == TrackioHtml.TYPE
     ]
     assert len(entries) == 1
-    file_path = entries[0]["chart"]["file_path"]
-    assert file_path.endswith(".html")
-    saved = Path(temp_dir) / "media" / file_path
+    saved = Path(temp_dir) / "media" / entries[0]["chart"]["file_path"]
     assert saved.is_file()
     assert "<svg" in saved.read_text(encoding="utf-8")
-
-
-def test_pyplot_module_to_svg():
-    matplotlib = pytest.importorskip("matplotlib")
-    matplotlib.use("Agg")
-    import matplotlib.pyplot as plt
-
-    plt.figure()
-    plt.plot([1, 2, 3])
-    html = TrackioHtml(plt)
-    plt.close("all")
-    assert "<svg" in html._html
 
 
 def test_matplotlib_animation_to_jshtml():
@@ -189,20 +114,12 @@ def test_matplotlib_animation_to_jshtml():
     assert "<script" in html._html.lower()
 
 
-def test_plotly_figure_to_html():
+def test_plotly_figure_logging(temp_dir):
     go = pytest.importorskip("plotly.graph_objects")
 
     fig = go.Figure(data=go.Scatter(x=[1, 2, 3], y=[4, 5, 6]))
     assert TrackioHtml.is_loggable_figure(fig)
 
-    html = TrackioHtml(fig)
-    assert "plotly" in html._html.lower()
-
-
-def test_plotly_figure_logging(temp_dir):
-    go = pytest.importorskip("plotly.graph_objects")
-
-    fig = go.Figure(data=go.Scatter(x=[1, 2, 3], y=[4, 5, 6]))
     run = Run(
         url=None, project=PROJECT_NAME, client=None, name="run-plotly", space_id=None
     )
@@ -217,8 +134,6 @@ def test_plotly_figure_logging(temp_dir):
         and entry["plot"].get("_type") == TrackioHtml.TYPE
     ]
     assert len(entries) == 1
-    file_path = entries[0]["plot"]["file_path"]
-    assert file_path.endswith(".html")
-    saved = Path(temp_dir) / "media" / file_path
+    saved = Path(temp_dir) / "media" / entries[0]["plot"]["file_path"]
     assert saved.is_file()
     assert "plotly" in saved.read_text(encoding="utf-8").lower()

--- a/tests/unit/test_html.py
+++ b/tests/unit/test_html.py
@@ -1,0 +1,224 @@
+import io
+from pathlib import Path
+
+import pytest
+
+from trackio import Html, Run
+from trackio.media import TrackioHtml
+from trackio.sqlite_storage import SQLiteStorage
+
+PROJECT_NAME = "test_project"
+
+FRAGMENT = "<h1>Hello</h1><p>Some text.</p>"
+FULL_DOCUMENT = "<!doctype html><html><body><p>full</p></body></html>"
+
+
+def test_html_alias():
+    assert Html is TrackioHtml
+
+
+def test_html_save(temp_dir):
+    html = TrackioHtml(FRAGMENT)
+    html._save(PROJECT_NAME, "test_run", 0)
+
+    expected_rel_dir = Path(PROJECT_NAME) / "test_run" / "0"
+    assert str(html._get_relative_file_path()).startswith(str(expected_rel_dir))
+    absolute_path = html._get_absolute_file_path()
+    assert str(absolute_path).endswith(".html")
+    assert absolute_path.is_file()
+    assert FRAGMENT in absolute_path.read_text(encoding="utf-8")
+
+
+def test_html_serialization(temp_dir):
+    html = TrackioHtml(FRAGMENT, caption="a caption")
+    html._save(PROJECT_NAME, "test_run", 0)
+    value = html._to_dict()
+
+    assert value.get("_type") == TrackioHtml.TYPE
+    assert value.get("file_path") == str(html._get_relative_file_path())
+    assert value.get("caption") == "a caption"
+
+
+def test_html_inject_wraps_fragment():
+    html = TrackioHtml(FRAGMENT)
+    assert html._html.lstrip().lower().startswith("<!doctype")
+    assert FRAGMENT in html._html
+
+
+def test_html_inject_false_passes_through():
+    html = TrackioHtml(FRAGMENT, inject=False)
+    assert html._html == FRAGMENT
+
+
+def test_html_full_document_not_double_wrapped():
+    html = TrackioHtml(FULL_DOCUMENT)
+    assert html._html == FULL_DOCUMENT
+
+
+def test_html_reads_html_file(tmp_path):
+    file_path = tmp_path / "report.html"
+    file_path.write_text(FULL_DOCUMENT, encoding="utf-8")
+
+    html = TrackioHtml(str(file_path))
+    assert html._html == FULL_DOCUMENT
+
+
+def test_html_from_text_file_like_object():
+    html = TrackioHtml(io.StringIO(FULL_DOCUMENT))
+    assert html._html == FULL_DOCUMENT
+
+
+def test_html_from_bytes_file_like_object():
+    html = TrackioHtml(io.BytesIO(FULL_DOCUMENT.encode("utf-8")))
+    assert html._html == FULL_DOCUMENT
+
+
+def test_html_from_file_like_object_not_at_start():
+    stream = io.StringIO()
+    stream.write(FULL_DOCUMENT)
+    html = TrackioHtml(stream)
+    assert html._html == FULL_DOCUMENT
+
+
+def test_html_invalid_type():
+    with pytest.raises(ValueError):
+        TrackioHtml(123)
+
+
+def test_html_string_with_null_byte_not_treated_as_path():
+    data = "weird\x00name.html"
+    html = TrackioHtml(data, inject=False)
+    assert html._html == data
+
+
+def test_data_is_not_path_ignored_but_warns():
+    with pytest.warns(UserWarning, match="data_is_not_path"):
+        html = TrackioHtml(FRAGMENT, data_is_not_path=True, inject=False)
+    assert html._html == FRAGMENT
+
+
+def test_is_loggable_figure_false_for_plain():
+    assert not TrackioHtml.is_loggable_figure("string")
+    assert not TrackioHtml.is_loggable_figure(1)
+    assert not TrackioHtml.is_loggable_figure({"a": 1})
+    assert not TrackioHtml.is_loggable_figure(TrackioHtml(FRAGMENT))
+
+
+def test_html_logging(temp_dir):
+    run = Run(
+        url=None, project=PROJECT_NAME, client=None, name="run-html", space_id=None
+    )
+    run.log({"loss": 0.1, "report": Html(FRAGMENT, caption="report")})
+    run.finish()
+
+    logs = SQLiteStorage.get_logs(PROJECT_NAME, "run-html")
+    entries = [
+        entry
+        for entry in logs
+        if isinstance(entry.get("report"), dict)
+        and entry["report"].get("_type") == TrackioHtml.TYPE
+    ]
+    assert len(entries) == 1
+    assert entries[0]["report"]["caption"] == "report"
+    assert entries[0]["report"]["file_path"].endswith(".html")
+
+
+def test_matplotlib_figure_logging(temp_dir):
+    matplotlib = pytest.importorskip("matplotlib")
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    fig, ax = plt.subplots()
+    ax.plot([1, 2, 3, 4])
+
+    assert TrackioHtml.is_loggable_figure(fig)
+    assert TrackioHtml.is_loggable_figure(plt)
+
+    run = Run(
+        url=None, project=PROJECT_NAME, client=None, name="run-mpl", space_id=None
+    )
+    run.log({"chart": fig})
+    run.finish()
+    plt.close(fig)
+
+    logs = SQLiteStorage.get_logs(PROJECT_NAME, "run-mpl")
+    entries = [
+        entry
+        for entry in logs
+        if isinstance(entry.get("chart"), dict)
+        and entry["chart"].get("_type") == TrackioHtml.TYPE
+    ]
+    assert len(entries) == 1
+    file_path = entries[0]["chart"]["file_path"]
+    assert file_path.endswith(".html")
+    saved = Path(temp_dir) / "media" / file_path
+    assert saved.is_file()
+    assert "<svg" in saved.read_text(encoding="utf-8")
+
+
+def test_pyplot_module_to_svg():
+    matplotlib = pytest.importorskip("matplotlib")
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    plt.figure()
+    plt.plot([1, 2, 3])
+    html = TrackioHtml(plt)
+    plt.close("all")
+    assert "<svg" in html._html
+
+
+def test_matplotlib_animation_to_jshtml():
+    matplotlib = pytest.importorskip("matplotlib")
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+    from matplotlib.animation import FuncAnimation
+
+    fig, ax = plt.subplots()
+    (line,) = ax.plot([], [])
+
+    def update(frame):
+        line.set_data([0, frame], [0, frame])
+        return (line,)
+
+    anim = FuncAnimation(fig, update, frames=2, blit=True)
+    assert TrackioHtml.is_loggable_figure(anim)
+
+    html = TrackioHtml(anim)
+    plt.close(fig)
+    assert "<script" in html._html.lower()
+
+
+def test_plotly_figure_to_html():
+    go = pytest.importorskip("plotly.graph_objects")
+
+    fig = go.Figure(data=go.Scatter(x=[1, 2, 3], y=[4, 5, 6]))
+    assert TrackioHtml.is_loggable_figure(fig)
+
+    html = TrackioHtml(fig)
+    assert "plotly" in html._html.lower()
+
+
+def test_plotly_figure_logging(temp_dir):
+    go = pytest.importorskip("plotly.graph_objects")
+
+    fig = go.Figure(data=go.Scatter(x=[1, 2, 3], y=[4, 5, 6]))
+    run = Run(
+        url=None, project=PROJECT_NAME, client=None, name="run-plotly", space_id=None
+    )
+    run.log({"plot": fig})
+    run.finish()
+
+    logs = SQLiteStorage.get_logs(PROJECT_NAME, "run-plotly")
+    entries = [
+        entry
+        for entry in logs
+        if isinstance(entry.get("plot"), dict)
+        and entry["plot"].get("_type") == TrackioHtml.TYPE
+    ]
+    assert len(entries) == 1
+    file_path = entries[0]["plot"]["file_path"]
+    assert file_path.endswith(".html")
+    saved = Path(temp_dir) / "media" / file_path
+    assert saved.is_file()
+    assert "plotly" in saved.read_text(encoding="utf-8").lower()

--- a/trackio/__init__.py
+++ b/trackio/__init__.py
@@ -32,6 +32,7 @@ from trackio.launch import launch_trackio_dashboard
 from trackio.markdown import Markdown
 from trackio.media import (
     TrackioAudio,
+    TrackioHtml,
     TrackioImage,
     TrackioVideo,
     get_project_media_path,
@@ -87,6 +88,7 @@ __all__ = [
     "Image",
     "Video",
     "Audio",
+    "Html",
     "Table",
     "Trace",
     "Histogram",
@@ -98,6 +100,7 @@ __all__ = [
 Audio = TrackioAudio
 Image = TrackioImage
 Video = TrackioVideo
+Html = TrackioHtml
 
 
 config = {}

--- a/trackio/frontend/src/pages/Media.svelte
+++ b/trackio/frontend/src/pages/Media.svelte
@@ -21,7 +21,13 @@
   }
 
   const PAGE_SIZE = 48;
-  const EMPTY_MEDIA_ITEMS = { images: [], videos: [], audios: [], tables: [] };
+  const EMPTY_MEDIA_ITEMS = {
+    images: [],
+    videos: [],
+    audios: [],
+    tables: [],
+    htmls: [],
+  };
 
   let rawMediaItems = $state(EMPTY_MEDIA_ITEMS);
   let sortOrder = $state("newest");
@@ -38,6 +44,7 @@
       videos: PAGE_SIZE,
       audios: PAGE_SIZE,
       tables: PAGE_SIZE,
+      htmls: PAGE_SIZE,
     };
   }
 
@@ -69,6 +76,7 @@
     videos: sortMediaItems(rawMediaItems.videos),
     audios: sortMediaItems(rawMediaItems.audios),
     tables: sortMediaItems(rawMediaItems.tables.filter(isDisplayableTable)),
+    htmls: sortMediaItems(rawMediaItems.htmls),
   }));
 
   function imageName(img) {
@@ -91,13 +99,15 @@
     videos: mediaItems.videos.slice(0, visibleCounts.videos),
     audios: mediaItems.audios.slice(0, visibleCounts.audios),
     tables: mediaItems.tables.slice(0, visibleCounts.tables),
+    htmls: mediaItems.htmls.slice(0, visibleCounts.htmls),
   }));
 
   let hasMedia = $derived(
     mediaItems.images.length > 0 ||
       mediaItems.videos.length > 0 ||
       mediaItems.audios.length > 0 ||
-      mediaItems.tables.length > 0,
+      mediaItems.tables.length > 0 ||
+      mediaItems.htmls.length > 0,
   );
 
   function showMore(type) {
@@ -137,6 +147,7 @@
       const videos = [];
       const audios = [];
       const tables = [];
+      const htmls = [];
       let mediaIndex = 0;
 
       if (logs) {
@@ -164,13 +175,16 @@
                 case "trackio.table":
                   tables.push(item);
                   break;
+                case "trackio.html":
+                  htmls.push(item);
+                  break;
               }
             }
           });
         });
       }
 
-      rawMediaItems = { images, videos, audios, tables };
+      rawMediaItems = { images, videos, audios, tables, htmls };
     } catch (e) {
       console.error("Failed to load media:", e);
     } finally {
@@ -281,7 +295,7 @@
       {:else}
         <h2>No media or tables in this run</h2>
         <p>Log images, video, audio, and tables by passing Trackio objects to <code>trackio.log()</code>:</p>
-        <pre><code>{'import trackio\n\ntrackio.init(project="my-project")\ntrackio.log({"plot": trackio.Image("figure.png")})\ntrackio.log({"clip": trackio.Video("output.mp4")})\ntrackio.log({"audio": trackio.Audio("speech.wav")})\n\nimport pandas as pd\ndf = pd.DataFrame({"epoch": [0, 1], "acc": [0.9, 0.95]})\ntrackio.log({"samples": trackio.Table(dataframe=df)})'}</code></pre>
+        <pre><code>{'import trackio\n\ntrackio.init(project="my-project")\ntrackio.log({"plot": trackio.Image("figure.png")})\ntrackio.log({"clip": trackio.Video("output.mp4")})\ntrackio.log({"audio": trackio.Audio("speech.wav")})\ntrackio.log({"report": trackio.Html("<h1>Results</h1>")})\n\nimport pandas as pd\ndf = pd.DataFrame({"epoch": [0, 1], "acc": [0.9, 0.95]})\ntrackio.log({"samples": trackio.Table(dataframe=df)})'}</code></pre>
         <p>Each type appears in its own section here once logged.</p>
       {/if}
     </div>
@@ -504,6 +518,41 @@
           <div class="pagination-row">
             <span>Showing {visibleMediaItems.tables.length} of {mediaItems.tables.length}</span>
             <button type="button" class="load-more-button" onclick={() => showMore("tables")}>Load more</button>
+          </div>
+        {/if}
+      </details>
+    {/if}
+
+    {#if mediaItems.htmls.length > 0}
+      <details class="section" open>
+        <summary class="section-summary">
+          <svg class="chevron" width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true">
+            <path d="M3 4.5L6 7.5L9 4.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+          </svg>
+          <span class="section-title">HTML ({mediaItems.htmls.length})</span>
+        </summary>
+        <div class="gallery html-gallery">
+          {#each visibleMediaItems.htmls as item}
+            <div class="gallery-item html-gallery-item">
+              <div class="media-label">{item.key}</div>
+              <iframe
+                class="html-frame"
+                src={getFilePath(item)}
+                title={item.caption || item.key}
+                sandbox="allow-scripts allow-downloads"
+                loading="lazy"
+              ></iframe>
+              {#if item.caption}
+                <div class="caption">{item.caption}</div>
+              {/if}
+              {@render meta(item)}
+            </div>
+          {/each}
+        </div>
+        {#if visibleCounts.htmls < mediaItems.htmls.length}
+          <div class="pagination-row">
+            <span>Showing {visibleMediaItems.htmls.length} of {mediaItems.htmls.length}</span>
+            <button type="button" class="load-more-button" onclick={() => showMore("htmls")}>Load more</button>
           </div>
         {/if}
       </details>
@@ -800,6 +849,16 @@
     width: 100%;
     display: block;
     border-radius: var(--radius-sm, 4px);
+  }
+  .html-gallery {
+    grid-template-columns: repeat(auto-fill, minmax(360px, 1fr));
+  }
+  .html-frame {
+    width: 100%;
+    height: 420px;
+    border: 1px solid var(--border-color-primary, #e5e7eb);
+    border-radius: var(--radius-sm, 4px);
+    background: var(--background-fill-primary, white);
   }
   .audio-gallery-item {
     justify-content: space-between;

--- a/trackio/media/__init__.py
+++ b/trackio/media/__init__.py
@@ -8,6 +8,7 @@ This module contains all media-related functionality including:
 """
 
 from trackio.media.audio import TrackioAudio
+from trackio.media.html import TrackioHtml
 from trackio.media.image import TrackioImage
 from trackio.media.media import TrackioMedia
 from trackio.media.utils import get_project_media_path
@@ -21,6 +22,7 @@ __all__ = [
     "TrackioImage",
     "TrackioVideo",
     "TrackioAudio",
+    "TrackioHtml",
     "get_project_media_path",
     "write_video",
     "write_audio",

--- a/trackio/media/html.py
+++ b/trackio/media/html.py
@@ -1,0 +1,154 @@
+import io
+import sys
+from pathlib import Path
+from typing import Any
+
+from trackio.media.media import TrackioMedia
+from trackio.utils import _emit_nonfatal_warning
+
+_BASE_STYLE = (
+    ":root{color-scheme:light dark;}"
+    "body{margin:0;padding:12px;"
+    "font-family:system-ui,-apple-system,sans-serif;}"
+    "img,svg{max-width:100%;height:auto;}"
+)
+
+
+class TrackioHtml(TrackioMedia):
+    """
+    Initializes an Html object.
+
+    Example:
+        ```python
+        import trackio
+
+        trackio.init(project="my-project")
+
+        # Raw HTML
+        trackio.log({"report": trackio.Html("<h1>Results</h1>")})
+
+        # Plotly figure
+        import plotly.express as px
+
+        fig = px.line(x=[1, 2, 3], y=[4, 5, 6])
+        trackio.log({"plot": trackio.Html(fig)})
+
+        # Matplotlib figure
+        import matplotlib.pyplot as plt
+
+        plt.plot([1, 2, 3, 4])
+        trackio.log({"chart": trackio.Html(plt)})
+        ```
+
+    Args:
+        data (`str`, `Path`, file-like, Plotly figure, or Matplotlib figure):
+            Raw HTML, a path to an `.html` file, a file-like object, or a Plotly
+            or Matplotlib figure.
+        inject (`bool`, *optional*):
+            Wrap HTML fragments in a styled document. Default is `True`.
+        data_is_not_path (`bool`, *optional*):
+            Accepted for `wandb.Html` compatibility but ignored.
+        caption (`str`, *optional*):
+            A string caption for the HTML.
+    """
+
+    TYPE = "trackio.html"
+
+    def __init__(
+        self,
+        data: Any,
+        inject: bool = True,
+        data_is_not_path: bool = False,
+        caption: str | None = None,
+    ):
+        if data_is_not_path:
+            _emit_nonfatal_warning(
+                "`data_is_not_path` is ignored; trackio auto-detects file paths "
+                "vs. raw HTML."
+            )
+        super().__init__(value=None, caption=caption)
+        self._format = "html"
+        self._html = self._maybe_wrap(self._resolve_html(data), inject)
+
+    @staticmethod
+    def is_plotly_figure(obj: Any) -> bool:
+        module = sys.modules.get("plotly.basedatatypes")
+        return module is not None and isinstance(obj, module.BaseFigure)
+
+    @staticmethod
+    def is_matplotlib_figure(obj: Any) -> bool:
+        module = sys.modules.get("matplotlib.figure")
+        return module is not None and isinstance(obj, module.Figure)
+
+    @staticmethod
+    def is_matplotlib_animation(obj: Any) -> bool:
+        module = sys.modules.get("matplotlib.animation")
+        return module is not None and isinstance(obj, module.Animation)
+
+    @staticmethod
+    def is_pyplot_module(obj: Any) -> bool:
+        return obj is sys.modules.get("matplotlib.pyplot")
+
+    @staticmethod
+    def is_loggable_figure(obj: Any) -> bool:
+        return (
+            TrackioHtml.is_plotly_figure(obj)
+            or TrackioHtml.is_matplotlib_animation(obj)
+            or TrackioHtml.is_pyplot_module(obj)
+            or TrackioHtml.is_matplotlib_figure(obj)
+        )
+
+    @staticmethod
+    def _resolve_html(data: Any) -> str:
+        if TrackioHtml.is_plotly_figure(data):
+            return data.to_html(full_html=True, include_plotlyjs="cdn")
+        if TrackioHtml.is_matplotlib_animation(data):
+            return data.to_jshtml()
+        if TrackioHtml.is_pyplot_module(data):
+            return TrackioHtml._matplotlib_figure_to_svg(data.gcf())
+        if TrackioHtml.is_matplotlib_figure(data):
+            return TrackioHtml._matplotlib_figure_to_svg(data)
+        if hasattr(data, "read"):
+            if hasattr(data, "seek"):
+                data.seek(0)
+            content = data.read()
+            if isinstance(content, bytes):
+                content = content.decode("utf-8")
+            return content
+        if isinstance(data, (str, Path)):
+            path = Path(data)
+            try:
+                is_html_file = (
+                    path.suffix.lower() in (".html", ".htm") and path.is_file()
+                )
+            except (OSError, ValueError):
+                is_html_file = False
+            if is_html_file:
+                return path.read_text(encoding="utf-8")
+            return str(data)
+        raise ValueError(
+            f"Invalid data type for Html, expected str, Path, file-like object, or "
+            f"a Plotly/Matplotlib figure, got {type(data)}"
+        )
+
+    @staticmethod
+    def _matplotlib_figure_to_svg(figure: Any) -> str:
+        buffer = io.StringIO()
+        figure.savefig(buffer, format="svg", bbox_inches="tight")
+        svg = buffer.getvalue()
+        return svg[svg.index("<svg") :]
+
+    @staticmethod
+    def _maybe_wrap(html: str, inject: bool) -> str:
+        if not inject:
+            return html
+        stripped = html.lstrip().lower()
+        if stripped.startswith("<!doctype") or stripped.startswith("<html"):
+            return html
+        return (
+            '<!doctype html><html><head><meta charset="utf-8">'
+            f"<style>{_BASE_STYLE}</style></head><body>{html}</body></html>"
+        )
+
+    def _save_media(self, file_path: Path):
+        file_path.write_text(self._html, encoding="utf-8")

--- a/trackio/run.py
+++ b/trackio/run.py
@@ -24,7 +24,7 @@ from trackio.cpu import CpuMonitor
 from trackio.gpu import GpuMonitor, gpu_available
 from trackio.histogram import Histogram
 from trackio.markdown import Markdown
-from trackio.media import TrackioMedia, get_project_media_path
+from trackio.media import TrackioHtml, TrackioMedia, get_project_media_path
 from trackio.pending_uploads import classify_pending_uploads, replay_pending_uploads
 from trackio.remote_client import RemoteClient, is_transient_remote_error
 from trackio.sqlite_storage import SQLiteStorage
@@ -1079,6 +1079,7 @@ class Run:
                 "trackio.image",
                 "trackio.video",
                 "trackio.audio",
+                "trackio.html",
             ]:
                 file_path = value.get("file_path")
                 if file_path:
@@ -1165,6 +1166,8 @@ class Run:
                     metrics[key] = value._to_dict()
                 elif isinstance(value, Markdown):
                     metrics[key] = value._to_dict()
+                elif TrackioHtml.is_loggable_figure(value):
+                    metrics[key] = self._process_media(TrackioHtml(value), media_step)
                 elif isinstance(value, TrackioMedia):
                     metrics[key] = self._process_media(value, media_step)
             metrics = utils.serialize_values(metrics)

--- a/trackio/sqlite_storage.py
+++ b/trackio/sqlite_storage.py
@@ -2201,12 +2201,14 @@ class SQLiteStorage:
                 "OR CAST(metrics AS TEXT) GLOB ? "
                 "OR CAST(metrics AS TEXT) GLOB ? "
                 "OR CAST(metrics AS TEXT) GLOB ? "
+                "OR CAST(metrics AS TEXT) GLOB ? "
                 "LIMIT 1",
                 (
                     '*"_type":"trackio.image"*',
                     '*"_type":"trackio.video"*',
                     '*"_type":"trackio.audio"*',
                     '*"_type":"trackio.table"*',
+                    '*"_type":"trackio.html"*',
                 ),
             )
             flags["reports"] = _exists(
@@ -3179,6 +3181,7 @@ class SQLiteStorage:
                 "trackio.image",
                 "trackio.video",
                 "trackio.audio",
+                "trackio.html",
             ]:
                 old_path = obj.get("file_path", "")
                 if isinstance(old_path, str):


### PR DESCRIPTION
adds support for #584 

Introduces `trackio.Html` for logging arbitrary html. `plotly`, `matplotlib` figures/animations passed to `trackio.log` are converted to html. 