### PR TITLE
Release carbonteq-trackio 0.31.5.post5 (bulk lifecycles + version fix)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,47 +1,85 @@
-# safe runs from main
+name: Publish CarbonTeq Trackio
 
-name: publish
 on:
+  workflow_dispatch:
   push:
-    branches:
-      - main
+    tags:
+      - "carbonteq-v*"
+
+permissions:
+  contents: read
 
 jobs:
-  version_or_publish:
-    runs-on: ubuntu-22.04
-    environment: publish
-    permissions:
-      contents: read
-      id-token: write
+  build:
+    runs-on: ubuntu-latest
     steps:
-      - name: checkout repo
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
         with:
-          fetch-depth: 0
           persist-credentials: false
-      - name: Install pnpm
-        uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # @v4
+
+      - uses: astral-sh/setup-uv@v6
         with:
-          version: 9.1.x
+          python-version: "3.12"
+
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
-          cache: pnpm
-          cache-dependency-path: pnpm-lock.yaml
-      - name: Install changesets
-        run: pnpm i --frozen-lockfile
-      - name: create and publish versions
-        id: changesets
-        uses: changesets/action@aba318e9165b45b7948c60273e0b72fce0a64eb9 # @v1
-        with:
-          version: pnpm ci:version
-          commit: "chore: update versions"
-          title: "chore: update versions"
-          publish: pnpm ci:tag
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: trackio/frontend/package-lock.json
+
+      - name: Build dashboard
+        working-directory: trackio/frontend
+        run: |
+          npm ci
+          npm run build
+
+      - name: Build Python artifacts
         env:
-          GITHUB_TOKEN: ${{ secrets.GRADIO_PAT }}
-      - name: publish to pypi
-        if: steps.changesets.outputs.hasChangesets != 'true'
-        uses: "gradio-app/github/actions/publish-pypi@main"
+          SKIP_FRONTEND_BUILD: "1"
+        run: uv build --wheel --sdist
+
+      - name: Verify artifacts
+        run: |
+          uvx twine check dist/*
+          uv run --no-project python - <<'PY'
+          import os
+          import tomllib
+          from pathlib import Path
+
+          version = tomllib.loads(Path("pyproject.toml").read_text())["project"]["version"]
+          wheels = list(Path("dist").glob(f"carbonteq_trackio-{version}-*.whl"))
+          sdists = list(Path("dist").glob(f"carbonteq_trackio-{version}.tar.gz"))
+          if len(wheels) != 1 or len(sdists) != 1:
+              raise SystemExit(
+                  f"expected one wheel and one sdist for {version}, "
+                  f"got wheels={wheels}, sdists={sdists}"
+              )
+          tag = os.environ.get("GITHUB_REF_NAME", "")
+          if os.environ.get("GITHUB_REF_TYPE") == "tag" and tag != f"carbonteq-v{version}":
+              raise SystemExit(
+                  f"release tag {tag!r} does not match carbonteq-v{version}"
+              )
+          PY
+
+      - uses: actions/upload-artifact@v4
         with:
-          use-oidc: true
+          name: carbonteq-trackio-python
+          path: dist/*
+          if-no-files-found: error
+
+  publish:
+    if: startsWith(github.ref, 'refs/tags/carbonteq-v')
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/project/carbonteq-trackio/
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: carbonteq-trackio-python
+          path: dist
+
+      - uses: pypa/gh-action-pypi-publish@release/v1

--- a/CARBONTEQ_FORK.md
+++ b/CARBONTEQ_FORK.md
@@ -1,0 +1,53 @@
+# CarbonTeq AI Trackio fork
+
+This repository is an additive fork of
+[`gradio-app/trackio`](https://github.com/gradio-app/trackio). It preserves the
+Trackio Python package, HTTP API, SQLite and Parquet persistence, artifacts, and
+the existing UI while adding platform-specific observability integrations.
+
+## Current extension
+
+`trackio.VerifiersTrace` stores a queryable display projection alongside the
+complete JSON-safe Verifiers trace record. Native Verifiers `traces.jsonl`
+remains authoritative. Trackio is an idempotent, query-optimized copy keyed by
+`(run_id, trace_type, external_id)`.
+
+The existing `trackio.Trace` type is unchanged. The existing UI renders the
+projected messages; there is no fork-specific trace UI in this phase.
+
+## Upstream baseline
+
+| CarbonTeq release | Upstream repository | Upstream commit |
+| --- | --- | --- |
+| Unreleased | `gradio-app/trackio` | `438cb28d2c82c7b7d42431e45d5677a8cc90eb77` |
+
+Every CarbonTeq release must add a row before it is tagged. Platform consumers
+must pin an immutable CarbonTeq commit rather than a branch or tag.
+
+## Updating from upstream
+
+```bash
+git fetch upstream
+git switch main
+git pull --ff-only origin main
+git switch -c maintenance/upstream-YYYY-MM-DD
+git merge --no-ff upstream/main
+uv sync --extra dev --extra spaces
+uv run pytest tests/unit -q
+git push -u origin maintenance/upstream-YYYY-MM-DD
+```
+
+Open a pull request into `carbonteq-ai/trackio:main`. Resolve conflicts by
+keeping upstream behavior intact and reapplying only the additive Verifiers
+fields. Before merging, verify standard traces, metrics, artifacts, API queries,
+SQLite migrations, and Parquet round trips as well as the Verifiers tests.
+
+The repository should keep these remotes:
+
+```text
+origin    git@github.com:carbonteq-ai/trackio.git
+upstream  https://github.com/gradio-app/trackio.git
+```
+
+Rust, Tokio, Doris, object-storage redesign, and a custom frontend are deferred
+and are not part of this fork contract.

--- a/CARBONTEQ_FORK.md
+++ b/CARBONTEQ_FORK.md
@@ -2,8 +2,9 @@
 
 This repository is an additive fork of
 [`gradio-app/trackio`](https://github.com/gradio-app/trackio). It preserves the
-Trackio Python package, HTTP API, SQLite and Parquet persistence, artifacts, and
-the existing UI while adding platform-specific observability integrations.
+Trackio Python package, HTTP API, SQLite-compatible and Parquet persistence,
+artifacts, and the existing UI while adding platform-specific observability
+integrations.
 
 ## Current extension
 
@@ -12,8 +13,23 @@ complete JSON-safe Verifiers trace record. Native Verifiers `traces.jsonl`
 remains authoritative. Trackio is an idempotent, query-optimized copy keyed by
 `(run_id, trace_type, external_id)`.
 
-The existing `trackio.Trace` type is unchanged. The existing UI renders the
-projected messages; there is no fork-specific trace UI in this phase.
+The existing `trackio.Trace` type and trace UI are unchanged. Verifiers traces
+have a separate `/verifiers` workspace because a rollout is a graph with
+branches, rewards, model calls, tools, phase timing, and environment errors—not
+just a conversation. The Verifiers UI renders structured projections and links
+each rollout to its producing experiment; it never displays the raw payload.
+
+## Storage engine
+
+Turso is the default SQL metadata engine through the `pyturso` embedded driver.
+It retains Trackio's SQLite-compatible database-per-project model and local-first
+operation. Set `TRACKIO_DATABASE_ENGINE=sqlite` for the stdlib SQLite fallback.
+
+Turso stores run, metric, trace, artifact-manifest, and lineage metadata. It is
+not the object store: media, model bytes, and native evaluation bundles remain
+under Trackio's existing artifact/file storage boundary. A hosted Hugging Face
+Space is optional and is not required for local operation. Remote sync can be
+added later without changing the Trackio SDK contract.
 
 ## Upstream baseline
 
@@ -39,8 +55,9 @@ git push -u origin maintenance/upstream-YYYY-MM-DD
 
 Open a pull request into `carbonteq-ai/trackio:main`. Resolve conflicts by
 keeping upstream behavior intact and reapplying only the additive Verifiers
-fields. Before merging, verify standard traces, metrics, artifacts, API queries,
-SQLite migrations, and Parquet round trips as well as the Verifiers tests.
+fields. Before merging, verify both Turso and SQLite modes, standard traces,
+metrics, artifacts, API queries, SQLite-compatible migrations, Parquet round
+trips, and both trace UIs as well as the Verifiers tests.
 
 The repository should keep these remotes:
 
@@ -49,5 +66,5 @@ origin    git@github.com:carbonteq-ai/trackio.git
 upstream  https://github.com/gradio-app/trackio.git
 ```
 
-Rust, Tokio, Doris, object-storage redesign, and a custom frontend are deferred
-and are not part of this fork contract.
+Rust, Tokio, Doris, and object-storage redesign are deferred and are not part of
+this fork contract.

--- a/CARBONTEQ_FORK.md
+++ b/CARBONTEQ_FORK.md
@@ -6,6 +6,19 @@ Trackio Python package, HTTP API, SQLite-compatible and Parquet persistence,
 artifacts, and the existing UI while adding platform-specific observability
 integrations.
 
+## Python distribution
+
+CarbonTeq publishes the fork as `carbonteq-trackio` while preserving the
+`trackio` import package and `trackio` console command. The first fork release
+is `0.31.5.post1`, derived from upstream Trackio `0.31.5`. Post-release numbers
+advance when CarbonTeq publishes additional fork changes without moving the
+upstream base.
+
+Framework packages must depend on `carbonteq-trackio`, not the upstream-owned
+`trackio` distribution and not a transitive Git URL. Self-deployed Trackio
+Spaces use the same CarbonTeq distribution identity so the deployed runtime
+retains the fork's storage, trace, and query behavior.
+
 ## Current extension
 
 `trackio.VerifiersTrace` stores a queryable display projection alongside the
@@ -38,7 +51,7 @@ added later without changing the Trackio SDK contract.
 
 | CarbonTeq release | Upstream repository | Upstream commit |
 | --- | --- | --- |
-| Unreleased | `gradio-app/trackio` | `438cb28d2c82c7b7d42431e45d5677a8cc90eb77` |
+| `0.31.5.post1` (release candidate) | `gradio-app/trackio` | `438cb28d2c82c7b7d42431e45d5677a8cc90eb77` |
 
 Every CarbonTeq release must add a row before it is tagged. Platform consumers
 must pin an immutable CarbonTeq commit rather than a branch or tag.

--- a/CARBONTEQ_FORK.md
+++ b/CARBONTEQ_FORK.md
@@ -78,11 +78,11 @@ system-metric, trace, alert, artifact-metadata, and lineage records; it is not
 a downstream analytical projection. Model and media bytes remain behind
 Trackio's existing server-managed artifact boundary.
 
-This implementation remains an unpublished candidate until its source changes
-are reviewed, committed, pushed, and consumed by immutable commit. The current
-deployment is bound to a source-diff and wheel-digest receipt. Operate one
-Trackio server replica until artifact-version allocation is made safe across
-replicas.
+This implementation is published on the CarbonTeq fork and must be consumed by
+immutable commit. The current deployment is still bound to an older
+source-diff and wheel-digest receipt until the corrected Trackio/Observatory
+services are rebuilt and promoted. Operate one Trackio server replica until
+artifact-version allocation is made safe across replicas.
 
 Raw project SQL remains deliberately unavailable with Doris because its tables
 are shared across projects rather than stored in one project-local database.

--- a/CARBONTEQ_FORK.md
+++ b/CARBONTEQ_FORK.md
@@ -10,7 +10,7 @@ integrations.
 
 CarbonTeq publishes the fork as `carbonteq-trackio` while preserving the
 `trackio` import package and `trackio` console command. The current fork release
-candidate is `0.31.5.post3`, derived from upstream Trackio `0.31.5`.
+is `0.31.5.post5`, derived from upstream Trackio `0.31.5`.
 Post-release numbers advance when CarbonTeq publishes additional fork changes
 without moving the upstream base.
 
@@ -105,6 +105,7 @@ added later without changing the Trackio SDK contract.
 | `0.31.5.post2` | `gradio-app/trackio` | `438cb28d2c82c7b7d42431e45d5677a8cc90eb77` |
 | `0.31.5.post3` | `gradio-app/trackio` | `438cb28d2c82c7b7d42431e45d5677a8cc90eb77` |
 | `0.31.5.post4` | `gradio-app/trackio` | `438cb28d2c82c7b7d42431e45d5677a8cc90eb77` |
+| `0.31.5.post5` | `gradio-app/trackio` | `438cb28d2c82c7b7d42431e45d5677a8cc90eb77` |
 
 `0.31.5.post4` adds project-scoped bulk read APIs so a client can describe every
 run without one configuration request and one history request per run:
@@ -114,12 +115,14 @@ run without one configuration request and one history request per run:
 - server `/get_run_lifecycles`
 - client `Api.run_lifecycles` and `Api.run_configs`
 
-Immutable published commit for this release:
-`7d831e7f3ac1b8f0bbae3d6a6acaf863552257df` (branch `feat/bulk-run-lifecycles`
-until merged to `main`).
+`0.31.5.post4` on `carbonteq/stable` was published with distribution metadata
+`post4` while `trackio._version.__version__` still said `post3`. That index is
+non-volatile, so `0.31.5.post5` is the corrected release: same APIs, matching
+import and distribution versions. Do not install `post4` from the index.
 
 Every CarbonTeq release must add a row before it is tagged. Platform consumers
-must pin an immutable CarbonTeq commit rather than a branch or tag.
+should prefer the published `carbonteq-trackio` distribution once it is on the
+configured index; until then they may pin an immutable CarbonTeq commit.
 
 ## Updating from upstream
 

--- a/CARBONTEQ_FORK.md
+++ b/CARBONTEQ_FORK.md
@@ -103,7 +103,20 @@ added later without changing the Trackio SDK contract.
 | --- | --- | --- |
 | `0.31.5.post1` | `gradio-app/trackio` | `438cb28d2c82c7b7d42431e45d5677a8cc90eb77` |
 | `0.31.5.post2` | `gradio-app/trackio` | `438cb28d2c82c7b7d42431e45d5677a8cc90eb77` |
-| `0.31.5.post3` (release candidate) | `gradio-app/trackio` | `438cb28d2c82c7b7d42431e45d5677a8cc90eb77` |
+| `0.31.5.post3` | `gradio-app/trackio` | `438cb28d2c82c7b7d42431e45d5677a8cc90eb77` |
+| `0.31.5.post4` | `gradio-app/trackio` | `438cb28d2c82c7b7d42431e45d5677a8cc90eb77` |
+
+`0.31.5.post4` adds project-scoped bulk read APIs so a client can describe every
+run without one configuration request and one history request per run:
+
+- `SQLiteStorage.get_run_lifecycles` / `DorisStorage.get_run_lifecycles` and
+  shared shaping in `trackio/lifecycle.py`
+- server `/get_run_lifecycles`
+- client `Api.run_lifecycles` and `Api.run_configs`
+
+Immutable published commit for this release:
+`7d831e7f3ac1b8f0bbae3d6a6acaf863552257df` (branch `feat/bulk-run-lifecycles`
+until merged to `main`).
 
 Every CarbonTeq release must add a row before it is tagged. Platform consumers
 must pin an immutable CarbonTeq commit rather than a branch or tag.

--- a/CARBONTEQ_FORK.md
+++ b/CARBONTEQ_FORK.md
@@ -9,10 +9,10 @@ integrations.
 ## Python distribution
 
 CarbonTeq publishes the fork as `carbonteq-trackio` while preserving the
-`trackio` import package and `trackio` console command. The first fork release
-is `0.31.5.post1`, derived from upstream Trackio `0.31.5`. Post-release numbers
-advance when CarbonTeq publishes additional fork changes without moving the
-upstream base.
+`trackio` import package and `trackio` console command. The current fork release
+candidate is `0.31.5.post2`, derived from upstream Trackio `0.31.5`.
+Post-release numbers advance when CarbonTeq publishes additional fork changes
+without moving the upstream base.
 
 Framework packages must depend on `carbonteq-trackio`, not the upstream-owned
 `trackio` distribution and not a transitive Git URL. Self-deployed Trackio
@@ -35,6 +35,19 @@ For an evaluation run, it also joins the selected rollout to the run's aggregate
 `eval/*` metrics so per-rollout evidence and overall results remain distinct but
 visible together.
 
+The self-hosted artifact API supports bounded, resumable uploads for model-sized
+blobs. The client negotiates an 8 MiB chunk size, acknowledges chunks
+idempotently, resumes a deterministic upload session after a client or server
+restart, verifies every chunk and the complete SHA-256, and commits an artifact
+version only after every manifest blob is durable. Servers without this
+capability retain the legacy path for files up to 32 MiB; the client refuses
+larger legacy uploads instead of buffering them in server memory.
+
+Incomplete upload sessions are project-scoped staging state. Cleanup reports
+reclaimable bytes in dry-run mode and expires only incomplete, aged sessions.
+Completed content-addressed blobs and artifact versions are not eligible for
+session cleanup.
+
 ## Storage engine
 
 Turso is the default SQL metadata engine through the `pyturso` embedded driver.
@@ -51,7 +64,8 @@ added later without changing the Trackio SDK contract.
 
 | CarbonTeq release | Upstream repository | Upstream commit |
 | --- | --- | --- |
-| `0.31.5.post1` (release candidate) | `gradio-app/trackio` | `438cb28d2c82c7b7d42431e45d5677a8cc90eb77` |
+| `0.31.5.post1` | `gradio-app/trackio` | `438cb28d2c82c7b7d42431e45d5677a8cc90eb77` |
+| `0.31.5.post2` (release candidate) | `gradio-app/trackio` | `438cb28d2c82c7b7d42431e45d5677a8cc90eb77` |
 
 Every CarbonTeq release must add a row before it is tagged. Platform consumers
 must pin an immutable CarbonTeq commit rather than a branch or tag.
@@ -82,5 +96,6 @@ origin    git@github.com:carbonteq-ai/trackio.git
 upstream  https://github.com/gradio-app/trackio.git
 ```
 
-Rust, Tokio, Doris, and object-storage redesign are deferred and are not part of
-this fork contract.
+Rust, Tokio, Doris, and direct worker access to object-storage credentials are
+deferred and are not part of this fork contract. Trackio's existing
+server-managed artifact store remains the byte-storage boundary.

--- a/CARBONTEQ_FORK.md
+++ b/CARBONTEQ_FORK.md
@@ -10,7 +10,7 @@ integrations.
 
 CarbonTeq publishes the fork as `carbonteq-trackio` while preserving the
 `trackio` import package and `trackio` console command. The current fork release
-candidate is `0.31.5.post2`, derived from upstream Trackio `0.31.5`.
+candidate is `0.31.5.post3`, derived from upstream Trackio `0.31.5`.
 Post-release numbers advance when CarbonTeq publishes additional fork changes
 without moving the upstream base.
 
@@ -35,6 +35,18 @@ For an evaluation run, it also joins the selected rollout to the run's aggregate
 `eval/*` metrics so per-rollout evidence and overall results remain distinct but
 visible together.
 
+The bundled dashboard uses the secure Vega 6 dependency line (`vega` 6.3.1,
+`vega-lite` 6.4.3, and `vega-embed` 7.1.0). Trackio emits Vega-Lite v6 schemas,
+keeps the canvas renderer explicit across the Embed 7 default-renderer change,
+and escapes dashboard-generated axis-label lookup expressions before Vega
+parses them. Frontend release gates include a production dependency audit,
+representative hostile-label compilation/execution, the complete frontend test
+suite, and a reproducible wheel build containing the generated dashboard. This
+upgrade closes `GHSA-7f2v-3qq3-vvjf` in Vega expressions and
+`GHSA-m9rg-mr6g-75gm` in `vega-functions`; the lock also carries patched
+Svelte, Vite, and Vitest releases and both full and production-only audits must
+remain at zero.
+
 The self-hosted artifact API supports bounded, resumable uploads for model-sized
 blobs. The client negotiates an 8 MiB chunk size, acknowledges chunks
 idempotently, resumes a deterministic upload session after a client or server
@@ -54,6 +66,31 @@ Turso is the default SQL metadata engine through the `pyturso` embedded driver.
 It retains Trackio's SQLite-compatible database-per-project model and local-first
 operation. Set `TRACKIO_DATABASE_ENGINE=sqlite` for the stdlib SQLite fallback.
 
+Apache Doris is implemented as a first-class engine selected with
+`TRACKIO_DATABASE_ENGINE=doris`. Its native provider and migration path have
+passed real-Doris SDK/HTTP, clean-schema bootstrap, content-reconciled
+migration, artifact, restart, concurrency, SQLite/Turso regression,
+backup/restore, retained-project migration, and deployed Trackio/Observatory
+checks. Metric time windows, canonical run listing, tab classification,
+artifact relogging, legacy-link folding, and stable ordering match the logical
+SQLite provider behavior. Doris is authoritative for run, metric,
+system-metric, trace, alert, artifact-metadata, and lineage records; it is not
+a downstream analytical projection. Model and media bytes remain behind
+Trackio's existing server-managed artifact boundary.
+
+This implementation remains an unpublished candidate until its source changes
+are reviewed, committed, pushed, and consumed by immutable commit. The current
+deployment is bound to a source-diff and wheel-digest receipt. Operate one
+Trackio server replica until artifact-version allocation is made safe across
+replicas.
+
+Raw project SQL remains deliberately unavailable with Doris because its tables
+are shared across projects rather than stored in one project-local database.
+The first release remains single-server: the process lock and idempotent
+artifact operations do not provide cross-process version allocation or a
+multi-table transaction. HA requires a staged or optimistic artifact protocol
+and schema-level coordination before additional Trackio writers are allowed.
+
 Turso stores run, metric, trace, artifact-manifest, and lineage metadata. It is
 not the object store: media, model bytes, and native evaluation bundles remain
 under Trackio's existing artifact/file storage boundary. A hosted Hugging Face
@@ -65,7 +102,8 @@ added later without changing the Trackio SDK contract.
 | CarbonTeq release | Upstream repository | Upstream commit |
 | --- | --- | --- |
 | `0.31.5.post1` | `gradio-app/trackio` | `438cb28d2c82c7b7d42431e45d5677a8cc90eb77` |
-| `0.31.5.post2` (release candidate) | `gradio-app/trackio` | `438cb28d2c82c7b7d42431e45d5677a8cc90eb77` |
+| `0.31.5.post2` | `gradio-app/trackio` | `438cb28d2c82c7b7d42431e45d5677a8cc90eb77` |
+| `0.31.5.post3` (release candidate) | `gradio-app/trackio` | `438cb28d2c82c7b7d42431e45d5677a8cc90eb77` |
 
 Every CarbonTeq release must add a row before it is tagged. Platform consumers
 must pin an immutable CarbonTeq commit rather than a branch or tag.
@@ -96,6 +134,6 @@ origin    git@github.com:carbonteq-ai/trackio.git
 upstream  https://github.com/gradio-app/trackio.git
 ```
 
-Rust, Tokio, Doris, and direct worker access to object-storage credentials are
-deferred and are not part of this fork contract. Trackio's existing
-server-managed artifact store remains the byte-storage boundary.
+Rust, Tokio, and direct worker access to object-storage credentials remain
+deferred. Native Doris support is additive; Trackio's existing server-managed
+artifact store remains the byte-storage boundary.

--- a/CARBONTEQ_FORK.md
+++ b/CARBONTEQ_FORK.md
@@ -18,6 +18,9 @@ have a separate `/verifiers` workspace because a rollout is a graph with
 branches, rewards, model calls, tools, phase timing, and environment errors—not
 just a conversation. The Verifiers UI renders structured projections and links
 each rollout to its producing experiment; it never displays the raw payload.
+For an evaluation run, it also joins the selected rollout to the run's aggregate
+`eval/*` metrics so per-rollout evidence and overall results remain distinct but
+visible together.
 
 ## Storage engine
 

--- a/README.md
+++ b/README.md
@@ -13,12 +13,17 @@
 
   
 [![trackio-backend](https://github.com/gradio-app/trackio/actions/workflows/test.yml/badge.svg)](https://github.com/gradio-app/trackio/actions/workflows/test.yml)
-[![PyPI downloads](https://img.shields.io/pypi/dm/trackio)](https://pypi.org/project/trackio/)
-[![PyPI](https://img.shields.io/pypi/v/trackio)](https://pypi.org/project/trackio/)
+[![PyPI downloads](https://img.shields.io/pypi/dm/carbonteq-trackio)](https://pypi.org/project/carbonteq-trackio/)
+[![PyPI](https://img.shields.io/pypi/v/carbonteq-trackio)](https://pypi.org/project/carbonteq-trackio/)
 ![Python version](https://img.shields.io/badge/python-3.10+-important)
 [![Twitter follow](https://img.shields.io/twitter/follow/trackioapp?style=social&label=follow)](https://twitter.com/trackioapp)
 
 </div>
+
+This is CarbonTeq's additive Trackio fork. Install it as
+`carbonteq-trackio`; it preserves the `trackio` Python import and command-line
+interface. See [`CARBONTEQ_FORK.md`](./CARBONTEQ_FORK.md) for the maintained
+delta and upstream baseline.
 
 Welcome to `trackio`: a lightweight, <u>free</u> experiment tracking library built by Hugging Face for humans and AI agents 🤗. 
 
@@ -58,13 +63,13 @@ https://github.com/user-attachments/assets/2683cf27-7520-4fff-9ee9-bdc08a8ca404
 Trackio requires [Python 3.10 or higher](https://www.python.org/downloads/). Install with `pip`:
 
 ```bash
-pip install trackio
+pip install carbonteq-trackio
 ```
 
 or with `uv`:
 
 ```bash
-uv pip install trackio
+uv pip install carbonteq-trackio
 ```
 
 ## Usage

--- a/docs/source/environment_variables.md
+++ b/docs/source/environment_variables.md
@@ -14,6 +14,24 @@ export TRACKIO_DIR="/path/to/trackio/data"
 
 Note: This environment variable applies as long as Trackio is not running in a Space with persistent storage enabled. If Trackio is running in a Space with persistent storage enabled (which is detected with the `PERSISTANT_STORAGE_ENABLED` env variable), then the Trackio data will be stored in `/data/trackio`.
 
+### `TRACKIO_READ_ONLY`
+
+Opens project databases in SQLite read-only mode and disables dataset imports or
+schema initialization. Use this for dashboards, APIs, and other consumers that
+must observe a live `TRACKIO_DIR` without being able to change its evidence.
+New commits made by a separate writer are visible on the consumer's next query;
+the consumer does not need to copy the database or restart.
+
+Mount the directory read-only as a second layer of protection:
+
+```bash
+export TRACKIO_DIR="/evidence/trackio"
+export TRACKIO_READ_ONLY="1"
+```
+
+The project database must already exist. This mode is for readers only; logging,
+artifact writes, schema migrations, and remote dataset imports are disabled.
+
 ### `TRACKIO_SERVER_URL`
 
 Base URL of a self-hosted Trackio server (`http://` or `https://`). You may include `write_token` in the query string (as in the `full_url` from `trackio.show()`), or keep the URL bare and set `TRACKIO_WRITE_TOKEN` instead. When set, `trackio.init()` sends metrics to that server. Equivalent to passing `server_url=` to `trackio.init()`.

--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -12,14 +12,14 @@ Install the library with pip or [uv](https://docs.astral.sh/uv/):
 uv is a fast Rust-based Python package and project manager. Refer to [Installation](https://docs.astral.sh/uv/getting-started/installation/) for installation instructions.
 
 ```bash
-uv pip install trackio
+uv pip install carbonteq-trackio
 ```
 
 </hfoption>
 <hfoption id="pip">
 
 ```bash
-pip install trackio
+pip install carbonteq-trackio
 ```
 
 </hfoption>
@@ -30,7 +30,7 @@ pip install trackio
 You can also install the latest version from source. First clone the repo and then run the installation with `pip`:
 
 ```bash
-git clone https://github.com/gradio-app/trackio.git
+git clone https://github.com/carbonteq-ai/trackio.git
 cd trackio/
 ```
 
@@ -77,17 +77,17 @@ Trackio has optional dependencies for additional features:
 **GPU Monitoring (NVIDIA)** - For logging NVIDIA GPU metrics (utilization, memory, temperature, etc.):
 
 ```bash
-pip install trackio[gpu]
+pip install carbonteq-trackio[gpu]
 ```
 
 **System Monitoring (Apple Silicon)** - For logging CPU, memory, and system metrics on Apple M-series Macs:
 
 ```bash
-pip install trackio[apple-gpu]
+pip install carbonteq-trackio[apple-gpu]
 ```
 
 **TensorBoard Import** - For importing TensorBoard event files:
 
 ```bash
-pip install trackio[tensorboard]
+pip install carbonteq-trackio[tensorboard]
 ```

--- a/docs/source/python_api.md
+++ b/docs/source/python_api.md
@@ -1,8 +1,8 @@
 # Python API for Managing Runs
 
-Trackio provides a Python API class (`trackio.Api()`) that allows you to programmatically manage runs in your projects. This API is similar to `wandb.Api()` and provides methods to delete runs, move runs between projects, and access run information.
+Trackio provides a Python API class (`trackio.Api()`) that allows you to programmatically read runs from a local database or a live Trackio server. The local API also provides methods to delete and move runs.
 
-**Note:** This is different from [Trackio as an API Server](api_mcp_server.md), which runs the Trackio dashboard as a web server with API endpoints. The Python API (`trackio.Api()`) is a client-side interface for managing runs in your local Trackio database.
+The remote form is a read-only client for [Trackio as an API Server](api_mcp_server.md). It returns the same logical run summaries, unsampled history, metric series, traces, alerts, and artifact lineage as the local form. Mutations remain local-only.
 
 ## Basic Usage
 
@@ -23,6 +23,17 @@ for run in runs:
 # Or access by index
 first_run = runs[0]
 ```
+
+To read a live self-hosted server without mounting its storage:
+
+```python
+api = trackio.Api(server_url="http://trackio:7860")
+runs = api.runs("my_project")
+```
+
+Each `api.runs()` call queries the server again, so newly committed runs appear
+without recreating the client. A `Runs` collection itself is a bounded result
+and does not change after it has loaded.
 
 ## Deleting Runs
 
@@ -66,6 +77,9 @@ Main entry point for the Trackio Python API.
 ```python
 api = trackio.Api()
 ```
+
+Pass `server_url=` to construct a read-only live server client. Omit it to read
+and manage local Trackio storage.
 
 #### Methods
 

--- a/docs/source/track.md
+++ b/docs/source/track.md
@@ -212,10 +212,10 @@ Trackio can automatically log system metrics in the background. It supports both
 
 ```bash
 # NVIDIA GPU monitoring
-pip install trackio[gpu]
+pip install carbonteq-trackio[gpu]
 
 # Apple Silicon system monitoring
-pip install trackio[apple-gpu]
+pip install carbonteq-trackio[apple-gpu]
 ```
 
 **Automatic logging (default):**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,12 +3,16 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project]
-name = "trackio"
-description = "A lightweight, local-first, and free experiment tracking library built on top of Hugging Face Datasets and Spaces."
+name = "carbonteq-trackio"
+version = "0.31.5.post1"
+description = "CarbonTeq-maintained Trackio fork with post-training trace and storage extensions."
 authors = [
     { name = "Abubakar Abid", email = "abubakar@huggingface.co" },
     { name = "Zach Nation", email = "zach@huggingface.co" },
     { name = "Saba Noorassa", email = "saba@huggingface.co" },
+]
+maintainers = [
+    { name = "CarbonTeq AI" },
 ]
 readme = "README.md"
 requires-python = ">=3.10"
@@ -30,11 +34,11 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]
-dynamic = ["version"]
 
 [project.urls]
-homepage = "https://github.com/gradio-app/trackio"
-repository = "https://github.com/gradio-app/trackio"
+homepage = "https://github.com/carbonteq-ai/trackio"
+repository = "https://github.com/carbonteq-ai/trackio"
+upstream = "https://github.com/gradio-app/trackio"
 
 [project.optional-dependencies]
 dev = [
@@ -72,10 +76,6 @@ trackio = "trackio.cli:main"
 [tool.hatch.build.targets.wheel]
 packages = ["trackio"]
 artifacts = ["trackio/frontend/dist/**", "trackio/frontend_templates/**"]
-
-[tool.hatch.version]
-path = "trackio/package.json"
-pattern = ".*\"version\":\\s*\"(?P<version>[^\"]+)\""
 
 [tool.ruff]
 # Exclude a variety of commonly ignored directories.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "carbonteq-trackio"
-version = "0.31.5.post2"
+version = "0.31.5.post3"
 description = "CarbonTeq-maintained Trackio fork with post-training trace and storage extensions."
 authors = [
     { name = "Abubakar Abid", email = "abubakar@huggingface.co" },
@@ -27,6 +27,7 @@ dependencies = [
     "orjson>=3.0,<4.0.0",
     "brotli>=1.0.0,<2.0.0",
     "pyturso>=0.7.0,<1.0.0",
+    "pymysql>=1.1.0,<2.0.0",
     "tomli>=2.0.0; python_version < '3.11'",
 ]
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "carbonteq-trackio"
-version = "0.31.5.post1"
+version = "0.31.5.post2"
 description = "CarbonTeq-maintained Trackio fork with post-training trace and storage extensions."
 authors = [
     { name = "Abubakar Abid", email = "abubakar@huggingface.co" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "carbonteq-trackio"
-version = "0.31.5.post3"
+version = "0.31.5.post4"
 description = "CarbonTeq-maintained Trackio fork with post-training trace and storage extensions."
 authors = [
     { name = "Abubakar Abid", email = "abubakar@huggingface.co" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "pillow<13.0.0",
     "orjson>=3.0,<4.0.0",
     "brotli>=1.0.0,<2.0.0",
+    "pyturso>=0.7.0,<1.0.0",
     "tomli>=2.0.0; python_version < '3.11'",
 ]
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "carbonteq-trackio"
-version = "0.31.5.post4"
+version = "0.31.5.post5"
 description = "CarbonTeq-maintained Trackio fork with post-training trace and storage extensions."
 authors = [
     { name = "Abubakar Abid", email = "abubakar@huggingface.co" },

--- a/tests/integration/test_doris_storage.py
+++ b/tests/integration/test_doris_storage.py
@@ -1,0 +1,299 @@
+import os
+import sqlite3
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+
+from trackio.doris_migration import migrate_sqlite_to_doris
+from trackio.doris_storage import DorisStorage
+
+REQUIRED_ENV = (
+    "TRACKIO_DORIS_HOST",
+    "TRACKIO_DORIS_DATABASE",
+    "TRACKIO_DORIS_USER",
+)
+
+
+pytestmark = pytest.mark.skipif(
+    any(not os.environ.get(name) for name in REQUIRED_ENV),
+    reason="real Doris integration settings are not configured",
+)
+
+
+def test_core_evidence_round_trip_is_idempotent():
+    project = "trackio-doris-integration"
+    run = "core-evidence"
+    run_id = "trackio-doris-integration-v1"
+    timestamps = [
+        "2026-07-26T11:20:00+00:00",
+        "2026-07-26T11:20:01+00:00",
+    ]
+    payload = {
+        "project": project,
+        "run": run,
+        "run_id": run_id,
+        "metrics_list": [
+            {
+                "loss": 1.0,
+                "tokens": 8,
+                "rollout": {
+                    "_type": "trackio.trace",
+                    "messages": [
+                        {"role": "user", "content": "test"},
+                        {"role": "assistant", "content": "ok"},
+                    ],
+                    "metadata": {"reward": 1.0},
+                },
+            },
+            {"loss": 0.5, "tokens": 16},
+        ],
+        "steps": [0, 1],
+        "timestamps": timestamps,
+        "log_ids": ["metric-0", "metric-1"],
+        "config": {"engine": "doris"},
+    }
+
+    DorisStorage.bulk_log(**payload)
+    DorisStorage.bulk_log(**payload)
+    DorisStorage.bulk_log_system(
+        project=project,
+        run=run,
+        run_id=run_id,
+        metrics_list=[{"gpu/utilization": 50.0}],
+        timestamps=["2026-07-26T11:20:00.500000+00:00"],
+        log_ids=["system-0"],
+    )
+    DorisStorage.bulk_alert(
+        project=project,
+        run=run,
+        run_id=run_id,
+        titles=["qualification"],
+        texts=["native Doris write/read"],
+        levels=["INFO"],
+        steps=[1],
+        timestamps=["2026-07-26T11:20:02+00:00"],
+        alert_ids=["alert-0"],
+    )
+
+    assert DorisStorage.get_log_count(project, run_id=run_id) == 2
+    assert DorisStorage.get_logs(project, run_id=run_id)[-1]["loss"] == 0.5
+    assert DorisStorage.get_run_config(project, run_id=run_id) == {"engine": "doris"}
+    assert (
+        DorisStorage.get_system_logs(project, run_id=run_id)[0]["gpu/utilization"]
+        == 50.0
+    )
+    assert (
+        DorisStorage.get_alerts(project, run_id=run_id)[0]["title"] == "qualification"
+    )
+    traces = DorisStorage.get_traces(project, run_id=run_id)
+    assert len(traces) == 1
+    assert traces[0]["metadata"]["reward"] == 1.0
+
+
+def test_artifact_metadata_lineage_and_run_mutations():
+    project = "trackio-doris-artifact-integration"
+    producer_id = "producer-v1"
+    manifest = [
+        {
+            "path": "adapter/config.json",
+            "digest": "a" * 64,
+            "size": 17,
+        }
+    ]
+
+    first = DorisStorage.commit_artifact_version(
+        project=project,
+        name="adapter",
+        type="model",
+        description="qualification",
+        manifest=manifest,
+        metadata={"format": "peft"},
+        aliases=["candidate"],
+        run_name="producer",
+        run_id=producer_id,
+    )
+    second = DorisStorage.commit_artifact_version(
+        project=project,
+        name="adapter",
+        type="model",
+        description="qualification",
+        manifest=manifest,
+        metadata={"format": "peft"},
+        aliases=["candidate"],
+        run_name="producer",
+        run_id=producer_id,
+    )
+    assert first["version_id"] == second["version_id"]
+    assert first["version"] == 0
+    assert set(first["aliases"]) == {"candidate", "latest"}
+
+    DorisStorage.insert_run_artifact_link(
+        project=project,
+        run_name="consumer",
+        run_id="consumer-v1",
+        version_id=first["version_id"],
+        direction="input",
+    )
+    linked = DorisStorage.get_run_artifacts(project, "consumer", run_id="consumer-v1")
+    assert linked["input"][0]["name"] == "adapter"
+    assert (
+        DorisStorage.get_artifact_consumers(project, first["version_id"])[0]["run_id"]
+        == "consumer-v1"
+    )
+
+    mutation_id = "mutation-v1"
+    DorisStorage.bulk_log(
+        project=project,
+        run="before",
+        run_id=mutation_id,
+        metrics_list=[{"value": 1}],
+        steps=[0],
+        timestamps=["2026-07-26T11:31:00+00:00"],
+        log_ids=["mutation-0"],
+        config={"state": "before"},
+    )
+    DorisStorage.rename_run(project, "before", "after", run_id=mutation_id)
+    assert DorisStorage.get_logs(project, "after", run_id=mutation_id)[0]["value"] == 1
+    assert DorisStorage.delete_run(project, "after", run_id=mutation_id)
+    assert not DorisStorage.delete_run(project, "after", run_id=mutation_id)
+
+
+def test_sqlite_copy_and_reconciliation(tmp_path):
+    source = tmp_path / "trackio-doris-migration-integration.db"
+    connection = sqlite3.connect(source)
+    try:
+        connection.execute(
+            """
+            CREATE TABLE metrics (
+                id INTEGER PRIMARY KEY,
+                run_id TEXT NOT NULL,
+                timestamp TEXT NOT NULL,
+                run_name TEXT NOT NULL,
+                step INTEGER NOT NULL,
+                metrics TEXT NOT NULL,
+                log_id TEXT,
+                space_id TEXT
+            )
+            """
+        )
+        connection.execute(
+            """
+            CREATE TABLE configs (
+                id INTEGER PRIMARY KEY,
+                run_id TEXT NOT NULL,
+                run_name TEXT NOT NULL,
+                config TEXT NOT NULL,
+                created_at TEXT NOT NULL
+            )
+            """
+        )
+        connection.executemany(
+            """
+            INSERT INTO metrics
+                (id, run_id, timestamp, run_name, step, metrics, log_id)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            [
+                (
+                    1,
+                    "migration-run-v1",
+                    "2026-07-26T11:40:00+00:00",
+                    "migration-run",
+                    0,
+                    '{"loss":1.0}',
+                    "migration-log-0",
+                ),
+                (
+                    2,
+                    "migration-run-v1",
+                    "2026-07-26T11:40:01+00:00",
+                    "migration-run",
+                    1,
+                    '{"loss":0.5}',
+                    "migration-log-1",
+                ),
+            ],
+        )
+        connection.execute(
+            """
+            INSERT INTO configs
+                (id, run_id, run_name, config, created_at)
+            VALUES (1, 'migration-run-v1', 'migration-run',
+                    '{"engine":"sqlite"}',
+                    '2026-07-26T11:40:00+00:00')
+            """
+        )
+        connection.commit()
+    finally:
+        connection.close()
+
+    receipt = migrate_sqlite_to_doris(
+        source,
+        tmp_path / "migration-receipt.json",
+        batch_size=1,
+    )
+    assert receipt["verified"] is True
+    project = source.stem
+    assert DorisStorage.get_log_count(project, run_id="migration-run-v1") == 2
+    assert DorisStorage.get_run_config(project, run_id="migration-run-v1") == {
+        "engine": "sqlite"
+    }
+
+    verified = migrate_sqlite_to_doris(
+        source,
+        tmp_path / "verify-receipt.json",
+        verify_only=True,
+    )
+    assert verified["verified"] is True
+
+
+def test_concurrent_writers_and_project_isolation():
+    project = "trackio-doris-concurrency"
+
+    def write(writer: int) -> None:
+        run_id = f"writer-{writer}"
+        DorisStorage.bulk_log(
+            project=project,
+            run="shared-name",
+            run_id=run_id,
+            metrics_list=[{"writer": writer, "value": index} for index in range(25)],
+            steps=list(range(25)),
+            timestamps=[
+                f"2026-07-26T12:{writer:02d}:{index:02d}+00:00" for index in range(25)
+            ],
+            log_ids=[f"writer-{writer}-log-{index}" for index in range(25)],
+            config={"writer": writer},
+        )
+
+    with ThreadPoolExecutor(max_workers=4) as executor:
+        list(executor.map(write, range(4)))
+    with ThreadPoolExecutor(max_workers=4) as executor:
+        list(executor.map(write, range(4)))
+
+    records = DorisStorage.get_run_records(project)
+    assert {record["id"] for record in records} == {
+        "writer-0",
+        "writer-1",
+        "writer-2",
+        "writer-3",
+    }
+    assert (
+        sum(
+            DorisStorage.get_log_count(project, run_id=f"writer-{writer}")
+            for writer in range(4)
+        )
+        == 100
+    )
+
+    other_project = "trackio-doris-concurrency-other"
+    DorisStorage.bulk_log(
+        project=other_project,
+        run="shared-name",
+        run_id="writer-0",
+        metrics_list=[{"value": 999}],
+        steps=[0],
+        timestamps=["2026-07-26T12:59:00+00:00"],
+        log_ids=["other-project-log"],
+    )
+    assert DorisStorage.get_log_count(other_project, run_id="writer-0") == 1
+    assert DorisStorage.get_log_count(project, run_id="writer-0") == 25

--- a/tests/ui/test_ui_display.py
+++ b/tests/ui/test_ui_display.py
@@ -208,6 +208,22 @@ def test_verifiers_rollouts_have_a_dedicated_branch_aware_ui(temp_dir):
             )
         }
     )
+    trackio.log(
+        {
+            "eval/rollouts": 4,
+            "eval/completed": 4,
+            "eval/mean_reward": 0.75,
+            "eval/error_rate": 0.0,
+            "eval/truncated_rollout_rate": 0.25,
+            "eval/model_call_latency_p95_seconds": 1.5,
+            "eval/input_tokens": 100,
+            "eval/output_tokens": 20,
+            "eval/provider_cost": 0.0123,
+            "eval/trace_sync_complete": 1,
+            "eval/reward/correct": 0.75,
+            "eval/environment_metric/tool_success": 0.5,
+        }
+    )
     trackio.finish()
     app, _, _, full_url = trackio.show(
         project=project, block_thread=False, open_browser=False
@@ -228,6 +244,10 @@ def test_verifiers_rollouts_have_a_dedicated_branch_aware_ui(temp_dir):
             ).to_be_visible()
             expect(page.get_by_role("button", name="Final", exact=True)).to_be_visible()
             expect(page.get_by_text("final answer", exact=True)).to_be_visible()
+            expect(page.get_by_text("Evaluation result", exact=True)).to_be_visible()
+            expect(page.get_by_text("aggregate across 4 rollouts", exact=True)).to_be_visible()
+            expect(page.get_by_text("0.750", exact=True).first).to_be_visible()
+            expect(page.get_by_text("$0.0123", exact=True)).to_be_visible()
             expect(page.get_by_text("must-not-render", exact=True)).to_have_count(0)
             expect(
                 page.get_by_role("button", name="Open experiment ↗", exact=True)

--- a/tests/ui/test_ui_display.py
+++ b/tests/ui/test_ui_display.py
@@ -28,7 +28,7 @@ def test_runs_plots_images_are_displayed(temp_dir):
             page.goto(full_url)
             page.wait_for_load_state("networkidle")
             nav_links = page.locator(".nav-link")
-            expect(nav_links).to_have_count(9)
+            expect(nav_links).to_have_count(10)
 
             run_label = page.locator(".run-name", has_text="test_run")
             expect(run_label).to_be_visible()
@@ -112,7 +112,7 @@ def test_navbar_page_navigation(temp_dir):
             page.goto(full_url)
             page.wait_for_load_state("networkidle")
             nav_links = page.locator(".nav-link")
-            expect(nav_links).to_have_count(9)
+            expect(nav_links).to_have_count(10)
 
             expect(page.locator(".metrics-page")).to_be_visible()
 
@@ -153,7 +153,7 @@ def test_runs_table_shows_run_data(temp_dir):
             page.wait_for_load_state("networkidle")
 
             nav_links = page.locator(".nav-link")
-            expect(nav_links).to_have_count(9)
+            expect(nav_links).to_have_count(10)
             page.get_by_role("button", name="Runs", exact=True).click()
             page.wait_for_load_state("networkidle")
 
@@ -167,6 +167,74 @@ def test_runs_table_shows_run_data(temp_dir):
             browser.close()
     finally:
         trackio.delete_project("test_runs_table", force=True)
+        app.close()
+
+
+def test_verifiers_rollouts_have_a_dedicated_branch_aware_ui(temp_dir):
+    project = "test_verifiers_ui"
+    trackio.init(project=project, name="eval-run")
+    trackio.log(
+        {
+            "rollout": trackio.VerifiersTrace(
+                {
+                    "id": "rollout-branching-1",
+                    "version": 2,
+                    "agent": {"model": "org/reasoning-model"},
+                    "task": {"type": "ToolTask", "data": {"prompt": "Solve it"}},
+                    "nodes": [
+                        {"message": {"role": "user", "content": "Solve it"}},
+                        {
+                            "parent": 0,
+                            "message": {
+                                "role": "assistant",
+                                "content": "discarded answer",
+                            },
+                        },
+                        {
+                            "parent": 0,
+                            "message": {"role": "assistant", "content": "final answer"},
+                        },
+                    ],
+                    "calls": [
+                        {"finish_reason": "stop", "usage": {"completion_tokens": 4}}
+                    ],
+                    "rewards": {"correct": 1.0},
+                    "metrics": {"tool_success": 1.0},
+                    "errors": [],
+                    "stop_condition": "agent_completed",
+                    "is_completed": True,
+                    "private_runtime_detail": "must-not-render",
+                }
+            )
+        }
+    )
+    trackio.finish()
+    app, _, _, full_url = trackio.show(
+        project=project, block_thread=False, open_browser=False
+    )
+
+    try:
+        with sync_playwright() as p:
+            browser = p.chromium.launch()
+            page = browser.new_page()
+            page.set_default_timeout(5000)
+            page.goto(full_url)
+            page.wait_for_load_state("networkidle")
+            page.get_by_role("button", name="Verifiers", exact=True).click()
+            expect(page.locator(".verifiers-page")).to_be_visible()
+            expect(page.get_by_text("rollout-branching-1", exact=True)).to_be_visible()
+            expect(
+                page.get_by_role("button", name="Branch 1", exact=True)
+            ).to_be_visible()
+            expect(page.get_by_role("button", name="Final", exact=True)).to_be_visible()
+            expect(page.get_by_text("final answer", exact=True)).to_be_visible()
+            expect(page.get_by_text("must-not-render", exact=True)).to_have_count(0)
+            expect(
+                page.get_by_role("button", name="Open experiment ↗", exact=True)
+            ).to_be_visible()
+            browser.close()
+    finally:
+        trackio.delete_project(project, force=True)
         app.close()
 
 

--- a/tests/unit/test_api_reads.py
+++ b/tests/unit/test_api_reads.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import pytest
 
 import trackio
+import trackio.api as api_module
 from trackio.sqlite_storage import SQLiteStorage
 
 
@@ -150,3 +151,41 @@ def test_api_read_only_mode_sees_new_runs_without_reopening_storage(temp_dir, mo
     monkeypatch.setenv("TRACKIO_READ_ONLY", "1")
 
     assert {run.name for run in api.runs(project)} == {"first", "second"}
+
+
+def test_api_remote_reader_uses_live_server_queries(monkeypatch):
+    class FakeRemoteClient:
+        runs = [
+            {"id": "run-1", "name": "first", "created_at": "2026-01-01T00:00:00+00:00"}
+        ]
+
+        def __init__(self, server_url, hf_token=None):
+            assert server_url == "http://trackio:7860"
+            assert hf_token is None
+
+        def predict(self, *, api_name, **kwargs):
+            assert kwargs["project"] == "live-project"
+            if api_name == "/get_runs_for_project":
+                return list(self.runs)
+            if api_name == "/get_run_summary":
+                return {
+                    "config": {"schema_version": 4},
+                    "num_logs": 1,
+                    "last_step": 7,
+                    "metrics": ["train/loss"],
+                }
+            if api_name == "/get_run_history":
+                return [{"step": 7, "timestamp": "now", "train/loss": 0.5}]
+            raise AssertionError(f"unexpected API call {api_name}")
+
+    monkeypatch.setattr(api_module, "RemoteClient", FakeRemoteClient)
+    api = trackio.Api(server_url="http://trackio:7860")
+
+    first = api.run("live-project", "run-1")
+    assert first.summary()["last_step"] == 7
+    assert first.metric_series()["train/loss"][0]["value"] == 0.5
+
+    FakeRemoteClient.runs.append(
+        {"id": "run-2", "name": "second", "created_at": "2026-01-02T00:00:00+00:00"}
+    )
+    assert {run.id for run in api.runs("live-project")} == {"run-1", "run-2"}

--- a/tests/unit/test_api_reads.py
+++ b/tests/unit/test_api_reads.py
@@ -95,7 +95,9 @@ def test_api_exposes_stable_run_reads(temp_dir):
     traces = run.traces(sort="step_asc")
     assert {trace["trace_type"] for trace in traces} == {"trackio", "verifiers"}
     assert run.traces(trace_type="verifiers")[0]["external_id"] == "vf-api-1"
-    assert run.artifacts()["output"][0]["name"] == "trained-model"
+    output_link = run.artifacts()["output"][0]
+    assert output_link["name"] == "trained-model"
+    assert output_link["digest"] == output.digest
     assert runs[consumer_id].artifacts()["input"][0]["name"] == "trained-model"
 
     with pytest.raises(ValueError, match="does not exist"):

--- a/tests/unit/test_api_reads.py
+++ b/tests/unit/test_api_reads.py
@@ -1,0 +1,123 @@
+from pathlib import Path
+
+import pytest
+
+import trackio
+
+
+def _verifiers_record() -> dict:
+    return {
+        "id": "vf-api-1",
+        "version": 2,
+        "agent": {"model": "org/model"},
+        "task": {"type": "ExampleTask", "data": {"idx": 1}},
+        "nodes": [
+            {"message": {"role": "user", "content": "question"}},
+            {
+                "parent": 0,
+                "message": {"role": "assistant", "content": "answer"},
+            },
+        ],
+        "calls": [],
+        "rewards": {"correct": 1.0},
+        "metrics": {},
+        "errors": [],
+        "stop_condition": "agent_completed",
+        "is_completed": True,
+    }
+
+
+def test_api_exposes_stable_run_reads(temp_dir):
+    project = "api-read-surface"
+    writer = trackio.init(
+        project=project,
+        name="train-run",
+        config={"model": {"id": "org/model"}},
+        group="package-1",
+    )
+    run_id = writer.id
+    writer.log({"train/loss": 2.0, "event/name": "started"}, step=0)
+    writer.log({"train/loss": 1.0}, step=1)
+    writer.log(
+        {
+            "trace": trackio.Trace(
+                [{"role": "user", "content": "hello"}],
+                {"kind": "standard"},
+            ),
+            "rollout": trackio.VerifiersTrace(_verifiers_record()),
+        },
+        step=2,
+    )
+
+    artifact_path = Path(temp_dir) / "model.txt"
+    artifact_path.write_text("weights")
+    output = writer.log_artifact(artifact_path, name="trained-model", type="model")
+    writer.finish()
+
+    consumer = trackio.init(project=project, name="eval-run")
+    consumer_id = consumer.id
+    consumer.use_artifact(f"{output.name}:{output.version}", type="model")
+    consumer.log({"eval/score": 0.9}, step=0)
+    consumer.finish()
+
+    api = trackio.Api()
+    runs = {run.id: run for run in api.runs(project)}
+    run = api.run(project, run_id)
+
+    assert api.capabilities() == {
+        "run_summaries": True,
+        "full_history": True,
+        "explicit_metric_steps": True,
+        "standard_traces": True,
+        "verifiers_traces": True,
+        "live_traces": True,
+        "artifact_lineage": True,
+        "alerts": True,
+    }
+    assert run.created_at is not None
+    assert run.summary()["config"]["model"] == {"id": "org/model"}
+    assert run.summary()["last_step"] == 2
+    assert run.history(keys=["train/loss"]) == [
+        {
+            "train/loss": 2.0,
+            "timestamp": run.history()[0]["timestamp"],
+            "step": 0,
+        },
+        {
+            "train/loss": 1.0,
+            "timestamp": run.history()[1]["timestamp"],
+            "step": 1,
+        },
+        {"timestamp": run.history()[2]["timestamp"], "step": 2},
+    ]
+    assert [point["value"] for point in run.metric_series(["train/loss"])["train/loss"]] == [2.0, 1.0]
+
+    traces = run.traces(sort="step_asc")
+    assert {trace["trace_type"] for trace in traces} == {"trackio", "verifiers"}
+    assert run.traces(trace_type="verifiers")[0]["external_id"] == "vf-api-1"
+    assert run.artifacts()["output"][0]["name"] == "trained-model"
+    assert runs[consumer_id].artifacts()["input"][0]["name"] == "trained-model"
+
+    with pytest.raises(ValueError, match="does not exist"):
+        api.run(project, "missing-run")
+
+
+def test_api_reads_empty_run_created_by_artifact_link(temp_dir):
+    project = "api-empty-run"
+    producer = trackio.init(project=project, name="producer")
+    artifact_path = Path(temp_dir) / "dataset.txt"
+    artifact_path.write_text("row")
+    artifact = producer.log_artifact(artifact_path, name="dataset", type="dataset")
+    producer.finish()
+
+    consumer = trackio.init(project=project, name="consumer")
+    consumer_id = consumer.id
+    consumer.use_artifact(f"dataset:{artifact.version}", type="dataset")
+    consumer.finish()
+
+    run = next(run for run in trackio.Api().runs(project) if run.id == consumer_id)
+    assert run.summary()["num_logs"] == 0
+    assert run.history() == []
+    assert run.metric_series() == {}
+    assert run.traces() == []
+    assert run.artifacts()["input"][0]["version"] == 0

--- a/tests/unit/test_api_reads.py
+++ b/tests/unit/test_api_reads.py
@@ -1,8 +1,10 @@
+import sqlite3
 from pathlib import Path
 
 import pytest
 
 import trackio
+from trackio.sqlite_storage import SQLiteStorage
 
 
 def _verifiers_record() -> dict:
@@ -123,3 +125,28 @@ def test_api_reads_empty_run_created_by_artifact_link(temp_dir):
     assert run.metric_series() == {}
     assert run.traces() == []
     assert run.artifacts()["input"][0]["version"] == 0
+
+
+def test_api_read_only_mode_sees_new_runs_without_reopening_storage(temp_dir, monkeypatch):
+    project = "api-live-read-only"
+    first = trackio.init(project=project, name="first")
+    first.log({"loss": 2.0}, step=0)
+    first.finish()
+
+    api = trackio.Api()
+    monkeypatch.setenv("TRACKIO_READ_ONLY", "1")
+    assert [run.name for run in api.runs(project)] == ["first"]
+    with pytest.raises(sqlite3.OperationalError, match="readonly"):
+        SQLiteStorage.bulk_log(
+            project,
+            "blocked",
+            [{"loss": 1.0}],
+        )
+
+    monkeypatch.delenv("TRACKIO_READ_ONLY")
+    second = trackio.init(project=project, name="second")
+    second.log({"loss": 1.0}, step=1)
+    second.finish()
+    monkeypatch.setenv("TRACKIO_READ_ONLY", "1")
+
+    assert {run.name for run in api.runs(project)} == {"first", "second"}

--- a/tests/unit/test_api_reads.py
+++ b/tests/unit/test_api_reads.py
@@ -41,6 +41,16 @@ def test_api_exposes_stable_run_reads(temp_dir):
     run_id = writer.id
     writer.log({"train/loss": 2.0, "event/name": "started"}, step=0)
     writer.log({"train/loss": 1.0}, step=1)
+    SQLiteStorage.bulk_log_system(
+        project,
+        "train-run",
+        [{"cpu/utilization": 42.0}, {"cpu/utilization": 51.0}],
+        timestamps=[
+            "2026-01-01T00:00:00+00:00",
+            "2026-01-01T00:00:05+00:00",
+        ],
+        run_id=run_id,
+    )
     writer.log(
         {
             "trace": trackio.Trace(
@@ -76,6 +86,7 @@ def test_api_exposes_stable_run_reads(temp_dir):
         "live_traces": True,
         "artifact_lineage": True,
         "alerts": True,
+        "system_metrics": True,
     }
     assert run.created_at is not None
     assert run.summary()["config"]["model"] == {"id": "org/model"}
@@ -94,6 +105,8 @@ def test_api_exposes_stable_run_reads(temp_dir):
         {"timestamp": run.history()[2]["timestamp"], "step": 2},
     ]
     assert [point["value"] for point in run.metric_series(["train/loss"])["train/loss"]] == [2.0, 1.0]
+    assert run.system_metric_names() == ["cpu/utilization"]
+    assert [row["cpu/utilization"] for row in run.system_history()] == [42.0, 51.0]
 
     traces = run.traces(sort="step_asc")
     assert {trace["trace_type"] for trace in traces} == {"trackio", "verifiers"}
@@ -176,6 +189,15 @@ def test_api_remote_reader_uses_live_server_queries(monkeypatch):
                 }
             if api_name == "/get_run_history":
                 return [{"step": 7, "timestamp": "now", "train/loss": 0.5}]
+            if api_name == "/get_system_metrics_for_run":
+                return ["cpu/utilization"]
+            if api_name == "/get_system_logs":
+                return [
+                    {
+                        "timestamp": "2026-01-01T00:00:01+00:00",
+                        "cpu/utilization": 33.0,
+                    }
+                ]
             raise AssertionError(f"unexpected API call {api_name}")
 
     monkeypatch.setattr(api_module, "RemoteClient", FakeRemoteClient)
@@ -184,6 +206,8 @@ def test_api_remote_reader_uses_live_server_queries(monkeypatch):
     first = api.run("live-project", "run-1")
     assert first.summary()["last_step"] == 7
     assert first.metric_series()["train/loss"][0]["value"] == 0.5
+    assert first.system_metric_names() == ["cpu/utilization"]
+    assert first.system_history()[0]["cpu/utilization"] == 33.0
 
     FakeRemoteClient.runs.append(
         {"id": "run-2", "name": "second", "created_at": "2026-01-02T00:00:00+00:00"}

--- a/tests/unit/test_artifact_resumable_process_e2e.py
+++ b/tests/unit/test_artifact_resumable_process_e2e.py
@@ -1,0 +1,268 @@
+"""Real-process producer test for resumable self-hosted artifact transport."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import socket
+import subprocess
+import sys
+import threading
+import time
+from pathlib import Path
+
+import httpx
+import pytest
+
+import trackio
+import trackio.remote_client as remote_client_module
+from trackio.remote_client import RemoteClient
+
+
+def _free_port() -> int:
+    with socket.socket() as listener:
+        listener.bind(("127.0.0.1", 0))
+        return int(listener.getsockname()[1])
+
+
+def _wait_ready(url: str, process: subprocess.Popen[str]) -> None:
+    deadline = time.monotonic() + 15
+    while time.monotonic() < deadline:
+        if process.poll() is not None:
+            stdout, stderr = process.communicate()
+            raise RuntimeError(
+                f"Trackio server exited early: stdout={stdout[-1000:]} stderr={stderr[-1000:]}"
+            )
+        try:
+            response = httpx.get(f"{url}/version", timeout=1)
+            if response.status_code == 200:
+                return
+        except httpx.RequestError:
+            pass
+        time.sleep(0.05)
+    raise TimeoutError("Trackio server did not become ready")
+
+
+def _start_server(
+    *,
+    server_dir: Path,
+    port: int,
+    token: str,
+) -> subprocess.Popen[str]:
+    environment = {
+        **os.environ,
+        "TRACKIO_DIR": str(server_dir),
+        "TRACKIO_WRITE_TOKEN": token,
+    }
+    return subprocess.Popen(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import trackio; "
+                f"trackio.show(open_browser=False, block_thread=True, host='127.0.0.1', server_port={port})"
+            ),
+        ],
+        env=environment,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+def _stop_server(server: subprocess.Popen[str]) -> None:
+    server.terminate()
+    try:
+        server.wait(timeout=10)
+    except subprocess.TimeoutExpired:
+        server.kill()
+        server.wait(timeout=5)
+
+
+def _rss_bytes(pid: int) -> int:
+    status = Path(f"/proc/{pid}/status").read_text()
+    for line in status.splitlines():
+        if line.startswith("VmRSS:"):
+            return int(line.split()[1]) * 1024
+    raise RuntimeError(f"VmRSS is unavailable for pid {pid}")
+
+
+def _write_deterministic(path: Path, size_bytes: int) -> str:
+    chunk = (b"trackio-resumable-e2e-" * 65536)[: 1024 * 1024]
+    sha = hashlib.sha256()
+    remaining = size_bytes
+    with path.open("wb") as handle:
+        while remaining:
+            payload = chunk[: min(remaining, len(chunk))]
+            handle.write(payload)
+            sha.update(payload)
+            remaining -= len(payload)
+    return sha.hexdigest()
+
+
+def _run_process_round_trip(
+    *,
+    temp_dir: str,
+    tmp_path: Path,
+    monkeypatch,
+    size_bytes: int,
+    project: str,
+) -> dict[str, int]:
+    server_dir = tmp_path / "server"
+    server_dir.mkdir()
+    port = _free_port()
+    url = f"http://127.0.0.1:{port}"
+    token = "qualification-only-token"
+    server = _start_server(server_dir=server_dir, port=port, token=token)
+    source = tmp_path / "weights.bin"
+    digest = _write_deterministic(source, size_bytes)
+    stop_monitor = threading.Event()
+    baseline_rss = 0
+    peak_rss = 0
+
+    def monitor_server() -> None:
+        nonlocal peak_rss
+        while not stop_monitor.wait(0.005):
+            peak_rss = max(peak_rss, _rss_bytes(server.pid))
+
+    try:
+        _wait_ready(url, server)
+        baseline_rss = _rss_bytes(server.pid)
+        peak_rss = baseline_rss
+        monitor = threading.Thread(target=monitor_server, daemon=True)
+        monitor.start()
+        monkeypatch.setenv("TRACKIO_WRITE_TOKEN", token)
+        run = trackio.init(
+            project=project,
+            name="producer",
+            server_url=url,
+            auto_log_cpu=False,
+            auto_log_gpu=False,
+            embed=False,
+        )
+        artifact = trackio.log_artifact(source, name="model", type="model")
+        trackio.finish()
+
+        assert artifact.version == "v0"
+        assert run.id
+        readback_sha = hashlib.sha256()
+        readback_size = 0
+        with httpx.stream(
+            "GET",
+            f"{url}/artifact_blob/{project}/{digest}",
+            timeout=300,
+        ) as response:
+            response.raise_for_status()
+            for chunk in response.iter_bytes():
+                readback_sha.update(chunk)
+                readback_size += len(chunk)
+        assert readback_sha.hexdigest() == digest
+        assert readback_size == size_bytes
+        assert not (
+            Path(temp_dir)
+            / "artifacts"
+            / project
+            / "blobs"
+            / "sha256"
+            / digest[:2]
+            / digest
+        ).samefile(server_dir / "artifacts" / project / "blobs" / "sha256" / digest[:2] / digest)
+        stop_monitor.set()
+        monitor.join(timeout=2)
+        return {
+            "server_baseline_rss_bytes": baseline_rss,
+            "server_peak_rss_bytes": peak_rss,
+            "server_peak_delta_bytes": peak_rss - baseline_rss,
+        }
+    finally:
+        stop_monitor.set()
+        _stop_server(server)
+
+
+def test_remote_log_artifact_uses_distinct_server_storage(
+    temp_dir,
+    tmp_path,
+    monkeypatch,
+):
+    _run_process_round_trip(
+        temp_dir=temp_dir,
+        tmp_path=tmp_path,
+        monkeypatch=monkeypatch,
+        size_bytes=16 * 1024 * 1024 + 17,
+        project="process-resumable",
+    )
+
+
+@pytest.mark.skipif(
+    os.environ.get("TRACKIO_LARGE_ARTIFACT_TEST") != "1",
+    reason="set TRACKIO_LARGE_ARTIFACT_TEST=1 for the 512 MiB transport gate",
+)
+def test_remote_log_artifact_round_trips_512_mib(
+    temp_dir,
+    tmp_path,
+    monkeypatch,
+):
+    evidence = _run_process_round_trip(
+        temp_dir=temp_dir,
+        tmp_path=tmp_path,
+        monkeypatch=monkeypatch,
+        size_bytes=512 * 1024 * 1024,
+        project="process-resumable-large",
+    )
+    print(json.dumps(evidence, sort_keys=True))
+    assert evidence["server_peak_delta_bytes"] < 128 * 1024 * 1024
+
+
+def test_client_resumes_after_server_process_restart(tmp_path, monkeypatch):
+    server_dir = tmp_path / "server"
+    server_dir.mkdir()
+    port = _free_port()
+    url = f"http://127.0.0.1:{port}"
+    token = "qualification-only-token"
+    project = "process-restart-resume"
+    source = tmp_path / "weights.bin"
+    digest = _write_deterministic(source, 16 * 1024 * 1024 + 17)
+    server = _start_server(server_dir=server_dir, port=port, token=token)
+    _wait_ready(url, server)
+    client = RemoteClient(url, write_token=token, verbose=False)
+    real_put = remote_client_module.httpx.put
+    puts = 0
+
+    def disconnect_second_chunk(*args, **kwargs):
+        nonlocal puts
+        puts += 1
+        if puts == 2:
+            request = httpx.Request("PUT", str(args[0]))
+            raise httpx.ConnectError("synthetic disconnect", request=request)
+        return real_put(*args, **kwargs)
+
+    try:
+        monkeypatch.setattr(
+            remote_client_module.httpx,
+            "put",
+            disconnect_second_chunk,
+        )
+        with pytest.raises(httpx.ConnectError, match="synthetic disconnect"):
+            client.upload_artifact_blob(project, digest, source)
+        _stop_server(server)
+
+        monkeypatch.setattr(remote_client_module.httpx, "put", real_put)
+        server = _start_server(server_dir=server_dir, port=port, token=token)
+        _wait_ready(url, server)
+        resumed = RemoteClient(url, write_token=token, verbose=False)
+
+        assert resumed.upload_artifact_blob(project, digest, source) is True
+        readback_sha = hashlib.sha256()
+        with httpx.stream(
+            "GET",
+            f"{url}/artifact_blob/{project}/{digest}",
+            timeout=30,
+        ) as response:
+            response.raise_for_status()
+            for chunk in response.iter_bytes():
+                readback_sha.update(chunk)
+        assert readback_sha.hexdigest() == digest
+    finally:
+        if server.poll() is None:
+            _stop_server(server)

--- a/tests/unit/test_artifact_resumable_upload.py
+++ b/tests/unit/test_artifact_resumable_upload.py
@@ -1,0 +1,279 @@
+"""End-to-end coverage for bounded, restart-safe artifact uploads."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import UTC, datetime, timedelta
+
+import httpx
+import pytest
+from starlette.testclient import TestClient
+
+from trackio import cas, utils
+from trackio.asgi_app import create_trackio_starlette_app
+from trackio.exceptions import TrackioAPIError
+from trackio.remote_client import _TrackioHTTPClient
+from trackio.resumable_uploads import expire_sessions
+
+
+def _digest(payload: bytes) -> str:
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _init(client: TestClient, *, digest: str, size: int, key: str = "client-key-00000001"):
+    response = client.post(
+        "/api/artifact-upload/resumable-project",
+        json={"digest": digest, "size_bytes": size, "idempotency_key": key},
+    )
+    assert response.status_code == 200, response.text
+    return response.json()
+
+
+def _put(client: TestClient, upload_id: str, index: int, payload: bytes):
+    return client.put(
+        f"/api/artifact-upload/resumable-project/{upload_id}/chunks/{index}",
+        content=payload,
+        headers={"x-trackio-chunk-sha256": _digest(payload)},
+    )
+
+
+def test_resumable_upload_streams_out_of_order_and_survives_app_restart(temp_dir):
+    first = b"a" * (8 * 1024 * 1024)
+    last = b"tail"
+    payload = first + last
+    app = create_trackio_starlette_app([], {})
+    client = TestClient(app)
+
+    capabilities = client.get("/api/artifact-upload/capabilities")
+    assert capabilities.status_code == 200
+    assert capabilities.json() == {
+        "resumable": True,
+        "compatibility_max_bytes": 32 * 1024 * 1024,
+        "chunk_size_bytes": 8 * 1024 * 1024,
+    }
+
+    session = _init(client, digest=_digest(payload), size=len(payload))
+    upload_id = session["upload_id"]
+    assert session["chunk_count"] == 2
+
+    response = _put(client, upload_id, 1, last)
+    assert response.status_code == 200
+    assert response.json()["already_present"] is False
+
+    incomplete = client.post(
+        f"/api/artifact-upload/resumable-project/{upload_id}"
+    )
+    assert incomplete.status_code == 409
+    assert "missing chunks: [0]" in incomplete.json()["error"]
+
+    restarted_client = TestClient(create_trackio_starlette_app([], {}))
+    status = restarted_client.get(
+        f"/api/artifact-upload/resumable-project/{upload_id}"
+    )
+    assert status.status_code == 200
+    assert status.json()["acknowledged_chunks"] == [1]
+
+    response = _put(restarted_client, upload_id, 0, first)
+    assert response.status_code == 200
+    duplicate = _put(restarted_client, upload_id, 0, first)
+    assert duplicate.status_code == 200
+    assert duplicate.json()["already_present"] is True
+
+    completed = restarted_client.post(
+        f"/api/artifact-upload/resumable-project/{upload_id}"
+    )
+    assert completed.status_code == 200
+    assert completed.json() == {
+        "digest": _digest(payload),
+        "size_bytes": len(payload),
+        "already_present": False,
+    }
+    assert cas.blob_path("resumable-project", _digest(payload)).read_bytes() == payload
+
+    retried = restarted_client.post(
+        f"/api/artifact-upload/resumable-project/{upload_id}"
+    )
+    assert retried.status_code == 200
+    assert retried.json()["already_present"] is True
+
+
+def test_resumable_upload_rejects_corrupt_chunk_without_acknowledging_it(temp_dir):
+    payload = b"expected"
+    client = TestClient(create_trackio_starlette_app([], {}))
+    session = _init(client, digest=_digest(payload), size=len(payload))
+    upload_id = session["upload_id"]
+
+    response = client.put(
+        f"/api/artifact-upload/resumable-project/{upload_id}/chunks/0",
+        content=payload,
+        headers={"x-trackio-chunk-sha256": _digest(b"different")},
+    )
+
+    assert response.status_code == 409
+    assert "digest mismatch" in response.json()["error"].lower()
+    status = client.get(f"/api/artifact-upload/resumable-project/{upload_id}")
+    assert status.json()["acknowledged_chunks"] == []
+    assert not cas.blob_path("resumable-project", _digest(payload)).exists()
+
+
+def test_resumable_upload_init_is_idempotent_and_rejects_key_reuse(temp_dir):
+    client = TestClient(create_trackio_starlette_app([], {}))
+    payload = b"weights"
+
+    first = _init(client, digest=_digest(payload), size=len(payload))
+    second = _init(client, digest=_digest(payload), size=len(payload))
+    assert second["upload_id"] == first["upload_id"]
+
+    conflict = client.post(
+        "/api/artifact-upload/resumable-project",
+        json={
+            "digest": _digest(b"other"),
+            "size_bytes": len(b"other"),
+            "idempotency_key": "client-key-00000001",
+        },
+    )
+    assert conflict.status_code == 409
+    assert "different artifact blob" in conflict.json()["error"]
+
+
+def test_resumable_upload_authorizes_every_mutating_and_status_route(temp_dir):
+    def authorize(request):
+        if request.headers.get("x-trackio-write-token") != "test-token":
+            raise TrackioAPIError("Unauthorized")
+
+    client = TestClient(
+        create_trackio_starlette_app([], {}, upload_authorizer=authorize)
+    )
+    payload = b"weights"
+    init_url = "/api/artifact-upload/resumable-project"
+
+    assert client.post(
+        init_url,
+        json={
+            "digest": _digest(payload),
+            "size_bytes": len(payload),
+            "idempotency_key": "client-key-00000001",
+        },
+    ).status_code == 401
+    session = client.post(
+        init_url,
+        headers={"x-trackio-write-token": "test-token"},
+        json={
+            "digest": _digest(payload),
+            "size_bytes": len(payload),
+            "idempotency_key": "client-key-00000001",
+        },
+    ).json()
+    status_url = f"{init_url}/{session['upload_id']}"
+    assert client.get(status_url).status_code == 401
+    assert client.post(status_url).status_code == 401
+    assert client.delete(status_url).status_code == 401
+
+
+def test_resumable_upload_abort_removes_incomplete_session(temp_dir):
+    client = TestClient(create_trackio_starlette_app([], {}))
+    payload = b"weights"
+    session = _init(client, digest=_digest(payload), size=len(payload))
+    status_url = (
+        f"/api/artifact-upload/resumable-project/{session['upload_id']}"
+    )
+
+    response = client.delete(status_url)
+
+    assert response.status_code == 200
+    assert response.json() == {"aborted": True}
+    assert client.get(status_url).status_code == 404
+
+
+def test_resumable_upload_completes_empty_blob(temp_dir):
+    client = TestClient(create_trackio_starlette_app([], {}))
+    payload = b""
+    session = _init(
+        client,
+        digest=_digest(payload),
+        size=0,
+        key="client-key-empty-0001",
+    )
+
+    completed = client.post(
+        f"/api/artifact-upload/resumable-project/{session['upload_id']}"
+    )
+
+    assert completed.status_code == 200
+    assert completed.json()["size_bytes"] == 0
+    assert cas.blob_path("resumable-project", _digest(payload)).read_bytes() == b""
+
+
+def test_expiry_is_dry_run_by_default_and_never_removes_completed_blob(temp_dir):
+    client = TestClient(create_trackio_starlette_app([], {}))
+    abandoned_payload = b"abandoned"
+    abandoned = _init(
+        client,
+        digest=_digest(abandoned_payload),
+        size=len(abandoned_payload),
+        key="client-key-expiry-0001",
+    )
+    assert _put(client, abandoned["upload_id"], 0, abandoned_payload).status_code == 200
+
+    completed_payload = b"retained"
+    completed = _init(
+        client,
+        digest=_digest(completed_payload),
+        size=len(completed_payload),
+        key="client-key-expiry-0002",
+    )
+    assert _put(client, completed["upload_id"], 0, completed_payload).status_code == 200
+    assert client.post(
+        f"/api/artifact-upload/resumable-project/{completed['upload_id']}"
+    ).status_code == 200
+
+    metadata = (
+        utils.project_artifacts_dir("resumable-project")
+        / "uploads"
+        / abandoned["upload_id"]
+        / "session.json"
+    )
+    payload = json.loads(metadata.read_text())
+    payload["updated_at"] = (datetime.now(UTC) - timedelta(days=2)).isoformat()
+    metadata.write_text(json.dumps(payload))
+    cutoff = datetime.now(UTC) - timedelta(days=1)
+
+    dry_run = expire_sessions(
+        project="resumable-project",
+        older_than=cutoff,
+    )
+    assert dry_run["dry_run"] is True
+    assert dry_run["session_count"] == 1
+    assert dry_run["reclaimable_bytes"] > 0
+    assert metadata.exists()
+
+    deleted = expire_sessions(
+        project="resumable-project",
+        older_than=cutoff,
+        dry_run=False,
+    )
+    assert deleted["session_count"] == 1
+    assert not metadata.exists()
+    assert cas.blob_path(
+        "resumable-project",
+        _digest(completed_payload),
+    ).read_bytes() == completed_payload
+
+
+def test_large_blob_fails_closed_against_legacy_server(tmp_path, monkeypatch):
+    def no_capabilities(url, **kwargs):
+        request = httpx.Request("GET", str(url))
+        return httpx.Response(404, request=request)
+
+    monkeypatch.setattr(httpx, "get", no_capabilities)
+    client = _TrackioHTTPClient("http://legacy.example")
+    small = tmp_path / "small.bin"
+    small.write_bytes(b"small")
+    large = tmp_path / "large.bin"
+    with large.open("wb") as handle:
+        handle.truncate(32 * 1024 * 1024 + 1)
+
+    assert client.upload_artifact_blob("project", "a" * 64, small) is False
+    with pytest.raises(RuntimeError, match="does not support resumable"):
+        client.upload_artifact_blob("project", "a" * 64, large)

--- a/tests/unit/test_artifact_server.py
+++ b/tests/unit/test_artifact_server.py
@@ -3,6 +3,7 @@
 import hashlib
 import sqlite3
 
+from trackio import database as trackio_database
 from trackio import server
 from trackio.sqlite_storage import SQLiteStorage
 
@@ -40,7 +41,7 @@ def _commit(
 
 def _insert_metrics_row(project, run_name, run_id):
     db_path = SQLiteStorage.init_db(project)
-    with sqlite3.connect(db_path) as conn:
+    with trackio_database.connect(str(db_path)) as conn:
         conn.execute(
             "INSERT INTO metrics (timestamp, run_id, run_name, step, metrics) "
             "VALUES (?, ?, ?, ?, ?)",

--- a/tests/unit/test_artifact_upload_cleanup_cli.py
+++ b/tests/unit/test_artifact_upload_cleanup_cli.py
@@ -1,0 +1,72 @@
+"""CLI safety tests for abandoned artifact-upload cleanup."""
+
+from __future__ import annotations
+
+import json
+import sys
+from datetime import UTC, datetime, timedelta
+
+from trackio import cli, utils
+from trackio.resumable_uploads import create_or_resume_session
+
+
+def test_cleanup_uploads_defaults_to_dry_run_and_requires_apply(
+    temp_dir,
+    monkeypatch,
+    capsys,
+):
+    project = "cleanup-cli"
+    session = create_or_resume_session(
+        project=project,
+        digest="a" * 64,
+        size_bytes=10,
+        idempotency_key="cleanup-client-key-0001",
+    )
+    metadata = (
+        utils.project_artifacts_dir(project)
+        / "uploads"
+        / session["upload_id"]
+        / "session.json"
+    )
+    payload = json.loads(metadata.read_text())
+    payload["updated_at"] = (datetime.now(UTC) - timedelta(days=2)).isoformat()
+    metadata.write_text(json.dumps(payload))
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "trackio",
+            "cleanup-uploads",
+            "--project",
+            project,
+            "--older-than-hours",
+            "24",
+            "--json",
+        ],
+    )
+    cli.main()
+    dry_run = json.loads(capsys.readouterr().out)
+    assert dry_run["dry_run"] is True
+    assert dry_run["session_count"] == 1
+    assert metadata.exists()
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "trackio",
+            "cleanup-uploads",
+            "--project",
+            project,
+            "--older-than-hours",
+            "24",
+            "--apply",
+            "--json",
+        ],
+    )
+    cli.main()
+    applied = json.loads(capsys.readouterr().out)
+    assert applied["dry_run"] is False
+    assert applied["session_count"] == 1
+    assert not metadata.exists()

--- a/tests/unit/test_deploy.py
+++ b/tests/unit/test_deploy.py
@@ -20,7 +20,7 @@ def test_get_source_install_dependencies_includes_mcp():
 def test_get_space_install_requirement_includes_mcp_extra():
     requirement = deploy._get_space_install_requirement()
 
-    assert requirement == f"trackio[spaces,mcp]=={deploy.trackio.__version__}"
+    assert requirement == f"carbonteq-trackio[spaces,mcp]=={deploy.trackio.__version__}"
 
 
 @patch("trackio.bucket_storage.huggingface_hub.list_bucket_tree")

--- a/tests/unit/test_distribution.py
+++ b/tests/unit/test_distribution.py
@@ -1,0 +1,7 @@
+from importlib.metadata import version
+
+import trackio
+
+
+def test_carbonteq_distribution_and_import_versions_match() -> None:
+    assert version("carbonteq-trackio") == trackio.__version__

--- a/tests/unit/test_doris_migration.py
+++ b/tests/unit/test_doris_migration.py
@@ -1,0 +1,335 @@
+import json
+import sqlite3
+from contextlib import contextmanager
+
+import pytest
+
+from trackio.doris_migration import (
+    AUTHORITATIVE_TABLES,
+    _records_evidence,
+    _target_evidence,
+    inspect_sqlite_project,
+    migrate_sqlite_to_doris,
+)
+from trackio.doris_storage import DorisStorage
+
+
+def _source_database(path):
+    connection = sqlite3.connect(path)
+    try:
+        connection.execute(
+            """
+            CREATE TABLE metrics (
+                id INTEGER PRIMARY KEY,
+                run_id TEXT NOT NULL,
+                timestamp TEXT NOT NULL,
+                run_name TEXT NOT NULL,
+                step INTEGER NOT NULL,
+                metrics TEXT NOT NULL,
+                log_id TEXT,
+                space_id TEXT
+            )
+            """
+        )
+        connection.execute(
+            """
+            CREATE TABLE configs (
+                id INTEGER PRIMARY KEY,
+                run_id TEXT NOT NULL,
+                run_name TEXT NOT NULL,
+                config TEXT NOT NULL,
+                created_at TEXT NOT NULL
+            )
+            """
+        )
+        connection.executemany(
+            """
+            INSERT INTO metrics
+                (id, run_id, timestamp, run_name, step, metrics, log_id)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            [
+                (
+                    1,
+                    "run-v1",
+                    "2026-07-26T11:00:00+00:00",
+                    "run",
+                    0,
+                    '{"loss":1.0}',
+                    "log-0",
+                ),
+                (
+                    2,
+                    "run-v1",
+                    "2026-07-26T11:00:01+00:00",
+                    "run",
+                    1,
+                    '{"loss":0.5}',
+                    "log-1",
+                ),
+            ],
+        )
+        connection.execute(
+            """
+            INSERT INTO configs
+                (id, run_id, run_name, config, created_at)
+            VALUES (1, 'run-v1', 'run', '{"engine":"sqlite"}',
+                    '2026-07-26T11:00:00+00:00')
+            """
+        )
+        connection.commit()
+    finally:
+        connection.close()
+
+
+def test_dry_run_inspects_without_connecting_to_doris(tmp_path):
+    source = tmp_path / "migration-project.db"
+    receipt = tmp_path / "receipt.json"
+    _source_database(source)
+
+    inspected = inspect_sqlite_project(source)
+    assert inspected["tables"]["metrics"] == 2
+    assert inspected["tables"]["configs"] == 1
+    assert inspected["run_count"] == 1
+
+    result = migrate_sqlite_to_doris(source, receipt, dry_run=True)
+    assert result["dry_run"] is True
+    assert result["verified"] is False
+    stored = json.loads(receipt.read_text())
+    assert stored["projects"][0]["source"]["sha256"] == inspected["sha256"]
+
+
+def test_project_filter_fails_closed_for_unknown_project(tmp_path):
+    source = tmp_path / "migration-project.db"
+    _source_database(source)
+
+    try:
+        migrate_sqlite_to_doris(
+            tmp_path,
+            tmp_path / "receipt.json",
+            dry_run=True,
+            projects=("missing-project",),
+        )
+    except FileNotFoundError as error:
+        assert "missing-project" in str(error)
+    else:
+        raise AssertionError("missing project filter should fail")
+
+
+def test_snapshot_includes_committed_wal_rows(tmp_path):
+    source = tmp_path / "wal-project.db"
+    _source_database(source)
+    connection = sqlite3.connect(source)
+    try:
+        assert connection.execute("PRAGMA journal_mode=WAL").fetchone()[0] == "wal"
+        connection.execute("PRAGMA wal_autocheckpoint=0")
+        connection.execute(
+            """
+            INSERT INTO metrics
+                (id, run_id, timestamp, run_name, step, metrics, log_id)
+            VALUES (3, 'run-v1', '2026-07-26T11:00:02+00:00',
+                    'run', 2, '{"loss":0.25}', 'log-2')
+            """
+        )
+        connection.commit()
+        assert source.with_name(f"{source.name}-wal").is_file()
+
+        inspected = inspect_sqlite_project(source)
+    finally:
+        connection.close()
+
+    assert inspected["wal_present"] is True
+    assert inspected["tables"]["metrics"] == 3
+    assert inspected["evidence"]["metrics"]["count"] == 3
+    assert inspected["sha256"] == inspected["snapshot_sha256"]
+
+
+def test_canonical_evidence_detects_same_count_different_content():
+    first = {
+        table: ([{"value": 1}] if table == "metrics" else [])
+        for table in AUTHORITATIVE_TABLES
+    }
+    second = {
+        table: ([{"value": 2}] if table == "metrics" else [])
+        for table in AUTHORITATIVE_TABLES
+    }
+
+    first_evidence = _records_evidence(first)
+    second_evidence = _records_evidence(second)
+
+    assert first_evidence["metrics"]["count"] == second_evidence["metrics"]["count"]
+    assert first_evidence["metrics"]["sha256"] != second_evidence["metrics"]["sha256"]
+
+
+def test_target_verification_connection_never_initializes_schema(monkeypatch):
+    calls = []
+
+    class Cursor:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return None
+
+        def execute(self, query, params):
+            calls.append((query, params))
+
+        def fetchall(self):
+            return []
+
+    class Connection:
+        def cursor(self):
+            return Cursor()
+
+    @contextmanager
+    def connection(*, initialize=True, include_database=True):
+        del include_database
+        assert initialize is False
+        yield Connection()
+
+    monkeypatch.setattr(DorisStorage, "_connection", staticmethod(connection))
+
+    evidence = _target_evidence("verify-only-project")
+
+    assert set(evidence) == set(AUTHORITATIVE_TABLES)
+    assert all(value["count"] == 0 for value in evidence.values())
+    assert calls
+
+
+def test_verify_only_does_not_call_schema_initializer(tmp_path, monkeypatch):
+    source = tmp_path / "migration-project.db"
+    _source_database(source)
+    source_evidence = inspect_sqlite_project(source)["evidence"]
+
+    def forbidden_initialize():
+        raise AssertionError("verify-only must not initialize Doris")
+
+    monkeypatch.setattr(DorisStorage, "initialize", forbidden_initialize)
+    monkeypatch.setattr(
+        "trackio.doris_migration._target_evidence",
+        lambda project: source_evidence,
+    )
+
+    result = migrate_sqlite_to_doris(
+        source,
+        tmp_path / "receipt.json",
+        verify_only=True,
+    )
+
+    assert result["verified"] is True
+    assert result["projects"][0]["target_evidence"] == source_evidence
+
+
+def test_verify_only_rejects_equal_counts_with_different_content(tmp_path, monkeypatch):
+    source = tmp_path / "migration-project.db"
+    receipt_path = tmp_path / "receipt.json"
+    _source_database(source)
+    target_evidence = inspect_sqlite_project(source)["evidence"]
+    target_evidence["metrics"] = {
+        **target_evidence["metrics"],
+        "sha256": "0" * 64,
+    }
+    monkeypatch.setattr(
+        "trackio.doris_migration._target_evidence",
+        lambda project: target_evidence,
+    )
+
+    with pytest.raises(RuntimeError, match="reconciliation failed"):
+        migrate_sqlite_to_doris(
+            source,
+            receipt_path,
+            verify_only=True,
+        )
+
+    receipt = json.loads(receipt_path.read_text())
+    mismatch = receipt["projects"][0]["mismatches"]["metrics"]
+    assert mismatch["source"]["count"] == mismatch["target"]["count"]
+    assert mismatch["source"]["sha256"] != mismatch["target"]["sha256"]
+
+
+def test_snapshot_evidence_covers_artifacts_aliases_and_links(tmp_path):
+    source = tmp_path / "artifact-project.db"
+    _source_database(source)
+    manifest = [{"path": "adapter.bin", "digest": "a" * 64, "size": 9}]
+    _, manifest_digest, _ = DorisStorage._canonical_manifest(manifest)
+    connection = sqlite3.connect(source)
+    try:
+        connection.executescript(
+            """
+            CREATE TABLE artifacts (
+                id INTEGER PRIMARY KEY,
+                name TEXT NOT NULL,
+                type TEXT NOT NULL,
+                description TEXT,
+                created_at TEXT NOT NULL
+            );
+            CREATE TABLE artifact_versions (
+                id INTEGER PRIMARY KEY,
+                artifact_id INTEGER NOT NULL,
+                version INTEGER NOT NULL,
+                manifest_digest TEXT NOT NULL,
+                manifest TEXT NOT NULL,
+                metadata TEXT,
+                size_bytes INTEGER NOT NULL,
+                producer_run_id TEXT,
+                producer_run_name TEXT,
+                created_at TEXT NOT NULL
+            );
+            CREATE TABLE artifact_aliases (
+                artifact_id INTEGER NOT NULL,
+                alias TEXT NOT NULL,
+                artifact_version_id INTEGER NOT NULL
+            );
+            CREATE TABLE run_artifact_links (
+                id INTEGER PRIMARY KEY,
+                run_id TEXT,
+                run_name TEXT,
+                artifact_version_id INTEGER NOT NULL,
+                direction TEXT NOT NULL,
+                created_at TEXT NOT NULL
+            );
+            """
+        )
+        connection.execute(
+            """
+            INSERT INTO artifacts
+                (id, name, type, description, created_at)
+            VALUES (1, 'adapter', 'model', 'retained',
+                    '2026-07-01T00:00:00+00:00')
+            """
+        )
+        connection.execute(
+            """
+            INSERT INTO artifact_versions
+                (id, artifact_id, version, manifest_digest, manifest, metadata,
+                 size_bytes, producer_run_id, producer_run_name, created_at)
+            VALUES (2, 1, 4, ?, ?, '{"format":"peft"}', 9,
+                    'run-v1', 'run', '2026-07-02T00:00:00+00:00')
+            """,
+            (manifest_digest, json.dumps(manifest)),
+        )
+        connection.execute(
+            """
+            INSERT INTO artifact_aliases
+                (artifact_id, alias, artifact_version_id)
+            VALUES (1, 'candidate', 2)
+            """
+        )
+        connection.execute(
+            """
+            INSERT INTO run_artifact_links
+                (id, run_id, run_name, artifact_version_id, direction, created_at)
+            VALUES (3, 'run-v1', 'run', 2, 'output',
+                    '2026-07-03T00:00:00+00:00')
+            """
+        )
+        connection.commit()
+    finally:
+        connection.close()
+
+    evidence = inspect_sqlite_project(source)["evidence"]
+
+    assert evidence["artifacts"]["count"] == 1
+    assert evidence["artifact_versions"]["count"] == 1
+    assert evidence["artifact_aliases"]["count"] == 1
+    assert evidence["run_artifact_links"]["count"] == 1

--- a/tests/unit/test_doris_schema.py
+++ b/tests/unit/test_doris_schema.py
@@ -1,0 +1,161 @@
+import pytest
+
+from trackio.doris_schema import (
+    MANAGED_TABLES,
+    SCHEMA_VERSION,
+    negotiate_schema,
+    schema_statements,
+)
+from trackio.doris_storage import DorisStorage
+
+
+def test_empty_database_is_the_only_bootstrap_state():
+    assert negotiate_schema(set(), None) == "bootstrap"
+    assert negotiate_schema({"unrelated_application_table"}, None) == "bootstrap"
+
+
+def test_complete_current_schema_is_ready_without_bootstrap():
+    assert negotiate_schema(set(MANAGED_TABLES), SCHEMA_VERSION) == "ready"
+
+
+@pytest.mark.parametrize(
+    ("tables", "version", "message"),
+    [
+        ({"metrics"}, None, "unversioned partial"),
+        ({"schema_versions", "metrics"}, None, "unversioned partial"),
+        (set(MANAGED_TABLES), SCHEMA_VERSION + 1, "newer"),
+        (set(MANAGED_TABLES), SCHEMA_VERSION - 1, "explicit migration"),
+        (
+            set(MANAGED_TABLES) - {"artifact_aliases"},
+            SCHEMA_VERSION,
+            "artifact_aliases",
+        ),
+    ],
+)
+def test_nonempty_incompatible_schema_fails_closed(tables, version, message):
+    with pytest.raises(RuntimeError, match=message):
+        negotiate_schema(tables, version)
+
+
+def test_schema_version_table_is_created_first_and_recorded_separately():
+    statements = schema_statements()
+
+    assert "CREATE TABLE IF NOT EXISTS schema_versions" in statements[0]
+    assert len(statements) == len(MANAGED_TABLES)
+    assert all(
+        "INSERT INTO schema_versions" not in statement for statement in statements
+    )
+
+
+class _SchemaCursor:
+    def __init__(self, tables, version):
+        self.tables = tables
+        self.version = version
+        self.executed = []
+        self.current = ""
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return None
+
+    def execute(self, query, params=None):
+        self.current = " ".join(query.split())
+        self.executed.append((self.current, params))
+
+    def fetchall(self):
+        if "information_schema.tables" in self.current:
+            return [{"table_name": table} for table in self.tables]
+        return []
+
+    def fetchone(self):
+        if "SELECT version FROM schema_versions" in self.current:
+            return {"version": self.version} if self.version is not None else None
+        return None
+
+
+class _SchemaConnection:
+    def __init__(self, cursor):
+        self._cursor = cursor
+        self.closed = False
+
+    def cursor(self):
+        return self._cursor
+
+    def close(self):
+        self.closed = True
+
+
+def _install_schema_connection(monkeypatch, tables, version):
+    cursor = _SchemaCursor(tables, version)
+    connection = _SchemaConnection(cursor)
+    settings = {
+        "host": "doris.internal",
+        "port": 9030,
+        "user": "trackio",
+        "password": "",
+        "database": "trackio_test",
+    }
+    monkeypatch.setattr(DorisStorage, "_schema_ready", False)
+    monkeypatch.setattr(DorisStorage, "_schema_target", None)
+    monkeypatch.setattr(
+        DorisStorage, "_settings", classmethod(lambda cls: settings.copy())
+    )
+    monkeypatch.setattr(
+        "trackio.doris_storage.pymysql.connect",
+        lambda **kwargs: connection,
+    )
+    return cursor, connection
+
+
+def test_current_schema_negotiation_executes_no_ddl(monkeypatch):
+    cursor, connection = _install_schema_connection(
+        monkeypatch,
+        set(MANAGED_TABLES),
+        SCHEMA_VERSION,
+    )
+
+    DorisStorage._ensure_schema()
+
+    statements = [query for query, _ in cursor.executed]
+    assert not any(query.startswith("CREATE ") for query in statements)
+    assert not any(query.startswith("INSERT ") for query in statements)
+    assert connection.closed is True
+
+
+def test_newer_schema_fails_before_any_write(monkeypatch):
+    cursor, _ = _install_schema_connection(
+        monkeypatch,
+        set(MANAGED_TABLES),
+        SCHEMA_VERSION + 1,
+    )
+
+    with pytest.raises(RuntimeError, match="newer"):
+        DorisStorage._ensure_schema()
+
+    statements = [query for query, _ in cursor.executed]
+    assert not any(
+        query.startswith(("CREATE ", "INSERT ", "UPDATE ", "DELETE "))
+        for query in statements
+    )
+
+
+def test_empty_database_records_version_only_after_all_tables(monkeypatch):
+    cursor, _ = _install_schema_connection(monkeypatch, set(), None)
+
+    DorisStorage._ensure_schema()
+
+    statements = [query for query, _ in cursor.executed]
+    version_write = next(
+        index
+        for index, query in enumerate(statements)
+        if query.startswith("INSERT INTO schema_versions")
+    )
+    table_writes = [
+        index
+        for index, query in enumerate(statements)
+        if query.startswith("CREATE TABLE")
+    ]
+    assert len(table_writes) == len(MANAGED_TABLES)
+    assert version_write > max(table_writes)

--- a/tests/unit/test_local_server_api.py
+++ b/tests/unit/test_local_server_api.py
@@ -1,4 +1,6 @@
 import asyncio
+import hashlib
+import json
 import tempfile
 from pathlib import Path
 from urllib.parse import parse_qs, urlparse
@@ -8,8 +10,9 @@ import pytest
 
 import trackio
 import trackio.context_vars as context_vars
+import trackio.remote_client as remote_client_module
 import trackio.utils as trackio_utils
-from trackio import Api
+from trackio import Api, cas
 from trackio.remote_client import RemoteClient as Client
 from trackio.sqlite_storage import SQLiteStorage
 
@@ -171,6 +174,82 @@ def test_server_url_logs_to_self_hosted_server(temp_dir):
         client = Client(url, verbose=False)
         runs = client.predict(project, api_name="/get_runs_for_project")
         assert any(r.get("name") == run_name for r in runs)
+    finally:
+        app.close()
+
+
+def test_server_url_logs_artifact_through_resumable_transport(temp_dir, tmp_path):
+    project = "test_self_hosted_artifact"
+    run_name = "self-hosted-artifact-run"
+    payload = (b"weights-" * (1024 * 1024)) + b"tail"
+    digest = hashlib.sha256(payload).hexdigest()
+    artifact_path = tmp_path / "weights.bin"
+    artifact_path.write_bytes(payload)
+
+    app, _, _, full_url = trackio.show(block_thread=False, open_browser=False)
+
+    try:
+        context_vars.current_server.set(None)
+        context_vars.current_project.set(None)
+        context_vars.current_run.set(None)
+
+        trackio.init(project=project, name=run_name, server_url=full_url)
+        logged = trackio.log_artifact(
+            artifact_path,
+            name="model",
+            type="model",
+        )
+        trackio.finish()
+
+        assert logged.version == "v0"
+        manifest = SQLiteStorage.get_artifact_manifest(project, "model", "v0")
+        assert manifest is not None
+        assert manifest["manifest"][0]["digest"] == digest
+        assert cas.blob_path(project, digest).read_bytes() == payload
+    finally:
+        app.close()
+
+
+def test_resumable_client_retries_only_missing_chunks(temp_dir, tmp_path, monkeypatch):
+    project = "test_resumable_retry"
+    payload = b"a" * (8 * 1024 * 1024) + b"tail"
+    digest = hashlib.sha256(payload).hexdigest()
+    source = tmp_path / "weights.bin"
+    source.write_bytes(payload)
+    app, url, _, full_url = trackio.show(block_thread=False, open_browser=False)
+    write_token = parse_qs(urlparse(full_url).query).get("write_token", [None])[0]
+    assert write_token
+    client = Client(url, write_token=write_token, verbose=False)
+    real_put = remote_client_module.httpx.put
+    puts = 0
+
+    def fail_second_put(*args, **kwargs):
+        nonlocal puts
+        puts += 1
+        if puts == 2:
+            request = httpx.Request("PUT", str(args[0]))
+            raise httpx.ConnectError("synthetic disconnect", request=request)
+        return real_put(*args, **kwargs)
+
+    try:
+        monkeypatch.setattr(remote_client_module.httpx, "put", fail_second_put)
+        with pytest.raises(httpx.ConnectError, match="synthetic disconnect"):
+            client.upload_artifact_blob(project, digest, source)
+
+        sessions = list(
+            (trackio_utils.project_artifacts_dir(project) / "uploads").glob(
+                "*/session.json"
+            )
+        )
+        assert len(sessions) == 1
+        staged = json.loads(sessions[0].read_text())
+        assert sorted(staged["chunks"]) == ["0"]
+
+        monkeypatch.setattr(remote_client_module.httpx, "put", real_put)
+        assert client.upload_artifact_blob(project, digest, source) is True
+        completed = json.loads(sessions[0].read_text())
+        assert completed["state"] == "completed"
+        assert cas.blob_path(project, digest).read_bytes() == payload
     finally:
         app.close()
 

--- a/tests/unit/test_local_server_api.py
+++ b/tests/unit/test_local_server_api.py
@@ -356,6 +356,7 @@ def test_get_tab_availability_reflects_data(temp_dir):
         "metrics": False,
         "system": False,
         "traces": False,
+        "verifiers-traces": False,
         "media": False,
         "reports": False,
         "files": False,
@@ -382,6 +383,7 @@ def test_get_tab_availability_reflects_data(temp_dir):
     assert result["media"] is False
     assert result["system"] is False
     assert result["traces"] is False
+    assert result["verifiers-traces"] is False
 
 
 def test_local_dashboard_supports_mcp(temp_dir):

--- a/tests/unit/test_sqlite_storage.py
+++ b/tests/unit/test_sqlite_storage.py
@@ -524,3 +524,41 @@ def test_query_project_normalizes_bytes(temp_dir):
 def test_query_project_missing_project(temp_dir):
     with pytest.raises(FileNotFoundError):
         SQLiteStorage.query_project("nonexistent", "SELECT 1")
+
+
+def test_get_run_lifecycles_answers_for_every_run_at_once(temp_dir):
+    """Listing a project must not cost a request per run.
+
+    Status and timings are logged as ordinary metric rows, so reading them one
+    run at a time made describing a project proportional to how many runs it
+    held. This answers for all of them in a single query.
+    """
+    SQLiteStorage.log(
+        project="lifecycles",
+        run="first",
+        metrics={"run/status": "running", "run/started_at": "t0", "loss": 1.0},
+    )
+    SQLiteStorage.log(
+        project="lifecycles",
+        run="first",
+        metrics={"run/status": "succeeded", "run/started_at": "t0", "run/finished_at": "t1"},
+    )
+    SQLiteStorage.log(
+        project="lifecycles",
+        run="second",
+        metrics={"run/status": "failed", "run/started_at": "t2", "run/error_type": "Boom"},
+    )
+    SQLiteStorage.log(project="lifecycles", run="third", metrics={"loss": 0.5})
+
+    lifecycles = SQLiteStorage.get_run_lifecycles("lifecycles")
+
+    assert len(lifecycles) == 2, "a run that logged no status has no lifecycle to report"
+    statuses = {values["run/status"] for values in lifecycles.values()}
+    assert statuses == {"succeeded", "failed"}, "the latest row for a run wins"
+    assert all("loss" not in values for values in lifecycles.values())
+    failed = next(v for v in lifecycles.values() if v["run/status"] == "failed")
+    assert failed["run/error_type"] == "Boom"
+
+
+def test_get_run_lifecycles_is_empty_for_an_unknown_project(temp_dir):
+    assert SQLiteStorage.get_run_lifecycles("never-created") == {}

--- a/tests/unit/test_storage_provider.py
+++ b/tests/unit/test_storage_provider.py
@@ -1,0 +1,439 @@
+import os
+import subprocess
+import sys
+from contextlib import contextmanager
+
+import pymysql
+import pytest
+
+from trackio.doris_storage import DorisStorage
+from trackio.sqlite_storage import SQLiteStorage
+from trackio.storage import get_storage, is_retryable_storage_error
+
+
+@pytest.mark.parametrize("engine", ["sqlite", "turso"])
+def test_embedded_engines_keep_sqlite_storage(engine):
+    assert get_storage(engine) is SQLiteStorage
+
+
+def test_unknown_engine_fails_with_supported_choices():
+    with pytest.raises(RuntimeError, match="'turso'.*'sqlite'.*'doris'"):
+        get_storage("postgres")
+
+
+def test_doris_selection_does_not_open_a_sqlite_database(tmp_path):
+    env = {
+        **os.environ,
+        "TRACKIO_DATABASE_ENGINE": "doris",
+        "TRACKIO_DORIS_HOST": "127.0.0.1",
+        "TRACKIO_DORIS_DATABASE": "trackio_test",
+        "TRACKIO_DORIS_USER": "trackio",
+        "TRACKIO_DIR": str(tmp_path),
+    }
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "from trackio.storage import Storage; "
+                "from trackio.doris_storage import DorisStorage; "
+                "assert Storage is DorisStorage"
+            ),
+        ],
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    assert list(tmp_path.glob("*.db")) == []
+
+
+@pytest.mark.parametrize("code", [1047, 1205, 2003, 2006, 2013])
+def test_transient_mysql_failures_are_retryable(code):
+    assert is_retryable_storage_error(pymysql.err.OperationalError(code, "transient"))
+
+
+def test_mysql_auth_failure_is_not_retried():
+    assert not is_retryable_storage_error(
+        pymysql.err.OperationalError(1045, "access denied")
+    )
+
+
+def test_doris_run_name_resolution_uses_run_creation_time():
+    class Cursor:
+        query = ""
+        params = ()
+
+        def execute(self, query, params):
+            self.query = query
+            self.params = params
+
+        def fetchone(self):
+            return {"run_id": "newer-run"}
+
+    cursor = Cursor()
+
+    resolved = DorisStorage._resolve_run_id(
+        cursor,
+        "project",
+        "same-name",
+        None,
+    )
+
+    assert resolved == "newer-run"
+    assert "MIN(timestamp) AS created_at" in cursor.query
+    assert "GROUP BY run_id" in cursor.query
+    assert "ORDER BY created_at DESC" in cursor.query
+    assert cursor.params == ("project", "same-name")
+
+
+def test_doris_run_records_match_sqlite_metric_and_artifact_authority():
+    records = DorisStorage._run_records_from_evidence(
+        [
+            {
+                "run_id": "metric-v1",
+                "run_name": "train",
+                "created_at": "2026-07-02T00:00:00+00:00",
+            },
+            {
+                "run_id": "metric-v1",
+                "run_name": "train",
+                "created_at": "2026-07-03T00:00:00+00:00",
+            },
+        ],
+        [
+            {
+                "run_id": None,
+                "run_name": "artifact-only",
+                "created_at": "2026-07-01T00:00:00+00:00",
+            },
+            {
+                "run_id": "artifact-v1",
+                "run_name": "artifact-only",
+                "created_at": "2026-07-01T00:00:01+00:00",
+            },
+            {
+                "run_id": None,
+                "run_name": "train",
+                "created_at": "2026-06-30T00:00:00+00:00",
+            },
+            {
+                "run_id": None,
+                "run_name": None,
+                "created_at": "2026-07-04T00:00:00+00:00",
+            },
+        ],
+    )
+
+    assert records == [
+        {
+            "id": "artifact-v1",
+            "name": "artifact-only",
+            "created_at": "2026-07-01T00:00:01+00:00",
+        },
+        {
+            "id": "metric-v1",
+            "name": "train",
+            "created_at": "2026-07-02T00:00:00+00:00",
+        },
+    ]
+    assert all(record["id"] != "None" for record in records)
+
+
+def test_doris_artifact_counts_fold_legacy_links_without_double_counting():
+    records = [
+        {
+            "id": "train-v1",
+            "name": "train",
+            "created_at": "2026-07-01T00:00:00+00:00",
+        }
+    ]
+    rows = [
+        {
+            "run_id": None,
+            "run_name": "train",
+            "version_id": 7,
+            "direction": "output",
+        },
+        {
+            "run_id": "train-v1",
+            "run_name": "train",
+            "version_id": 7,
+            "direction": "output",
+        },
+        {
+            "run_id": "train-v1",
+            "run_name": "train",
+            "version_id": 8,
+            "direction": "input",
+        },
+    ]
+
+    assert DorisStorage._artifact_link_counts_from_rows(rows, records) == [
+        {
+            "run_id": "train-v1",
+            "run_name": "train",
+            "input": 1,
+            "output": 1,
+        }
+    ]
+
+
+def test_doris_at_time_window_matches_sqlite_filter_precedence(monkeypatch):
+    rows = [
+        {"timestamp": "2026-07-27T10:00:00Z", "step": 0, "loss": 3.0},
+        {
+            "timestamp": "2026-07-27T10:00:02+00:00",
+            "step": 1,
+            "loss": 2.0,
+        },
+        {
+            "timestamp": "2026-07-27T10:00:05+00:00",
+            "step": 2,
+            "loss": 1.0,
+        },
+    ]
+    monkeypatch.setattr(
+        DorisStorage,
+        "get_logs",
+        classmethod(lambda cls, *args, **kwargs: rows),
+    )
+
+    around_time = DorisStorage.get_metric_values(
+        "project",
+        "run",
+        "loss",
+        at_time="2026-07-27T10:00:02+00:00",
+        window=2,
+    )
+    exact_step = DorisStorage.get_snapshot(
+        "project",
+        "run",
+        step=2,
+        at_time="2026-07-27T10:00:00+00:00",
+        window=10,
+    )
+
+    assert [row["step"] for row in around_time] == [0, 1]
+    assert exact_step["loss"] == [
+        {
+            "timestamp": "2026-07-27T10:00:05+00:00",
+            "step": 2,
+            "value": 1.0,
+        }
+    ]
+
+
+def test_doris_tab_flags_classify_payloads_and_trace_types(monkeypatch):
+    seen = []
+
+    class Cursor:
+        query = ""
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return None
+
+        def execute(self, query, params):
+            self.query = " ".join(query.split())
+            seen.append((self.query, params))
+
+        def fetchone(self):
+            if (
+                '"_type":"trackio.image"' in self.query
+                or '"_type":"trackio.markdown"' in self.query
+                or "trace_type = 'verifiers'" in self.query
+            ):
+                return {"present": 1}
+            return None
+
+    class Connection:
+        def cursor(self):
+            return Cursor()
+
+    @contextmanager
+    def connection(**kwargs):
+        del kwargs
+        yield Connection()
+
+    monkeypatch.setattr(DorisStorage, "_connection", staticmethod(connection))
+
+    assert DorisStorage.get_tab_availability_flags("project") == {
+        "metrics": False,
+        "media": True,
+        "reports": True,
+        "system": False,
+        "traces": False,
+        "alerts": False,
+        "verifiers_traces": True,
+        "artifacts": False,
+    }
+    assert any("REGEXP" in query for query, _ in seen)
+    assert any("trace_type = 'trackio'" in query for query, _ in seen)
+
+
+@pytest.mark.parametrize(
+    ("description", "expects_update"),
+    [(None, False), ("revised", True)],
+)
+def test_doris_artifact_relog_preserves_identity_fields(
+    monkeypatch, description, expects_update
+):
+    executed = []
+
+    class Cursor:
+        query = ""
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return None
+
+        def execute(self, query, params):
+            self.query = " ".join(query.split())
+            executed.append((self.query, params))
+
+        def fetchone(self):
+            if "SELECT artifact_type FROM artifacts" in self.query:
+                return {"artifact_type": "model"}
+            if "SELECT version_id, version_number FROM artifact_versions" in self.query:
+                return {"version_id": 7, "version_number": 0}
+            if "SELECT version_number FROM artifact_aliases" in self.query:
+                return None
+            raise AssertionError(f"unexpected fetchone query: {self.query}")
+
+    class Connection:
+        def cursor(self):
+            return Cursor()
+
+    @contextmanager
+    def connection(**kwargs):
+        del kwargs
+        yield Connection()
+
+    monkeypatch.setattr(DorisStorage, "_connection", staticmethod(connection))
+    monkeypatch.setattr(
+        DorisStorage,
+        "get_artifact_manifest",
+        classmethod(
+            lambda cls, project, name, spec: {
+                "version_id": 7,
+                "version": 0,
+            }
+        ),
+    )
+
+    DorisStorage.commit_artifact_version(
+        project="project",
+        name="adapter",
+        type="model",
+        description=description,
+        manifest=[{"path": "model.bin", "digest": "a" * 64, "size": 1}],
+        metadata=None,
+        aliases=None,
+        run_name="producer",
+        run_id="producer-v1",
+    )
+
+    statements = [query for query, _ in executed]
+    assert not any("INSERT INTO artifacts " in query for query in statements)
+    assert (
+        any("UPDATE artifacts SET description" in query for query in statements)
+        is expects_update
+    )
+
+
+def test_artifact_migration_preserves_versions_and_lineage_timestamps(monkeypatch):
+    executed = []
+
+    class Cursor:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return None
+
+        def execute(self, query, params):
+            executed.append((" ".join(query.split()), params))
+
+    class Connection:
+        def cursor(self):
+            return Cursor()
+
+    @contextmanager
+    def connection(**kwargs):
+        del kwargs
+        yield Connection()
+
+    monkeypatch.setattr(
+        DorisStorage,
+        "_connection",
+        staticmethod(connection),
+    )
+    manifest = [{"path": "model.bin", "digest": "a" * 64, "size": 7}]
+    _, manifest_digest, _ = DorisStorage._canonical_manifest(manifest)
+
+    DorisStorage.import_artifact_graph(
+        "project",
+        artifacts=[
+            {
+                "id": 10,
+                "name": "adapter",
+                "type": "model",
+                "description": "retained",
+                "created_at": "2026-07-01T00:00:00+00:00",
+            }
+        ],
+        versions=[
+            {
+                "id": 20,
+                "artifact_id": 10,
+                "version": 4,
+                "manifest_digest": manifest_digest,
+                "manifest": manifest,
+                "metadata": {"format": "peft"},
+                "size_bytes": 7,
+                "producer_run_id": "producer-v1",
+                "producer_run_name": "producer",
+                "created_at": "2026-07-02T00:00:00+00:00",
+            }
+        ],
+        aliases=[
+            {
+                "artifact_id": 10,
+                "artifact_version_id": 20,
+                "alias": "candidate",
+            }
+        ],
+        links=[
+            {
+                "run_id": "consumer-v1",
+                "run_name": "consumer",
+                "artifact_version_id": 20,
+                "direction": "input",
+                "created_at": "2026-07-03T00:00:00+00:00",
+            }
+        ],
+    )
+
+    artifact_write = next(
+        item for item in executed if "INSERT INTO artifacts" in item[0]
+    )
+    version_write = next(
+        item for item in executed if "INSERT INTO artifact_versions" in item[0]
+    )
+    alias_write = next(
+        item for item in executed if "INSERT INTO artifact_aliases" in item[0]
+    )
+    link_write = next(
+        item for item in executed if "INSERT INTO run_artifact_links" in item[0]
+    )
+    assert artifact_write[1][-1] == "2026-07-01T00:00:00+00:00"
+    assert version_write[1][3] == 4
+    assert version_write[1][-1] == "2026-07-02T00:00:00+00:00"
+    assert alias_write[1][4] == 4
+    assert link_write[1][-1] == "2026-07-03T00:00:00+00:00"

--- a/tests/unit/test_trace.py
+++ b/tests/unit/test_trace.py
@@ -1,10 +1,39 @@
 import os
+import sqlite3
 
 import pytest
 
-from trackio import Run, Trace
+from trackio import Run, Trace, VerifiersTrace
 from trackio.media import TrackioImage
 from trackio.sqlite_storage import SQLiteStorage
+
+
+def verifiers_record(trace_id="vf-trace-1"):
+    return {
+        "id": trace_id,
+        "version": 2,
+        "agent": {"model": "org/model"},
+        "task": {"type": "ExampleTask", "data": {"idx": 7}},
+        "nodes": [
+            {"message": {"role": "user", "content": "solve this"}},
+            {
+                "parent": 0,
+                "sampled": True,
+                "message": {"role": "assistant", "content": "first branch"},
+            },
+            {
+                "parent": 0,
+                "sampled": True,
+                "message": {"role": "assistant", "content": "final branch"},
+            },
+        ],
+        "calls": [{"finish_reason": "length", "usage": {"completion_tokens": 8}}],
+        "rewards": {"correct": 0.5},
+        "metrics": {"format": 1.0},
+        "errors": [],
+        "stop_condition": "agent_completed",
+        "is_completed": True,
+    }
 
 
 def test_trace_to_dict(image_ndarray, temp_dir):
@@ -33,6 +62,29 @@ def test_trace_to_dict(image_ndarray, temp_dir):
 def test_trace_requires_message_dicts():
     with pytest.raises(TypeError, match="list of dictionaries"):
         Trace(messages=["bad"])  # type: ignore[arg-type]
+
+
+def test_verifiers_trace_preserves_native_record_and_projects_final_branch():
+    record = verifiers_record()
+    trace = VerifiersTrace(record)
+
+    payload = trace._to_dict(project="proj", run="run1", step=0)
+
+    assert payload["_type"] == VerifiersTrace.TYPE
+    assert payload["external_id"] == "vf-trace-1"
+    assert payload["schema_version"] == 2
+    assert payload["payload"] == record
+    assert payload["messages"][-1]["content"] == "final branch"
+    assert payload["metadata"]["model"] == "org/model"
+    assert payload["metadata"]["reward"] == 0.5
+    assert payload["metadata"]["is_truncated"] is True
+
+
+def test_verifiers_trace_requires_native_identity():
+    with pytest.raises(TypeError, match="non-empty string"):
+        VerifiersTrace({"version": 2})
+    with pytest.raises(TypeError, match="integer"):
+        VerifiersTrace({"id": "trace", "version": "2"})
 
 
 def test_trace_logging_and_query(temp_dir):
@@ -118,6 +170,67 @@ def test_trace_logging_keeps_scalar_metrics_separate(temp_dir):
     assert len(SQLiteStorage.get_traces("proj", "trace-run")) == 1
 
 
+def test_verifiers_trace_logging_is_idempotent_and_filterable(temp_dir):
+    run = Run(url=None, project="proj", client=None, name="trace-run", space_id=None)
+    native = VerifiersTrace(verifiers_record())
+    run.log({"rollout": native})
+    run.log({"rollout": native})
+    run.log(
+        {
+            "conversation": Trace(
+                messages=[{"role": "user", "content": "standard"}]
+            )
+        }
+    )
+    run.finish()
+
+    all_traces = SQLiteStorage.get_traces("proj", "trace-run")
+    verifiers = SQLiteStorage.get_traces(
+        "proj", "trace-run", trace_type="verifiers"
+    )
+    standard = SQLiteStorage.get_traces("proj", "trace-run", trace_type="trackio")
+
+    assert len(all_traces) == 2
+    assert len(verifiers) == 1
+    assert len(standard) == 1
+    assert verifiers[0]["external_id"] == "vf-trace-1"
+    assert verifiers[0]["payload"]["task"]["type"] == "ExampleTask"
+
+
+def test_verifiers_trace_search_does_not_index_native_payload(temp_dir):
+    run = Run(url=None, project="proj", client=None, name="trace-run", space_id=None)
+    record = verifiers_record()
+    record["private_runtime_detail"] = "payload-only-secret"
+    run.log({"rollout": VerifiersTrace(record)})
+    run.finish()
+
+    assert SQLiteStorage.get_traces(
+        "proj", "trace-run", search="final branch"
+    )
+    assert not SQLiteStorage.get_traces(
+        "proj", "trace-run", search="payload-only-secret"
+    )
+
+
+def test_existing_trace_table_migrates_additively(temp_dir):
+    db_path = SQLiteStorage.get_project_db_path("proj")
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """CREATE TABLE traces (
+                id TEXT PRIMARY KEY, run_id TEXT NOT NULL, timestamp TEXT NOT NULL,
+                run_name TEXT NOT NULL, step INTEGER NOT NULL, key TEXT NOT NULL,
+                trace_index INTEGER, messages TEXT NOT NULL, metadata TEXT NOT NULL,
+                search_text TEXT NOT NULL, log_id TEXT, space_id TEXT
+            )"""
+        )
+
+    SQLiteStorage.init_db("proj")
+
+    with sqlite3.connect(db_path) as conn:
+        columns = {row[1] for row in conn.execute("PRAGMA table_info(traces)")}
+    assert {"trace_type", "external_id", "schema_version", "payload"} <= columns
+
+
 def test_trace_export_import_roundtrip(temp_dir):
     run = Run(url=None, project="proj", client=None, name="trace-run", space_id=None)
     run.log(
@@ -131,6 +244,23 @@ def test_trace_export_import_roundtrip(temp_dir):
             ),
         }
     )
+    run.finish()
+
+    before = SQLiteStorage.get_traces("proj", "trace-run")
+    db_path = SQLiteStorage.get_project_db_path("proj")
+    SQLiteStorage._dataset_import_attempted = True
+    SQLiteStorage.export_to_parquet()
+    os.unlink(db_path)
+    SQLiteStorage.import_from_parquet()
+
+    after = SQLiteStorage.get_traces("proj", "trace-run")
+    assert after == before
+
+
+def test_verifiers_trace_export_import_roundtrip(temp_dir):
+    pytest.importorskip("pyarrow")
+    run = Run(url=None, project="proj", client=None, name="trace-run", space_id=None)
+    run.log({"rollout": VerifiersTrace(verifiers_record())})
     run.finish()
 
     before = SQLiteStorage.get_traces("proj", "trace-run")

--- a/trackio/__init__.py
+++ b/trackio/__init__.py
@@ -1,6 +1,5 @@
 import atexit
 import glob
-import json
 import logging
 import os
 import shutil
@@ -15,6 +14,7 @@ from huggingface_hub import SpaceStorage
 from huggingface_hub.errors import LocalTokenNotFoundError
 
 from trackio import context_vars, deploy, utils
+from trackio._version import __version__ as __version__
 from trackio.alerts import AlertLevel
 from trackio.api import Api
 from trackio.apple_gpu import apple_gpu_available
@@ -51,10 +51,6 @@ from trackio.typehints import UploadEntry
 from trackio.utils import TRACKIO_DIR, TRACKIO_LOGO_DIR, _emit_nonfatal_warning
 
 logging.getLogger("httpx").setLevel(logging.WARNING)
-
-__version__ = json.loads(Path(__file__).parent.joinpath("package.json").read_text())[
-    "version"
-]
 
 
 class _TupleNoPrint(tuple):

--- a/trackio/__init__.py
+++ b/trackio/__init__.py
@@ -46,7 +46,7 @@ from trackio.run import Run
 from trackio.server import TrackioDashboardApp, build_starlette_app_only
 from trackio.sqlite_storage import SQLiteStorage
 from trackio.table import Table
-from trackio.trace import Trace
+from trackio.trace import Trace, VerifiersTrace
 from trackio.typehints import UploadEntry
 from trackio.utils import TRACKIO_DIR, TRACKIO_LOGO_DIR, _emit_nonfatal_warning
 
@@ -89,6 +89,7 @@ __all__ = [
     "Audio",
     "Table",
     "Trace",
+    "VerifiersTrace",
     "Histogram",
     "Markdown",
     "Api",

--- a/trackio/_version.py
+++ b/trackio/_version.py
@@ -1,3 +1,3 @@
 """Python distribution version for the CarbonTeq-maintained Trackio fork."""
 
-__version__ = "0.31.5.post3"
+__version__ = "0.31.5.post5"

--- a/trackio/_version.py
+++ b/trackio/_version.py
@@ -1,0 +1,3 @@
+"""Python distribution version for the CarbonTeq-maintained Trackio fork."""
+
+__version__ = "0.31.5.post1"

--- a/trackio/_version.py
+++ b/trackio/_version.py
@@ -1,3 +1,3 @@
 """Python distribution version for the CarbonTeq-maintained Trackio fork."""
 
-__version__ = "0.31.5.post1"
+__version__ = "0.31.5.post2"

--- a/trackio/_version.py
+++ b/trackio/_version.py
@@ -1,3 +1,3 @@
 """Python distribution version for the CarbonTeq-maintained Trackio fork."""
 
-__version__ = "0.31.5.post2"
+__version__ = "0.31.5.post3"

--- a/trackio/api.py
+++ b/trackio/api.py
@@ -169,6 +169,39 @@ class Run:
                     )
         return series
 
+    def system_metric_names(self) -> list[str]:
+        """Return the names of host metrics recorded for this run."""
+
+        if self._remote_client is not None:
+            return self._remote(
+                "/get_system_metrics_for_run",
+                project=self.project,
+                run=self.name,
+                run_id=self.id,
+            )
+        return SQLiteStorage.get_all_system_metrics_for_run(
+            self.project,
+            self.name,
+            run_id=self.id,
+        )
+
+    def system_history(self) -> list[dict[str, Any]]:
+        """Return host telemetry in timestamp order without resampling."""
+
+        if self._remote_client is not None:
+            return self._remote(
+                "/get_system_logs",
+                project=self.project,
+                run=self.name,
+                run_id=self.id,
+            )
+        return SQLiteStorage.get_system_logs(
+            self.project,
+            self.name,
+            run_id=self.id,
+            max_points=None,
+        )
+
     def traces(
         self,
         *,
@@ -333,6 +366,7 @@ class Api:
             "live_traces": True,
             "artifact_lineage": True,
             "alerts": True,
+            "system_metrics": True,
         }
 
     def runs(self, project: str) -> Runs:

--- a/trackio/api.py
+++ b/trackio/api.py
@@ -1,5 +1,6 @@
 from typing import Any, Iterator, Sequence
 
+from trackio.remote_client import RemoteClient
 from trackio.sqlite_storage import SQLiteStorage
 
 
@@ -10,12 +11,19 @@ class Run:
         name: str,
         run_id: str | None = None,
         created_at: str | None = None,
+        remote_client: RemoteClient | None = None,
     ):
         self.project = project
         self.name = name
         self._id = run_id or name
         self.created_at = created_at
+        self._remote_client = remote_client
         self._config = None
+
+    def _remote(self, api_name: str, **kwargs: Any) -> Any:
+        if self._remote_client is None:
+            raise RuntimeError("run is not backed by a remote Trackio server")
+        return self._remote_client.predict(api_name=api_name, **kwargs)
 
     @property
     def id(self) -> str:
@@ -24,12 +32,30 @@ class Run:
     @property
     def config(self) -> dict | None:
         if self._config is None:
-            self._config = SQLiteStorage.get_run_config(
-                self.project, self.name, run_id=self.id
-            )
+            if self._remote_client is not None:
+                summary = self._remote(
+                    "/get_run_summary",
+                    project=self.project,
+                    run=self.name,
+                    run_id=self.id,
+                )
+                self._config = summary.get("config")
+            else:
+                self._config = SQLiteStorage.get_run_config(
+                    self.project, self.name, run_id=self.id
+                )
         return self._config
 
     def alerts(self, level: str | None = None, since: str | None = None) -> list[dict]:
+        if self._remote_client is not None:
+            return self._remote(
+                "/get_alerts",
+                project=self.project,
+                run=self.name,
+                run_id=self.id,
+                level=level,
+                since=since,
+            )
         return SQLiteStorage.get_alerts(
             self.project, run_name=self.name, run_id=self.id, level=level, since=since
         )
@@ -37,9 +63,25 @@ class Run:
     def summary(self) -> dict[str, Any]:
         """Return stable metadata describing the run's stored evidence."""
 
-        summary = SQLiteStorage.get_run_config(
-            self.project, self.name, run_id=self.id
-        )
+        if self._remote_client is not None:
+            remote_summary = self._remote(
+                "/get_run_summary",
+                project=self.project,
+                run=self.name,
+                run_id=self.id,
+            )
+            return {
+                "project": self.project,
+                "name": self.name,
+                "id": self.id,
+                "created_at": self.created_at,
+                "config": remote_summary.get("config"),
+                "num_logs": remote_summary.get("num_logs", 0),
+                "last_step": remote_summary.get("last_step"),
+                "metrics": remote_summary.get("metrics", []),
+            }
+
+        summary = SQLiteStorage.get_run_config(self.project, self.name, run_id=self.id)
         return {
             "project": self.project,
             "name": self.name,
@@ -70,13 +112,22 @@ class Run:
         fields and do not expose Trackio's physical storage schema.
         """
 
-        rows = SQLiteStorage.get_logs(
-            self.project,
-            self.name,
-            max_points=None,
-            run_id=self.id,
-            scalar_only=scalar_only,
-        )
+        if self._remote_client is not None:
+            rows = self._remote(
+                "/get_run_history",
+                project=self.project,
+                run=self.name,
+                run_id=self.id,
+                scalar_only=scalar_only,
+            )
+        else:
+            rows = SQLiteStorage.get_logs(
+                self.project,
+                self.name,
+                max_points=None,
+                run_id=self.id,
+                scalar_only=scalar_only,
+            )
         if keys is None:
             return rows
         selected = set(keys)
@@ -98,7 +149,9 @@ class Run:
             tuple(names)
             if names is not None
             else tuple(
-                SQLiteStorage.get_all_metrics_for_run(
+                self.summary()["metrics"]
+                if self._remote_client is not None
+                else SQLiteStorage.get_all_metrics_for_run(
                     self.project, self.name, run_id=self.id
                 )
             )
@@ -128,6 +181,19 @@ class Run:
     ) -> list[dict[str, Any]]:
         """Return standard or Verifiers traces for this run."""
 
+        kwargs = {
+            "project": self.project,
+            "run": self.name,
+            "search": search,
+            "sort": sort,
+            "limit": limit,
+            "offset": offset,
+            "run_id": self.id,
+            "step": step,
+            "trace_type": trace_type,
+        }
+        if self._remote_client is not None:
+            return self._remote("/get_traces", **kwargs)
         return SQLiteStorage.get_traces(
             self.project,
             self.name,
@@ -143,14 +209,30 @@ class Run:
     def artifacts(self) -> dict[str, list[dict[str, Any]]]:
         """Return this run's input and output artifact edges."""
 
-        links = SQLiteStorage.get_run_artifacts(
-            self.project, run_name=self.name, run_id=self.id
-        )
+        if self._remote_client is not None:
+            links = self._remote(
+                "/get_run_artifacts",
+                project=self.project,
+                run=self.name,
+                run_id=self.id,
+            )
+        else:
+            links = SQLiteStorage.get_run_artifacts(
+                self.project, run_name=self.name, run_id=self.id
+            )
         for records in links.values():
             for record in records:
-                manifest = SQLiteStorage.get_artifact_manifest(
-                    self.project, record["name"], f"v{record['version']}"
-                )
+                if self._remote_client is not None:
+                    manifest = self._remote(
+                        "/get_artifact_manifest",
+                        project=self.project,
+                        name=record["name"],
+                        spec=f"v{record['version']}",
+                    )
+                else:
+                    manifest = SQLiteStorage.get_artifact_manifest(
+                        self.project, record["name"], f"v{record['version']}"
+                    )
                 if manifest is None:
                     continue
                 record["description"] = manifest.get("description")
@@ -159,9 +241,13 @@ class Run:
         return links
 
     def delete(self) -> bool:
+        if self._remote_client is not None:
+            raise RuntimeError("trackio.Api remote runs are read-only")
         return SQLiteStorage.delete_run(self.project, self.name, run_id=self.id)
 
     def move(self, new_project: str) -> bool:
+        if self._remote_client is not None:
+            raise RuntimeError("trackio.Api remote runs are read-only")
         success = SQLiteStorage.move_run(
             self.project, self.name, new_project, run_id=self.id
         )
@@ -170,6 +256,8 @@ class Run:
         return success
 
     def rename(self, new_name: str) -> "Run":
+        if self._remote_client is not None:
+            raise RuntimeError("trackio.Api remote runs are read-only")
         SQLiteStorage.rename_run(self.project, self.name, new_name, run_id=self.id)
         self.name = new_name
         return self
@@ -179,13 +267,20 @@ class Run:
 
 
 class Runs:
-    def __init__(self, project: str):
+    def __init__(self, project: str, remote_client: RemoteClient | None = None):
         self.project = project
+        self._remote_client = remote_client
         self._runs = None
 
     def _load_runs(self):
         if self._runs is None:
-            records = SQLiteStorage.get_run_records(self.project)
+            records = (
+                self._remote_client.predict(
+                    project=self.project, api_name="/get_runs_for_project"
+                )
+                if self._remote_client is not None
+                else SQLiteStorage.get_run_records(self.project)
+            )
             self._runs = [
                 Run(
                     self.project,
@@ -196,6 +291,7 @@ class Runs:
                         if record.get("created_at") is not None
                         else None
                     ),
+                    remote_client=self._remote_client,
                 )
                 for record in records
             ]
@@ -218,6 +314,13 @@ class Runs:
 
 
 class Api:
+    def __init__(
+        self, server_url: str | None = None, *, hf_token: str | None = None
+    ) -> None:
+        self._remote_client = (
+            RemoteClient(server_url, hf_token=hf_token) if server_url is not None else None
+        )
+
     def capabilities(self) -> dict[str, bool]:
         """Return stable read capabilities implemented by this API."""
 
@@ -233,6 +336,8 @@ class Api:
         }
 
     def runs(self, project: str) -> Runs:
+        if self._remote_client is not None:
+            return Runs(project, self._remote_client)
         if not SQLiteStorage.get_project_db_path(project).exists():
             raise ValueError(f"Project '{project}' does not exist")
         return Runs(project)
@@ -252,6 +357,14 @@ class Api:
         level: str | None = None,
         since: str | None = None,
     ) -> list[dict]:
+        if self._remote_client is not None:
+            return self._remote_client.predict(
+                project=project,
+                run=run,
+                level=level,
+                since=since,
+                api_name="/get_alerts",
+            )
         if not SQLiteStorage.get_project_db_path(project).exists():
             raise ValueError(f"Project '{project}' does not exist")
         return SQLiteStorage.get_alerts(project, run_name=run, level=level, since=since)

--- a/trackio/api.py
+++ b/trackio/api.py
@@ -186,7 +186,7 @@ class Run:
         )
 
     def system_history(self) -> list[dict[str, Any]]:
-        """Return host telemetry in timestamp order without resampling."""
+        """Return provider-bounded host telemetry in timestamp order."""
 
         if self._remote_client is not None:
             return self._remote(

--- a/trackio/api.py
+++ b/trackio/api.py
@@ -369,6 +369,16 @@ class Api:
             "system_metrics": True,
         }
 
+    def run_configs(self, project: str) -> dict[str, Any]:
+        """Every run's configuration in one request.
+
+        The server has always been able to answer this for a whole project;
+        without it on the client, callers read configurations one run at a time.
+        """
+        if self._remote_client is None:
+            return SQLiteStorage.get_all_run_configs(project)
+        return self._remote_client.predict(project=project, api_name="/get_run_configs")
+
     def run_lifecycles(self, project: str) -> dict[str, Any]:
         """Every run's latest lifecycle values in one request.
 

--- a/trackio/api.py
+++ b/trackio/api.py
@@ -143,9 +143,20 @@ class Run:
     def artifacts(self) -> dict[str, list[dict[str, Any]]]:
         """Return this run's input and output artifact edges."""
 
-        return SQLiteStorage.get_run_artifacts(
+        links = SQLiteStorage.get_run_artifacts(
             self.project, run_name=self.name, run_id=self.id
         )
+        for records in links.values():
+            for record in records:
+                manifest = SQLiteStorage.get_artifact_manifest(
+                    self.project, record["name"], f"v{record['version']}"
+                )
+                if manifest is None:
+                    continue
+                record["description"] = manifest.get("description")
+                record["metadata"] = manifest.get("metadata") or {}
+                record["digest"] = manifest.get("manifest_digest")
+        return links
 
     def delete(self) -> bool:
         return SQLiteStorage.delete_run(self.project, self.name, run_id=self.id)

--- a/trackio/api.py
+++ b/trackio/api.py
@@ -1,13 +1,20 @@
-from typing import Iterator
+from typing import Any, Iterator, Sequence
 
 from trackio.sqlite_storage import SQLiteStorage
 
 
 class Run:
-    def __init__(self, project: str, name: str, run_id: str | None = None):
+    def __init__(
+        self,
+        project: str,
+        name: str,
+        run_id: str | None = None,
+        created_at: str | None = None,
+    ):
         self.project = project
         self.name = name
         self._id = run_id or name
+        self.created_at = created_at
         self._config = None
 
     @property
@@ -25,6 +32,119 @@ class Run:
     def alerts(self, level: str | None = None, since: str | None = None) -> list[dict]:
         return SQLiteStorage.get_alerts(
             self.project, run_name=self.name, run_id=self.id, level=level, since=since
+        )
+
+    def summary(self) -> dict[str, Any]:
+        """Return stable metadata describing the run's stored evidence."""
+
+        summary = SQLiteStorage.get_run_config(
+            self.project, self.name, run_id=self.id
+        )
+        return {
+            "project": self.project,
+            "name": self.name,
+            "id": self.id,
+            "created_at": self.created_at,
+            "config": summary,
+            "num_logs": SQLiteStorage.get_log_count(
+                self.project, self.name, run_id=self.id
+            ),
+            "last_step": SQLiteStorage.get_last_step(
+                self.project, self.name, run_id=self.id
+            ),
+            "metrics": SQLiteStorage.get_all_metrics_for_run(
+                self.project, self.name, run_id=self.id
+            ),
+        }
+
+    def history(
+        self,
+        keys: Sequence[str] | None = None,
+        *,
+        scalar_only: bool = False,
+    ) -> list[dict[str, Any]]:
+        """Return unsampled run history in occurrence order.
+
+        ``keys`` projects the result while always retaining ``step`` and
+        ``timestamp``. The returned dictionaries contain only public logical
+        fields and do not expose Trackio's physical storage schema.
+        """
+
+        rows = SQLiteStorage.get_logs(
+            self.project,
+            self.name,
+            max_points=None,
+            run_id=self.id,
+            scalar_only=scalar_only,
+        )
+        if keys is None:
+            return rows
+        selected = set(keys)
+        return [
+            {
+                key: value
+                for key, value in row.items()
+                if key in selected or key in {"step", "timestamp"}
+            }
+            for row in rows
+        ]
+
+    def metric_series(
+        self, names: Sequence[str] | None = None
+    ) -> dict[str, list[dict[str, Any]]]:
+        """Return metric values grouped by name with explicit steps."""
+
+        metric_names = (
+            tuple(names)
+            if names is not None
+            else tuple(
+                SQLiteStorage.get_all_metrics_for_run(
+                    self.project, self.name, run_id=self.id
+                )
+            )
+        )
+        series = {name: [] for name in metric_names}
+        for row in self.history(metric_names):
+            for name in metric_names:
+                if name in row:
+                    series[name].append(
+                        {
+                            "step": row.get("step"),
+                            "timestamp": row.get("timestamp"),
+                            "value": row[name],
+                        }
+                    )
+        return series
+
+    def traces(
+        self,
+        *,
+        search: str | None = None,
+        sort: str | None = None,
+        limit: int | None = None,
+        offset: int = 0,
+        step: int | None = None,
+        trace_type: str | None = None,
+    ) -> list[dict[str, Any]]:
+        """Return standard or Verifiers traces for this run."""
+
+        return SQLiteStorage.get_traces(
+            self.project,
+            self.name,
+            search=search,
+            sort=sort,
+            limit=limit,
+            offset=offset,
+            run_id=self.id,
+            step=step,
+            trace_type=trace_type,
+        )
+
+    def artifacts(self) -> dict[str, list[dict[str, Any]]]:
+        """Return this run's input and output artifact edges."""
+
+        return SQLiteStorage.get_run_artifacts(
+            self.project, run_name=self.name, run_id=self.id
         )
 
     def delete(self) -> bool:
@@ -60,6 +180,11 @@ class Runs:
                     self.project,
                     str(record["name"]),
                     run_id=str(record["id"]) if record["id"] is not None else None,
+                    created_at=(
+                        str(record["created_at"])
+                        if record.get("created_at") is not None
+                        else None
+                    ),
                 )
                 for record in records
             ]
@@ -82,10 +207,32 @@ class Runs:
 
 
 class Api:
+    def capabilities(self) -> dict[str, bool]:
+        """Return stable read capabilities implemented by this API."""
+
+        return {
+            "run_summaries": True,
+            "full_history": True,
+            "explicit_metric_steps": True,
+            "standard_traces": True,
+            "verifiers_traces": True,
+            "live_traces": True,
+            "artifact_lineage": True,
+            "alerts": True,
+        }
+
     def runs(self, project: str) -> Runs:
         if not SQLiteStorage.get_project_db_path(project).exists():
             raise ValueError(f"Project '{project}' does not exist")
         return Runs(project)
+
+    def run(self, project: str, run_id: str) -> Run:
+        """Return one run by immutable ID."""
+
+        for run in self.runs(project):
+            if run.id == run_id:
+                return run
+        raise ValueError(f"Run '{run_id}' does not exist in project '{project}'")
 
     def alerts(
         self,

--- a/trackio/api.py
+++ b/trackio/api.py
@@ -369,6 +369,17 @@ class Api:
             "system_metrics": True,
         }
 
+    def run_lifecycles(self, project: str) -> dict[str, Any]:
+        """Every run's latest lifecycle values in one request.
+
+        Reading these per run makes listing a project cost a request per run.
+        """
+        if self._remote_client is None:
+            return SQLiteStorage.get_run_lifecycles(project)
+        return self._remote_client.predict(
+            project=project, api_name="/get_run_lifecycles"
+        )
+
     def runs(self, project: str) -> Runs:
         if self._remote_client is not None:
             return Runs(project, self._remote_client)

--- a/trackio/asgi_app.py
+++ b/trackio/asgi_app.py
@@ -35,6 +35,7 @@ from trackio.resumable_uploads import (
 
 logger = logging.getLogger("trackio.asgi_app")
 
+
 def _normalize_allowed_file_roots(
     allowed_file_roots: list[str | Path] | None,
 ) -> tuple[Path, ...]:

--- a/trackio/asgi_app.py
+++ b/trackio/asgi_app.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import inspect
 import json
 import logging
@@ -18,14 +19,21 @@ from starlette.responses import FileResponse, JSONResponse, Response, StreamingR
 from starlette.routing import Route
 
 from trackio import utils
+from trackio._version import __version__
 from trackio.exceptions import TrackioAPIError
 from trackio.remote_client import HTTP_API_VERSION
+from trackio.resumable_uploads import (
+    COMPATIBILITY_MAX_BYTES,
+    DEFAULT_CHUNK_SIZE,
+    UploadSessionError,
+    abort_session,
+    complete_session,
+    create_or_resume_session,
+    get_session,
+    store_chunk,
+)
 
 logger = logging.getLogger("trackio.asgi_app")
-
-_PACKAGE_JSON_PATH = Path(__file__).parent / "package.json"
-_TRACKIO_PACKAGE_VERSION = json.loads(_PACKAGE_JSON_PATH.read_text())["version"]
-
 
 def _normalize_allowed_file_roots(
     allowed_file_roots: list[str | Path] | None,
@@ -140,7 +148,7 @@ async def version_handler(request: Request) -> Response:
     mcp_enabled = bool(getattr(request.app.state, "mcp_enabled", False))
     return JSONResponse(
         {
-            "version": _TRACKIO_PACKAGE_VERSION,
+            "version": __version__,
             "api_version": HTTP_API_VERSION,
             "api_transport": "http",
             "mcp_enabled": mcp_enabled,
@@ -408,6 +416,135 @@ async def upload_handler(request: Request) -> Response:
     return JSONResponse({"paths": saved_paths})
 
 
+def _authorize_artifact_upload(request: Request) -> Response | None:
+    upload_authorizer = getattr(request.app.state, "upload_authorizer", None)
+    if callable(upload_authorizer):
+        try:
+            upload_authorizer(request)
+        except TrackioAPIError as error:
+            return JSONResponse({"error": str(error)}, status_code=401)
+    return None
+
+
+def _upload_error(error: Exception) -> JSONResponse:
+    if isinstance(error, FileNotFoundError):
+        return JSONResponse({"error": str(error)}, status_code=404)
+    if isinstance(error, UploadSessionError):
+        return JSONResponse({"error": str(error)}, status_code=409)
+    if isinstance(error, (TypeError, ValueError, KeyError)):
+        return JSONResponse({"error": str(error)}, status_code=400)
+    logger.exception("Artifact upload request failed")
+    return JSONResponse({"error": "Artifact upload failed."}, status_code=500)
+
+
+def _resumable_session_lock(request: Request, upload_id: str) -> asyncio.Lock:
+    with request.app.state.resumable_upload_locks_guard:
+        return request.app.state.resumable_upload_locks.setdefault(
+            upload_id,
+            asyncio.Lock(),
+        )
+
+
+async def artifact_upload_capabilities_handler(request: Request) -> Response:
+    return JSONResponse(
+        {
+            "resumable": True,
+            "compatibility_max_bytes": COMPATIBILITY_MAX_BYTES,
+            "chunk_size_bytes": DEFAULT_CHUNK_SIZE,
+        }
+    )
+
+
+async def artifact_upload_init_handler(request: Request) -> Response:
+    if unauthorized := _authorize_artifact_upload(request):
+        return unauthorized
+    try:
+        payload = await request.json()
+        with request.app.state.resumable_upload_lock:
+            session = create_or_resume_session(
+                project=request.path_params["project"],
+                digest=payload["digest"],
+                size_bytes=payload["size_bytes"],
+                idempotency_key=payload["idempotency_key"],
+            )
+        return JSONResponse(session)
+    except Exception as error:
+        return _upload_error(error)
+
+
+async def artifact_upload_status_handler(request: Request) -> Response:
+    if unauthorized := _authorize_artifact_upload(request):
+        return unauthorized
+    try:
+        async with _resumable_session_lock(
+            request,
+            request.path_params["upload_id"],
+        ):
+            session = get_session(
+                request.path_params["project"],
+                request.path_params["upload_id"],
+            )
+        return JSONResponse(session)
+    except Exception as error:
+        return _upload_error(error)
+
+
+async def artifact_upload_chunk_handler(request: Request) -> Response:
+    if unauthorized := _authorize_artifact_upload(request):
+        return unauthorized
+    try:
+        claimed_digest = request.headers["x-trackio-chunk-sha256"]
+        index = int(request.path_params["index"])
+        async with _resumable_session_lock(
+            request,
+            request.path_params["upload_id"],
+        ):
+            result = await store_chunk(
+                project=request.path_params["project"],
+                upload_id=request.path_params["upload_id"],
+                index=index,
+                claimed_digest=claimed_digest,
+                chunks=request.stream(),
+            )
+        return JSONResponse(result)
+    except Exception as error:
+        return _upload_error(error)
+
+
+async def artifact_upload_complete_handler(request: Request) -> Response:
+    if unauthorized := _authorize_artifact_upload(request):
+        return unauthorized
+    try:
+        async with _resumable_session_lock(
+            request,
+            request.path_params["upload_id"],
+        ):
+            result = complete_session(
+                request.path_params["project"],
+                request.path_params["upload_id"],
+            )
+        return JSONResponse(result)
+    except Exception as error:
+        return _upload_error(error)
+
+
+async def artifact_upload_abort_handler(request: Request) -> Response:
+    if unauthorized := _authorize_artifact_upload(request):
+        return unauthorized
+    try:
+        async with _resumable_session_lock(
+            request,
+            request.path_params["upload_id"],
+        ):
+            aborted = abort_session(
+                request.path_params["project"],
+                request.path_params["upload_id"],
+            )
+        return JSONResponse({"aborted": aborted})
+    except Exception as error:
+        return _upload_error(error)
+
+
 async def gradio_upload_alias_handler(request: Request) -> Response:
     return await upload_handler(request)
 
@@ -463,6 +600,36 @@ def create_trackio_starlette_app(
         [
             Route("/version", endpoint=version_handler, methods=["GET"]),
             Route("/api/upload", endpoint=upload_handler, methods=["POST"]),
+            Route(
+                "/api/artifact-upload/capabilities",
+                endpoint=artifact_upload_capabilities_handler,
+                methods=["GET"],
+            ),
+            Route(
+                "/api/artifact-upload/{project:str}",
+                endpoint=artifact_upload_init_handler,
+                methods=["POST"],
+            ),
+            Route(
+                "/api/artifact-upload/{project:str}/{upload_id:str}",
+                endpoint=artifact_upload_status_handler,
+                methods=["GET"],
+            ),
+            Route(
+                "/api/artifact-upload/{project:str}/{upload_id:str}",
+                endpoint=artifact_upload_complete_handler,
+                methods=["POST"],
+            ),
+            Route(
+                "/api/artifact-upload/{project:str}/{upload_id:str}",
+                endpoint=artifact_upload_abort_handler,
+                methods=["DELETE"],
+            ),
+            Route(
+                "/api/artifact-upload/{project:str}/{upload_id:str}/chunks/{index:int}",
+                endpoint=artifact_upload_chunk_handler,
+                methods=["PUT"],
+            ),
             Route("/api/{api_name:str}", endpoint=api_handler, methods=["POST"]),
             Route("/file", endpoint=file_handler, methods=["GET"]),
             Route(
@@ -525,6 +692,9 @@ def create_trackio_starlette_app(
     app.state.upload_authorizer = upload_authorizer
     app.state.uploaded_temp_files = set()
     app.state.uploaded_temp_files_lock = threading.Lock()
+    app.state.resumable_upload_lock = threading.Lock()
+    app.state.resumable_upload_locks = {}
+    app.state.resumable_upload_locks_guard = threading.Lock()
     if utils.on_spaces():
         app.state.gradio_call_events = {}
         app.state.gradio_call_events_lock = threading.Lock()

--- a/trackio/cli.py
+++ b/trackio/cli.py
@@ -179,6 +179,32 @@ def _handle_cleanup_uploads(args):
         print("Run again with --apply to delete only the listed incomplete sessions.")
 
 
+def _handle_storage_migrate(args) -> None:
+    from trackio.doris_migration import migrate_sqlite_to_doris
+
+    try:
+        receipt = migrate_sqlite_to_doris(
+            Path(args.source),
+            Path(args.receipt),
+            dry_run=args.dry_run,
+            verify_only=args.verify_only,
+            projects=tuple(args.project or ()),
+            batch_size=args.batch_size,
+        )
+    except (FileNotFoundError, RuntimeError, ValueError) as error:
+        error_exit(str(error))
+    if receipt["dry_run"]:
+        action = "inspected"
+    elif receipt["verify_only"]:
+        action = "verified"
+    else:
+        action = "migrated and verified"
+    print(
+        f"Trackio storage {action}: projects={len(receipt['projects'])} "
+        f"receipt={args.receipt}"
+    )
+
+
 def _extract_reports(
     run: str, logs: list[dict], report_name: str | None = None
 ) -> list[dict]:
@@ -471,6 +497,50 @@ def main():
         help="Delete the reported incomplete sessions; the default is dry-run.",
     )
     cleanup_uploads_parser.add_argument("--json", action="store_true")
+
+    storage_parser = subparsers.add_parser(
+        "storage",
+        help="Inspect or migrate Trackio storage providers.",
+    )
+    storage_subparsers = storage_parser.add_subparsers(
+        dest="storage_command", required=True
+    )
+    storage_migrate_parser = storage_subparsers.add_parser(
+        "migrate",
+        help="Copy SQLite/Turso project databases into Apache Doris.",
+    )
+    storage_migrate_parser.add_argument(
+        "--source",
+        required=True,
+        help="Trackio directory or one project .db file.",
+    )
+    storage_migrate_parser.add_argument(
+        "--receipt",
+        required=True,
+        help="Path for the redacted migration and reconciliation receipt.",
+    )
+    storage_migrate_parser.add_argument(
+        "--project",
+        action="append",
+        help="Migrate only this canonical project name; may be repeated.",
+    )
+    storage_migrate_parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=500,
+        help="Maximum evidence rows per Doris write batch.",
+    )
+    mode = storage_migrate_parser.add_mutually_exclusive_group()
+    mode.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Inspect source databases and write a receipt without changing Doris.",
+    )
+    mode.add_argument(
+        "--verify-only",
+        action="store_true",
+        help="Compare source and Doris counts without copying records.",
+    )
 
     sync_parser = subparsers.add_parser(
         "sync",
@@ -1285,9 +1355,8 @@ def main():
         "freeze",
         "skills",
         "cleanup-uploads",
-    ) and _get_space(
-        args
-    ):
+        "storage",
+    ) and _get_space(args):
         error_exit(
             f"The '{args.command}' command does not support --space (remote mode)."
         )
@@ -1309,6 +1378,9 @@ def main():
         _handle_status()
     elif args.command == "cleanup-uploads":
         _handle_cleanup_uploads(args)
+    elif args.command == "storage":
+        if args.storage_command == "migrate":
+            _handle_storage_migrate(args)
     elif args.command == "sync":
         _handle_sync(args)
     elif args.command == "freeze":

--- a/trackio/cli.py
+++ b/trackio/cli.py
@@ -2,6 +2,7 @@ import argparse
 import os
 import re
 import sys
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 import huggingface_hub
@@ -31,6 +32,7 @@ from trackio.frontend_config import (
     unset_persisted_frontend_dir,
 )
 from trackio.markdown import Markdown
+from trackio.resumable_uploads import expire_sessions
 from trackio.server import get_project_summary, get_run_summary
 from trackio.sqlite_storage import SQLiteStorage
 
@@ -153,6 +155,28 @@ def _handle_config(args):
         else:
             print("No Trackio default frontend was set.")
         return
+
+
+def _handle_cleanup_uploads(args):
+    if args.older_than_hours <= 0:
+        error_exit("--older-than-hours must be positive.")
+    cutoff = datetime.now(UTC) - timedelta(hours=args.older_than_hours)
+    result = expire_sessions(
+        project=args.project,
+        older_than=cutoff,
+        dry_run=not args.apply,
+    )
+    if args.json:
+        print(format_json(result))
+        return
+    action = "Would reclaim" if result["dry_run"] else "Reclaimed"
+    print(
+        f"{action} {result['reclaimable_bytes']} bytes from "
+        f"{result['session_count']} incomplete upload session(s) "
+        f"in project '{result['project']}'."
+    )
+    if result["dry_run"] and result["session_count"]:
+        print("Run again with --apply to delete only the listed incomplete sessions.")
 
 
 def _extract_reports(
@@ -429,6 +453,24 @@ def main():
         "status",
         help="Show the status of all local Trackio projects, including sync status.",
     )
+
+    cleanup_uploads_parser = subparsers.add_parser(
+        "cleanup-uploads",
+        help="Report or remove expired incomplete artifact-upload staging.",
+    )
+    cleanup_uploads_parser.add_argument("--project", required=True)
+    cleanup_uploads_parser.add_argument(
+        "--older-than-hours",
+        type=float,
+        default=24,
+        help="Only include incomplete sessions not updated within this many hours.",
+    )
+    cleanup_uploads_parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Delete the reported incomplete sessions; the default is dry-run.",
+    )
+    cleanup_uploads_parser.add_argument("--json", action="store_true")
 
     sync_parser = subparsers.add_parser(
         "sync",
@@ -1236,7 +1278,14 @@ def main():
         if trailing_globals.hf_token is not None:
             args.hf_token = trailing_globals.hf_token
 
-    if args.command in ("show", "status", "sync", "freeze", "skills") and _get_space(
+    if args.command in (
+        "show",
+        "status",
+        "sync",
+        "freeze",
+        "skills",
+        "cleanup-uploads",
+    ) and _get_space(
         args
     ):
         error_exit(
@@ -1258,6 +1307,8 @@ def main():
         )
     elif args.command == "status":
         _handle_status()
+    elif args.command == "cleanup-uploads":
+        _handle_cleanup_uploads(args)
     elif args.command == "sync":
         _handle_sync(args)
     elif args.command == "freeze":

--- a/trackio/cpu.py
+++ b/trackio/cpu.py
@@ -293,7 +293,8 @@ def log_cpu(run: "Run | None" = None) -> dict:
         _ensure_psutil()
     except ImportError:
         warnings.warn(
-            "trackio.log_cpu() requires psutil. Install it with: pip install trackio[cpu]"
+            "trackio.log_cpu() requires psutil. Install it with: "
+            "pip install carbonteq-trackio[cpu]"
         )
         return {}
 

--- a/trackio/database.py
+++ b/trackio/database.py
@@ -9,9 +9,14 @@ from typing import Any
 import turso as _turso
 
 ENGINE = os.environ.get("TRACKIO_DATABASE_ENGINE", "turso").strip().lower()
-if ENGINE not in {"turso", "sqlite"}:
-    raise RuntimeError("TRACKIO_DATABASE_ENGINE must be 'turso' or 'sqlite'")
+if ENGINE not in {"turso", "sqlite", "doris"}:
+    raise RuntimeError("TRACKIO_DATABASE_ENGINE must be 'turso', 'sqlite', or 'doris'")
 
+# This module is deliberately the SQLite-compatible driver boundary. Doris is
+# selected one layer above it through ``trackio.storage``. Keep the sqlite
+# symbols importable so legacy modules can load, but fail closed if a
+# SQLite-specific caller accidentally attempts to open a database in Doris
+# mode.
 _driver = _turso if ENGINE == "turso" else _sqlite
 
 
@@ -79,6 +84,11 @@ def connect(
     **kwargs: Any,
 ) -> Any:
     """Open the configured engine while retaining sqlite3-compatible callers."""
+    if ENGINE == "doris":
+        raise RuntimeError(
+            "SQLite-compatible connect() is unavailable when "
+            "TRACKIO_DATABASE_ENGINE=doris; use the selected Trackio storage provider"
+        )
     if ENGINE == "turso":
         del timeout, check_same_thread
         return _TursoConnection(_turso.connect(database, **kwargs))

--- a/trackio/database.py
+++ b/trackio/database.py
@@ -1,0 +1,100 @@
+"""Database driver boundary for Trackio's SQLite-compatible metadata store."""
+
+from __future__ import annotations
+
+import os
+import sqlite3 as _sqlite
+from typing import Any
+
+import turso as _turso
+
+ENGINE = os.environ.get("TRACKIO_DATABASE_ENGINE", "turso").strip().lower()
+if ENGINE not in {"turso", "sqlite"}:
+    raise RuntimeError("TRACKIO_DATABASE_ENGINE must be 'turso' or 'sqlite'")
+
+_driver = _turso if ENGINE == "turso" else _sqlite
+
+
+class _TursoConnection:
+    """Small sqlite3-compatibility wrapper around pyturso connections.
+
+    pyturso currently permits operations after ``close()``. Trackio relies on
+    sqlite3's stricter lifecycle contract, so enforce it at the driver boundary
+    instead of leaking backend-specific behavior throughout the application.
+    """
+
+    def __init__(self, connection: Any) -> None:
+        object.__setattr__(self, "_connection", connection)
+        object.__setattr__(self, "_closed", False)
+
+    def _check_open(self) -> None:
+        if self._closed:
+            raise _sqlite.ProgrammingError("Cannot operate on a closed database.")
+
+    def close(self) -> None:
+        if not self._closed:
+            self._connection.close()
+            object.__setattr__(self, "_closed", True)
+
+    def __enter__(self) -> _TursoConnection:
+        self._check_open()
+        self._connection.__enter__()
+        return self
+
+    def __exit__(self, exc_type: Any, exc: Any, traceback: Any) -> Any:
+        self._check_open()
+        return self._connection.__exit__(exc_type, exc, traceback)
+
+    def __getattr__(self, name: str) -> Any:
+        self._check_open()
+        return getattr(self._connection, name)
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        if name in {"_connection", "_closed"}:
+            object.__setattr__(self, name, value)
+            return
+        self._check_open()
+        setattr(self._connection, name, value)
+
+
+Connection = _TursoConnection if ENGINE == "turso" else _sqlite.Connection
+Cursor = _driver.Cursor
+Row = _driver.Row
+Error = _driver.Error
+DatabaseError = _driver.DatabaseError
+OperationalError = (
+    (_turso.OperationalError, _turso.DatabaseError)
+    if ENGINE == "turso"
+    else _sqlite.OperationalError
+)
+IntegrityError = _driver.IntegrityError
+ProgrammingError = _driver.ProgrammingError
+ReadonlyDatabaseError = _sqlite.DatabaseError
+
+
+def connect(
+    database: str,
+    timeout: float = 30.0,
+    check_same_thread: bool = True,
+    **kwargs: Any,
+) -> Any:
+    """Open the configured engine while retaining sqlite3-compatible callers."""
+    if ENGINE == "turso":
+        del timeout, check_same_thread
+        return _TursoConnection(_turso.connect(database, **kwargs))
+    return _sqlite.connect(
+        database,
+        timeout=timeout,
+        check_same_thread=check_same_thread,
+        **kwargs,
+    )
+
+
+def readonly_sqlite_connect(database: str) -> _sqlite.Connection:
+    """Open an immutable compatibility reader for guarded arbitrary SQL."""
+    connection = _sqlite.connect(f"file:{database}?mode=ro", uri=True)
+    connection.row_factory = _sqlite.Row
+    return connection
+
+
+sqlite_authorizer = _sqlite

--- a/trackio/deploy.py
+++ b/trackio/deploy.py
@@ -735,6 +735,11 @@ def _replay_pending_uploads(
         pending_uploads,
         project,
         predict=client.predict,
+        artifact_blob_uploader=(
+            client.upload_artifact_blob
+            if callable(getattr(type(client), "upload_artifact_blob", None))
+            else None
+        ),
         hf_token=hf_token,
         warn_missing=_warn_missing,
         verbose=True,

--- a/trackio/deploy.py
+++ b/trackio/deploy.py
@@ -306,7 +306,7 @@ def _get_source_install_dependencies() -> str:
 
 
 def _get_space_install_requirement() -> str:
-    return f"trackio[spaces,mcp]=={trackio.__version__}"
+    return f"carbonteq-trackio[spaces,mcp]=={trackio.__version__}"
 
 
 def _is_trackio_installed_from_source() -> bool:
@@ -316,7 +316,7 @@ def _is_trackio_installed_from_source() -> bool:
         if "site-packages" not in trackio_file and "dist-packages" not in trackio_file:
             return True
 
-        dist = importlib.metadata.distribution("trackio")
+        dist = importlib.metadata.distribution("carbonteq-trackio")
         if dist.files:
             files = list(dist.files)
             has_pth = any(".pth" in str(f) for f in files)

--- a/trackio/doris_migration.py
+++ b/trackio/doris_migration.py
@@ -1,0 +1,722 @@
+"""Copy and reconcile Trackio project databases into Apache Doris."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sqlite3
+from collections import defaultdict
+from contextlib import contextmanager
+from datetime import UTC, datetime
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Any, Iterator
+
+import orjson
+
+from trackio.doris_storage import DorisStorage
+from trackio.utils import deserialize_values
+
+AUTHORITATIVE_TABLES = (
+    "metrics",
+    "configs",
+    "system_metrics",
+    "traces",
+    "alerts",
+    "project_metadata",
+    "artifacts",
+    "artifact_versions",
+    "artifact_aliases",
+    "run_artifact_links",
+)
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for chunk in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _tables(connection: sqlite3.Connection) -> set[str]:
+    return {
+        str(row[0])
+        for row in connection.execute(
+            "SELECT name FROM sqlite_master WHERE type = 'table'"
+        )
+    }
+
+
+def _rows(connection: sqlite3.Connection, table: str) -> list[dict[str, Any]]:
+    if table not in _tables(connection):
+        return []
+    return [dict(row) for row in connection.execute(f"SELECT * FROM {table}")]
+
+
+def _decode(value: Any, default: Any) -> Any:
+    if value is None:
+        return default
+    return deserialize_values(orjson.loads(value))
+
+
+def _canonical_json(value: Any, default: Any) -> Any:
+    if value is None:
+        return default
+    return orjson.loads(value)
+
+
+def _canonical_evidence(records: list[dict[str, Any]]) -> dict[str, Any]:
+    encoded = [orjson.dumps(record, option=orjson.OPT_SORT_KEYS) for record in records]
+    encoded.sort()
+    digest = hashlib.sha256()
+    for record in encoded:
+        digest.update(len(record).to_bytes(8, "big"))
+        digest.update(record)
+    return {"count": len(encoded), "sha256": digest.hexdigest()}
+
+
+def _records_evidence(
+    records: dict[str, list[dict[str, Any]]],
+) -> dict[str, dict[str, Any]]:
+    return {
+        table: _canonical_evidence(records.get(table, []))
+        for table in AUTHORITATIVE_TABLES
+    }
+
+
+@contextmanager
+def _sqlite_snapshot(db_path: Path) -> Iterator[tuple[Path, dict[str, Any]]]:
+    """Yield a consistent read-only backup, including committed WAL records."""
+
+    if not db_path.is_file():
+        raise FileNotFoundError(f"Trackio project database not found: {db_path}")
+    source_stat = db_path.stat()
+    wal_path = Path(f"{db_path}-wal")
+    metadata = {
+        "source_file_sha256": _sha256(db_path),
+        "source_file_bytes": source_stat.st_size,
+        "source_file_mtime_ns": source_stat.st_mtime_ns,
+        "wal_present": wal_path.is_file(),
+    }
+    with TemporaryDirectory(prefix="trackio-doris-snapshot-") as directory:
+        snapshot = Path(directory) / db_path.name
+        source = sqlite3.connect(
+            f"{db_path.resolve().as_uri()}?mode=ro",
+            uri=True,
+            timeout=30,
+        )
+        target = sqlite3.connect(snapshot)
+        try:
+            source.execute("PRAGMA query_only = ON")
+            source.backup(target)
+            target.commit()
+        finally:
+            target.close()
+            source.close()
+        metadata["snapshot_sha256"] = _sha256(snapshot)
+        metadata["snapshot_bytes"] = snapshot.stat().st_size
+        yield snapshot, metadata
+
+
+def _source_records(
+    connection: sqlite3.Connection,
+) -> dict[str, list[dict[str, Any]]]:
+    metrics = [
+        {
+            "run_id": str(row.get("run_id") or row["run_name"]),
+            "timestamp": str(row["timestamp"]),
+            "run_name": str(row["run_name"]),
+            "step": int(row["step"]),
+            "metrics": _canonical_json(row["metrics"], {}),
+            "log_id": row.get("log_id"),
+            "space_id": row.get("space_id"),
+        }
+        for row in _rows(connection, "metrics")
+    ]
+    configs = [
+        {
+            "run_id": str(row.get("run_id") or row["run_name"]),
+            "run_name": str(row["run_name"]),
+            "config": _canonical_json(row["config"], {}),
+            "created_at": str(row["created_at"]),
+        }
+        for row in _rows(connection, "configs")
+    ]
+    system_metrics = [
+        {
+            "run_id": str(row.get("run_id") or row["run_name"]),
+            "timestamp": str(row["timestamp"]),
+            "run_name": str(row["run_name"]),
+            "metrics": _canonical_json(row["metrics"], {}),
+            "log_id": row.get("log_id"),
+            "space_id": row.get("space_id"),
+        }
+        for row in _rows(connection, "system_metrics")
+    ]
+    traces = [
+        {
+            "trace_id": str(row["id"]),
+            "run_id": str(row.get("run_id") or row["run_name"]),
+            "timestamp": str(row["timestamp"]),
+            "run_name": str(row["run_name"]),
+            "step": int(row["step"]),
+            "metric_key": str(row["key"]),
+            "trace_index": row.get("trace_index"),
+            "messages": _canonical_json(row["messages"], []),
+            "metadata": _canonical_json(row["metadata"], {}),
+            "search_text": str(row.get("search_text") or ""),
+            "log_id": row.get("log_id"),
+            "space_id": row.get("space_id"),
+            "trace_type": str(row.get("trace_type") or "trackio"),
+            "external_id": row.get("external_id"),
+            "schema_version": row.get("schema_version"),
+            "payload": _canonical_json(row.get("payload"), None),
+        }
+        for row in _rows(connection, "traces")
+    ]
+    alerts = [
+        {
+            "run_id": str(row.get("run_id") or row["run_name"]),
+            "timestamp": str(row["timestamp"]),
+            "run_name": str(row["run_name"]),
+            "title": str(row["title"]),
+            "text": row.get("text"),
+            "level": str(row["level"]),
+            "step": row.get("step"),
+            "alert_id": row.get("alert_id"),
+        }
+        for row in _rows(connection, "alerts")
+    ]
+    project_metadata = [
+        {"key": str(row["key"]), "value": str(row["value"])}
+        for row in _rows(connection, "project_metadata")
+    ]
+
+    source_artifacts = _rows(connection, "artifacts")
+    artifacts_by_id = {int(row["id"]): row for row in source_artifacts}
+    artifacts = [
+        {
+            "name": str(row["name"]),
+            "type": str(row["type"]),
+            "description": row.get("description"),
+            "created_at": str(row["created_at"]),
+        }
+        for row in source_artifacts
+    ]
+    source_versions = _rows(connection, "artifact_versions")
+    versions_by_id = {int(row["id"]): row for row in source_versions}
+    artifact_versions = []
+    for row in source_versions:
+        artifact = artifacts_by_id.get(int(row["artifact_id"]))
+        if artifact is None:
+            raise RuntimeError("artifact version references a missing artifact")
+        manifest = _canonical_json(row["manifest"], [])
+        canonical_manifest, manifest_digest, size_bytes = (
+            DorisStorage._canonical_manifest(manifest)
+        )
+        if manifest_digest != str(row["manifest_digest"]):
+            raise RuntimeError(
+                "source artifact version manifest digest is inconsistent"
+            )
+        if size_bytes != int(row["size_bytes"]):
+            raise RuntimeError("source artifact version size is inconsistent")
+        artifact_versions.append(
+            {
+                "artifact_name": str(artifact["name"]),
+                "version": int(row["version"]),
+                "manifest_digest": manifest_digest,
+                "manifest": canonical_manifest,
+                "metadata": _canonical_json(row.get("metadata"), None),
+                "size_bytes": int(row["size_bytes"]),
+                "producer_run_id": row.get("producer_run_id"),
+                "producer_run_name": row.get("producer_run_name"),
+                "created_at": str(row["created_at"]),
+            }
+        )
+    artifact_aliases = []
+    for row in _rows(connection, "artifact_aliases"):
+        artifact = artifacts_by_id.get(int(row["artifact_id"]))
+        version = versions_by_id.get(int(row["artifact_version_id"]))
+        if artifact is None or version is None:
+            raise RuntimeError("artifact alias references missing artifact data")
+        if int(version["artifact_id"]) != int(row["artifact_id"]):
+            raise RuntimeError(
+                "artifact alias references a version from another artifact"
+            )
+        artifact_aliases.append(
+            {
+                "artifact_name": str(artifact["name"]),
+                "alias": str(row["alias"]),
+                "version": int(version["version"]),
+            }
+        )
+    run_artifact_links = []
+    for row in _rows(connection, "run_artifact_links"):
+        version = versions_by_id.get(int(row["artifact_version_id"]))
+        if version is None:
+            raise RuntimeError(
+                "run artifact link references a missing artifact version"
+            )
+        artifact = artifacts_by_id.get(int(version["artifact_id"]))
+        if artifact is None:
+            raise RuntimeError("run artifact link references a missing artifact")
+        run_artifact_links.append(
+            {
+                "run_id": row.get("run_id"),
+                "run_name": row.get("run_name"),
+                "artifact_name": str(artifact["name"]),
+                "version": int(version["version"]),
+                "direction": str(row["direction"]),
+                "created_at": str(row["created_at"]),
+            }
+        )
+    return {
+        "metrics": metrics,
+        "configs": configs,
+        "system_metrics": system_metrics,
+        "traces": traces,
+        "alerts": alerts,
+        "project_metadata": project_metadata,
+        "artifacts": artifacts,
+        "artifact_versions": artifact_versions,
+        "artifact_aliases": artifact_aliases,
+        "run_artifact_links": run_artifact_links,
+    }
+
+
+def _inspect_sqlite_snapshot(
+    snapshot_path: Path,
+    source_path: Path,
+    snapshot_metadata: dict[str, Any],
+) -> dict[str, Any]:
+    connection = sqlite3.connect(
+        f"{snapshot_path.resolve().as_uri()}?mode=ro&immutable=1",
+        uri=True,
+    )
+    connection.row_factory = sqlite3.Row
+    try:
+        tables = _tables(connection)
+        counts = {
+            table: int(
+                connection.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0]
+            )
+            for table in sorted(tables)
+            if not table.startswith("sqlite_")
+        }
+        runs = set()
+        for table in ("metrics", "configs", "system_metrics", "traces", "alerts"):
+            if table not in tables:
+                continue
+            for row in connection.execute(f"SELECT * FROM {table}"):
+                runs.add(
+                    str(row["run_id"] if "run_id" in row.keys() else row["run_name"])
+                )
+        evidence = _records_evidence(_source_records(connection))
+    finally:
+        connection.close()
+    return {
+        "project": source_path.stem,
+        "path": str(source_path),
+        "sha256": snapshot_metadata["snapshot_sha256"],
+        "bytes": snapshot_metadata["snapshot_bytes"],
+        **snapshot_metadata,
+        "tables": counts,
+        "run_count": len(runs),
+        "evidence": evidence,
+    }
+
+
+def inspect_sqlite_project(db_path: Path) -> dict[str, Any]:
+    with _sqlite_snapshot(db_path) as (snapshot, metadata):
+        return _inspect_sqlite_snapshot(snapshot, db_path, metadata)
+
+
+def _migrate_project(
+    db_path: Path,
+    project: str,
+    batch_size: int,
+) -> dict[str, Any]:
+    connection = sqlite3.connect(
+        f"{db_path.resolve().as_uri()}?mode=ro&immutable=1",
+        uri=True,
+    )
+    connection.row_factory = sqlite3.Row
+    migrated: dict[str, int] = defaultdict(int)
+    try:
+        metrics_by_run: dict[tuple[str, str], list[dict[str, Any]]] = defaultdict(list)
+        for row in _rows(connection, "metrics"):
+            run_name = str(row["run_name"])
+            run_id = str(row.get("run_id") or run_name)
+            metrics_by_run[(run_id, run_name)].append(row)
+        for (run_id, run_name), rows in metrics_by_run.items():
+            rows.sort(key=lambda item: (str(item["timestamp"]), int(item["id"])))
+            for start in range(0, len(rows), batch_size):
+                batch = rows[start : start + batch_size]
+                DorisStorage.bulk_log(
+                    project=project,
+                    run=run_name,
+                    run_id=run_id,
+                    metrics_list=[_decode(row["metrics"], {}) for row in batch],
+                    steps=[int(row["step"]) for row in batch],
+                    timestamps=[str(row["timestamp"]) for row in batch],
+                    log_ids=[row.get("log_id") for row in batch],
+                    space_id=None,
+                )
+            migrated["metrics"] += len(rows)
+
+        for row in _rows(connection, "configs"):
+            run_name = str(row["run_name"])
+            DorisStorage.upsert_run_config(
+                project=project,
+                run=run_name,
+                run_id=str(row.get("run_id") or run_name),
+                config=_decode(row["config"], {}),
+                created_at=str(row["created_at"]),
+            )
+            migrated["configs"] += 1
+
+        system_by_run: dict[tuple[str, str], list[dict[str, Any]]] = defaultdict(list)
+        for row in _rows(connection, "system_metrics"):
+            run_name = str(row["run_name"])
+            run_id = str(row.get("run_id") or run_name)
+            system_by_run[(run_id, run_name)].append(row)
+        for (run_id, run_name), rows in system_by_run.items():
+            rows.sort(key=lambda item: (str(item["timestamp"]), int(item["id"])))
+            for start in range(0, len(rows), batch_size):
+                batch = rows[start : start + batch_size]
+                DorisStorage.bulk_log_system(
+                    project=project,
+                    run=run_name,
+                    run_id=run_id,
+                    metrics_list=[_decode(row["metrics"], {}) for row in batch],
+                    timestamps=[str(row["timestamp"]) for row in batch],
+                    log_ids=[row.get("log_id") for row in batch],
+                )
+            migrated["system_metrics"] += len(rows)
+
+        alerts_by_run: dict[tuple[str, str], list[dict[str, Any]]] = defaultdict(list)
+        for row in _rows(connection, "alerts"):
+            run_name = str(row["run_name"])
+            run_id = str(row.get("run_id") or run_name)
+            alerts_by_run[(run_id, run_name)].append(row)
+        for (run_id, run_name), rows in alerts_by_run.items():
+            for start in range(0, len(rows), batch_size):
+                batch = rows[start : start + batch_size]
+                DorisStorage.bulk_alert(
+                    project=project,
+                    run=run_name,
+                    run_id=run_id,
+                    titles=[str(row["title"]) for row in batch],
+                    texts=[row.get("text") for row in batch],
+                    levels=[str(row["level"]) for row in batch],
+                    steps=[row.get("step") for row in batch],
+                    timestamps=[str(row["timestamp"]) for row in batch],
+                    alert_ids=[row.get("alert_id") for row in batch],
+                )
+            migrated["alerts"] += len(rows)
+
+        trace_rows = []
+        for row in _rows(connection, "traces"):
+            trace_rows.append(
+                {
+                    **row,
+                    "messages": _decode(row.get("messages"), []),
+                    "metadata": _decode(row.get("metadata"), {}),
+                    "payload": _decode(row.get("payload"), None),
+                }
+            )
+        for start in range(0, len(trace_rows), batch_size):
+            DorisStorage.import_trace_rows(
+                project, trace_rows[start : start + batch_size]
+            )
+        migrated["traces"] += len(trace_rows)
+
+        for row in _rows(connection, "project_metadata"):
+            DorisStorage.set_project_metadata(
+                project, str(row["key"]), str(row["value"])
+            )
+            migrated["project_metadata"] += 1
+
+        artifacts = _rows(connection, "artifacts")
+        versions = _rows(connection, "artifact_versions")
+        aliases = _rows(connection, "artifact_aliases")
+        links = _rows(connection, "run_artifact_links")
+        for version in versions:
+            version["manifest"] = _decode(version["manifest"], [])
+            version["metadata"] = _decode(version.get("metadata"), None)
+        DorisStorage.import_artifact_graph(
+            project,
+            artifacts=artifacts,
+            versions=versions,
+            aliases=aliases,
+            links=links,
+        )
+        migrated["artifacts"] += len(artifacts)
+        migrated["artifact_versions"] += len(versions)
+        migrated["artifact_aliases"] += len(aliases)
+        migrated["run_artifact_links"] += len(links)
+    finally:
+        connection.close()
+    return dict(migrated)
+
+
+def _target_records(
+    cursor: Any,
+    project: str,
+) -> dict[str, list[dict[str, Any]]]:
+    def rows(table: str) -> list[dict[str, Any]]:
+        cursor.execute(f"SELECT * FROM {table} WHERE project_id = %s", (project,))
+        return list(cursor.fetchall())
+
+    metrics = [
+        {
+            "run_id": str(row["run_id"]),
+            "timestamp": str(row["timestamp"]),
+            "run_name": str(row["run_name"]),
+            "step": int(row["step"]),
+            "metrics": _canonical_json(row["metrics"], {}),
+            "log_id": row.get("log_id"),
+            "space_id": row.get("space_id"),
+        }
+        for row in rows("metrics")
+    ]
+    configs = [
+        {
+            "run_id": str(row["run_id"]),
+            "run_name": str(row["run_name"]),
+            "config": _canonical_json(row["config"], {}),
+            "created_at": str(row["created_at"]),
+        }
+        for row in rows("configs")
+    ]
+    system_metrics = [
+        {
+            "run_id": str(row["run_id"]),
+            "timestamp": str(row["timestamp"]),
+            "run_name": str(row["run_name"]),
+            "metrics": _canonical_json(row["metrics"], {}),
+            "log_id": row.get("log_id"),
+            "space_id": row.get("space_id"),
+        }
+        for row in rows("system_metrics")
+    ]
+    traces = [
+        {
+            "trace_id": str(row["trace_id"]),
+            "run_id": str(row["run_id"]),
+            "timestamp": str(row["timestamp"]),
+            "run_name": str(row["run_name"]),
+            "step": int(row["step"]),
+            "metric_key": str(row["metric_key"]),
+            "trace_index": row.get("trace_index"),
+            "messages": _canonical_json(row["messages"], []),
+            "metadata": _canonical_json(row["metadata"], {}),
+            "search_text": str(row.get("search_text") or ""),
+            "log_id": row.get("log_id"),
+            "space_id": row.get("space_id"),
+            "trace_type": str(row.get("trace_type") or "trackio"),
+            "external_id": row.get("external_id"),
+            "schema_version": row.get("schema_version"),
+            "payload": _canonical_json(row.get("payload"), None),
+        }
+        for row in rows("traces")
+    ]
+    alerts = [
+        {
+            "run_id": str(row["run_id"]),
+            "timestamp": str(row["timestamp"]),
+            "run_name": str(row["run_name"]),
+            "title": str(row["title"]),
+            "text": row.get("text"),
+            "level": str(row["level"]),
+            "step": row.get("step"),
+            "alert_id": row.get("alert_id"),
+        }
+        for row in rows("alerts")
+    ]
+    project_metadata = [
+        {
+            "key": str(row["metadata_key"]),
+            "value": str(row["metadata_value"]),
+        }
+        for row in rows("project_metadata")
+    ]
+
+    target_artifacts = rows("artifacts")
+    artifacts_by_id = {int(row["artifact_id"]): row for row in target_artifacts}
+    artifacts = [
+        {
+            "name": str(row["name"]),
+            "type": str(row["artifact_type"]),
+            "description": row.get("description"),
+            "created_at": str(row["created_at"]),
+        }
+        for row in target_artifacts
+    ]
+    target_versions = rows("artifact_versions")
+    versions_by_id = {int(row["version_id"]): row for row in target_versions}
+    artifact_versions = []
+    for row in target_versions:
+        artifact = artifacts_by_id.get(int(row["artifact_id"]))
+        if artifact is None:
+            raise RuntimeError("Doris artifact version references a missing artifact")
+        manifest = _canonical_json(row["manifest"], [])
+        canonical_manifest, manifest_digest, size_bytes = (
+            DorisStorage._canonical_manifest(manifest)
+        )
+        if manifest_digest != str(row["manifest_digest"]):
+            raise RuntimeError("Doris artifact version manifest digest is inconsistent")
+        if size_bytes != int(row["size_bytes"]):
+            raise RuntimeError("Doris artifact version size is inconsistent")
+        artifact_versions.append(
+            {
+                "artifact_name": str(artifact["name"]),
+                "version": int(row["version_number"]),
+                "manifest_digest": manifest_digest,
+                "manifest": canonical_manifest,
+                "metadata": _canonical_json(row.get("metadata"), None),
+                "size_bytes": int(row["size_bytes"]),
+                "producer_run_id": row.get("producer_run_id"),
+                "producer_run_name": row.get("producer_run_name"),
+                "created_at": str(row["created_at"]),
+            }
+        )
+    artifact_aliases = []
+    for row in rows("artifact_aliases"):
+        artifact = artifacts_by_id.get(int(row["artifact_id"]))
+        version = versions_by_id.get(int(row["version_id"]))
+        if artifact is None or version is None:
+            raise RuntimeError("Doris artifact alias references missing artifact data")
+        if int(version["artifact_id"]) != int(row["artifact_id"]):
+            raise RuntimeError(
+                "Doris artifact alias references a version from another artifact"
+            )
+        if int(version["version_number"]) != int(row["version_number"]):
+            raise RuntimeError("Doris artifact alias version metadata is inconsistent")
+        artifact_aliases.append(
+            {
+                "artifact_name": str(artifact["name"]),
+                "alias": str(row["alias"]),
+                "version": int(version["version_number"]),
+            }
+        )
+    run_artifact_links = []
+    for row in rows("run_artifact_links"):
+        version = versions_by_id.get(int(row["version_id"]))
+        if version is None:
+            raise RuntimeError(
+                "Doris run artifact link references a missing artifact version"
+            )
+        artifact = artifacts_by_id.get(int(version["artifact_id"]))
+        if artifact is None:
+            raise RuntimeError("Doris run artifact link references a missing artifact")
+        run_artifact_links.append(
+            {
+                "run_id": row.get("run_id"),
+                "run_name": row.get("run_name"),
+                "artifact_name": str(artifact["name"]),
+                "version": int(version["version_number"]),
+                "direction": str(row["direction"]),
+                "created_at": str(row["created_at"]),
+            }
+        )
+    return {
+        "metrics": metrics,
+        "configs": configs,
+        "system_metrics": system_metrics,
+        "traces": traces,
+        "alerts": alerts,
+        "project_metadata": project_metadata,
+        "artifacts": artifacts,
+        "artifact_versions": artifact_versions,
+        "artifact_aliases": artifact_aliases,
+        "run_artifact_links": run_artifact_links,
+    }
+
+
+def _target_evidence(project: str) -> dict[str, dict[str, Any]]:
+    # Verification is deliberately non-initializing: a missing database or
+    # schema is a failed verification, not permission to create remote state.
+    with (
+        DorisStorage._connection(initialize=False) as connection,
+        connection.cursor() as cursor,
+    ):
+        return _records_evidence(_target_records(cursor, project))
+
+
+def migrate_sqlite_to_doris(
+    source: Path,
+    receipt_path: Path,
+    *,
+    dry_run: bool = False,
+    verify_only: bool = False,
+    projects: tuple[str, ...] = (),
+    batch_size: int = 500,
+) -> dict[str, Any]:
+    if batch_size < 1:
+        raise ValueError("batch_size must be positive")
+    candidates = (
+        [source]
+        if source.is_file()
+        else sorted(path for path in source.glob("*.db") if path.is_file())
+    )
+    if projects:
+        selected = set(projects)
+        candidates = [path for path in candidates if path.stem in selected]
+        missing = selected - {path.stem for path in candidates}
+        if missing:
+            raise FileNotFoundError(
+                f"Trackio project database not found: {', '.join(sorted(missing))}"
+            )
+    if not candidates:
+        raise FileNotFoundError(f"No Trackio project databases found under {source}")
+
+    results = []
+    for db_path in candidates:
+        with _sqlite_snapshot(db_path) as (snapshot, metadata):
+            source_info = _inspect_sqlite_snapshot(snapshot, db_path, metadata)
+            migrated = {}
+            if not dry_run and not verify_only:
+                DorisStorage.initialize()
+                migrated = _migrate_project(snapshot, db_path.stem, batch_size)
+            target = {} if dry_run else _target_evidence(db_path.stem)
+            expected = source_info["evidence"]
+            mismatches = {
+                table: {
+                    "source": expected[table],
+                    "target": target.get(table),
+                }
+                for table in AUTHORITATIVE_TABLES
+                if not dry_run and expected[table] != target.get(table)
+            }
+            results.append(
+                {
+                    "source": source_info,
+                    "migrated": migrated,
+                    "target_evidence": target,
+                    "mismatches": mismatches,
+                    "verified": not dry_run and not mismatches,
+                }
+            )
+
+    receipt = {
+        "schema_version": 1,
+        "kind": "trackio-sqlite-to-doris",
+        "created_at": datetime.now(UTC).isoformat(),
+        "dry_run": dry_run,
+        "verify_only": verify_only,
+        "batch_size": batch_size,
+        "projects": results,
+        "verified": not dry_run and all(result["verified"] for result in results),
+    }
+    receipt_path.parent.mkdir(parents=True, exist_ok=True)
+    receipt_path.write_text(json.dumps(receipt, indent=2, sort_keys=True) + "\n")
+    if not dry_run and not receipt["verified"]:
+        raise RuntimeError(
+            f"Doris migration reconciliation failed; inspect {receipt_path}"
+        )
+    return receipt
+
+
+__all__ = ["inspect_sqlite_project", "migrate_sqlite_to_doris"]

--- a/trackio/doris_schema.py
+++ b/trackio/doris_schema.py
@@ -1,0 +1,224 @@
+"""Versioned Apache Doris schema for Trackio's logical evidence store."""
+
+from __future__ import annotations
+
+SCHEMA_VERSION = 1
+MANAGED_TABLES = (
+    "schema_versions",
+    "metrics",
+    "configs",
+    "system_metrics",
+    "traces",
+    "alerts",
+    "project_metadata",
+    "artifacts",
+    "artifact_versions",
+    "artifact_aliases",
+    "run_artifact_links",
+)
+
+
+def negotiate_schema(
+    tables: set[str],
+    recorded_version: int | None,
+) -> str:
+    """Return ``bootstrap`` or ``ready`` without changing Doris.
+
+    A partially-created or unversioned Trackio schema is never repaired
+    implicitly. That makes a failed bootstrap visible instead of allowing a
+    later process to silently claim that incomplete tables are current.
+    """
+
+    managed = tables.intersection(MANAGED_TABLES)
+    if not managed:
+        return "bootstrap"
+    if "schema_versions" not in managed or recorded_version is None:
+        raise RuntimeError(
+            "Apache Doris contains an unversioned partial Trackio schema; "
+            "recover or remove it before startup"
+        )
+    if recorded_version > SCHEMA_VERSION:
+        raise RuntimeError(
+            "Apache Doris Trackio schema is newer than this Trackio runtime "
+            f"({recorded_version} > {SCHEMA_VERSION})"
+        )
+    if recorded_version < SCHEMA_VERSION:
+        raise RuntimeError(
+            "Apache Doris Trackio schema requires an explicit migration "
+            f"({recorded_version} < {SCHEMA_VERSION})"
+        )
+    missing = set(MANAGED_TABLES).difference(tables)
+    if missing:
+        raise RuntimeError(
+            "Apache Doris Trackio schema is incomplete at version "
+            f"{recorded_version}; missing: {', '.join(sorted(missing))}"
+        )
+    return "ready"
+
+
+def schema_statements(replication_num: int = 1) -> tuple[str, ...]:
+    properties = f'PROPERTIES ("replication_num" = "{replication_num}")'
+    return (
+        f"""
+        CREATE TABLE IF NOT EXISTS schema_versions (
+            component VARCHAR(64) NOT NULL,
+            version INT NOT NULL,
+            applied_at VARCHAR(64) NOT NULL
+        )
+        UNIQUE KEY(component)
+        DISTRIBUTED BY HASH(component) BUCKETS 1
+        {properties}
+        """,
+        f"""
+        CREATE TABLE IF NOT EXISTS metrics (
+            project_id VARCHAR(255) NOT NULL,
+            event_id VARCHAR(64) NOT NULL,
+            run_id VARCHAR(255) NOT NULL,
+            timestamp VARCHAR(64) NOT NULL,
+            run_name VARCHAR(255) NOT NULL,
+            step BIGINT NOT NULL,
+            metrics STRING NOT NULL,
+            log_id VARCHAR(255) NULL,
+            space_id VARCHAR(255) NULL
+        )
+        UNIQUE KEY(project_id, event_id)
+        DISTRIBUTED BY HASH(project_id, event_id) BUCKETS 1
+        {properties}
+        """,
+        f"""
+        CREATE TABLE IF NOT EXISTS configs (
+            project_id VARCHAR(255) NOT NULL,
+            run_id VARCHAR(255) NOT NULL,
+            run_name VARCHAR(255) NOT NULL,
+            config STRING NOT NULL,
+            created_at VARCHAR(64) NOT NULL
+        )
+        UNIQUE KEY(project_id, run_id)
+        DISTRIBUTED BY HASH(project_id, run_id) BUCKETS 1
+        {properties}
+        """,
+        f"""
+        CREATE TABLE IF NOT EXISTS system_metrics (
+            project_id VARCHAR(255) NOT NULL,
+            event_id VARCHAR(64) NOT NULL,
+            run_id VARCHAR(255) NOT NULL,
+            timestamp VARCHAR(64) NOT NULL,
+            run_name VARCHAR(255) NOT NULL,
+            metrics STRING NOT NULL,
+            log_id VARCHAR(255) NULL,
+            space_id VARCHAR(255) NULL
+        )
+        UNIQUE KEY(project_id, event_id)
+        DISTRIBUTED BY HASH(project_id, event_id) BUCKETS 1
+        {properties}
+        """,
+        f"""
+        CREATE TABLE IF NOT EXISTS traces (
+            project_id VARCHAR(255) NOT NULL,
+            trace_id VARCHAR(768) NOT NULL,
+            run_id VARCHAR(255) NOT NULL,
+            timestamp VARCHAR(64) NOT NULL,
+            run_name VARCHAR(255) NOT NULL,
+            step BIGINT NOT NULL,
+            metric_key VARCHAR(512) NOT NULL,
+            trace_index INT NULL,
+            messages STRING NOT NULL,
+            metadata STRING NOT NULL,
+            search_text STRING NOT NULL,
+            log_id VARCHAR(255) NULL,
+            space_id VARCHAR(255) NULL,
+            trace_type VARCHAR(64) NOT NULL,
+            external_id VARCHAR(768) NULL,
+            schema_version INT NULL,
+            payload STRING NULL
+        )
+        UNIQUE KEY(project_id, trace_id)
+        DISTRIBUTED BY HASH(project_id, trace_id) BUCKETS 1
+        {properties}
+        """,
+        f"""
+        CREATE TABLE IF NOT EXISTS alerts (
+            project_id VARCHAR(255) NOT NULL,
+            event_id VARCHAR(64) NOT NULL,
+            run_id VARCHAR(255) NOT NULL,
+            timestamp VARCHAR(64) NOT NULL,
+            run_name VARCHAR(255) NOT NULL,
+            title STRING NOT NULL,
+            text STRING NULL,
+            level VARCHAR(32) NOT NULL,
+            step BIGINT NULL,
+            alert_id VARCHAR(255) NULL
+        )
+        UNIQUE KEY(project_id, event_id)
+        DISTRIBUTED BY HASH(project_id, event_id) BUCKETS 1
+        {properties}
+        """,
+        f"""
+        CREATE TABLE IF NOT EXISTS project_metadata (
+            project_id VARCHAR(255) NOT NULL,
+            metadata_key VARCHAR(255) NOT NULL,
+            metadata_value STRING NOT NULL
+        )
+        UNIQUE KEY(project_id, metadata_key)
+        DISTRIBUTED BY HASH(project_id, metadata_key) BUCKETS 1
+        {properties}
+        """,
+        f"""
+        CREATE TABLE IF NOT EXISTS artifacts (
+            project_id VARCHAR(255) NOT NULL,
+            artifact_id BIGINT NOT NULL,
+            name VARCHAR(512) NOT NULL,
+            artifact_type VARCHAR(255) NOT NULL,
+            description STRING NULL,
+            created_at VARCHAR(64) NOT NULL
+        )
+        UNIQUE KEY(project_id, artifact_id)
+        DISTRIBUTED BY HASH(project_id, artifact_id) BUCKETS 1
+        {properties}
+        """,
+        f"""
+        CREATE TABLE IF NOT EXISTS artifact_versions (
+            project_id VARCHAR(255) NOT NULL,
+            version_id BIGINT NOT NULL,
+            artifact_id BIGINT NOT NULL,
+            version_number BIGINT NOT NULL,
+            manifest_digest VARCHAR(64) NOT NULL,
+            manifest STRING NOT NULL,
+            metadata STRING NULL,
+            size_bytes BIGINT NOT NULL,
+            producer_run_id VARCHAR(255) NULL,
+            producer_run_name VARCHAR(255) NULL,
+            created_at VARCHAR(64) NOT NULL
+        )
+        UNIQUE KEY(project_id, version_id)
+        DISTRIBUTED BY HASH(project_id, version_id) BUCKETS 1
+        {properties}
+        """,
+        f"""
+        CREATE TABLE IF NOT EXISTS artifact_aliases (
+            project_id VARCHAR(255) NOT NULL,
+            artifact_id BIGINT NOT NULL,
+            alias VARCHAR(255) NOT NULL,
+            version_id BIGINT NOT NULL,
+            version_number BIGINT NOT NULL,
+            updated_at VARCHAR(64) NOT NULL
+        )
+        UNIQUE KEY(project_id, artifact_id, alias)
+        DISTRIBUTED BY HASH(project_id, artifact_id) BUCKETS 1
+        {properties}
+        """,
+        f"""
+        CREATE TABLE IF NOT EXISTS run_artifact_links (
+            project_id VARCHAR(255) NOT NULL,
+            link_id BIGINT NOT NULL,
+            run_id VARCHAR(255) NULL,
+            run_name VARCHAR(255) NULL,
+            version_id BIGINT NOT NULL,
+            direction VARCHAR(16) NOT NULL,
+            created_at VARCHAR(64) NOT NULL
+        )
+        UNIQUE KEY(project_id, link_id)
+        DISTRIBUTED BY HASH(project_id, link_id) BUCKETS 1
+        {properties}
+        """,
+    )

--- a/trackio/doris_storage.py
+++ b/trackio/doris_storage.py
@@ -16,6 +16,7 @@ from pymysql.cursors import DictCursor
 
 import trackio.cas as cas
 import trackio.references as references
+from trackio.lifecycle import lifecycle_row
 from trackio.doris_schema import (
     MANAGED_TABLES,
     SCHEMA_VERSION,
@@ -1208,6 +1209,33 @@ class DorisStorage:
             return {
                 str(row["run_id"]): int(row["max_step"]) for row in cursor.fetchall()
             }
+
+    @classmethod
+    def get_run_lifecycles(cls, project: str) -> dict[str, dict]:
+        """Return the latest lifecycle row for every run in `project`.
+
+    Lifecycle values are logged as ordinary metric rows, so describing a run
+    otherwise costs a request per run and a listing costs one per run in the
+    project. This answers for every run at once, which is what makes listing a
+    project cost the same whether it holds one run or a thousand.
+    """
+        lifecycles: dict[str, dict] = {}
+        with cls._connection() as connection, connection.cursor() as cursor:
+            cursor.execute(
+                """
+                SELECT run_id, timestamp, metrics FROM metrics
+                WHERE project_id = %s AND metrics LIKE %s
+                ORDER BY timestamp, event_id
+                """,
+                (project, "%run/status%"),
+            )
+            for row in cursor.fetchall():
+                values = _decode(row["metrics"])
+                if not isinstance(values, dict) or "run/status" not in values:
+                    continue
+                # Ordered oldest first, so the last row seen for a run wins.
+                lifecycles[str(row["run_id"])] = lifecycle_row(values)
+        return lifecycles
 
     @classmethod
     def get_alerts(

--- a/trackio/doris_storage.py
+++ b/trackio/doris_storage.py
@@ -1,0 +1,2099 @@
+"""Native Apache Doris persistence for a self-hosted Trackio server."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import re
+import threading
+from contextlib import contextmanager
+from datetime import datetime, timedelta, timezone
+from typing import Any, Iterator
+
+import orjson
+import pymysql
+from pymysql.cursors import DictCursor
+
+import trackio.cas as cas
+import trackio.references as references
+from trackio.doris_schema import (
+    MANAGED_TABLES,
+    SCHEMA_VERSION,
+    negotiate_schema,
+    schema_statements,
+)
+from trackio.dummy_commit_scheduler import DummyCommitScheduler
+from trackio.sqlite_storage import SQLiteStorage
+from trackio.utils import deserialize_values, serialize_values
+
+_DATABASE_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]{0,63}$")
+
+
+def _required_env(name: str) -> str:
+    value = os.environ.get(name, "").strip()
+    if not value:
+        raise RuntimeError(f"{name} is required when TRACKIO_DATABASE_ENGINE=doris")
+    return value
+
+
+def _json(value: Any) -> str:
+    return orjson.dumps(serialize_values(value)).decode("utf-8")
+
+
+def _decode(value: str | bytes) -> Any:
+    return deserialize_values(orjson.loads(value))
+
+
+def _event_id(
+    project: str,
+    run_id: str,
+    timestamp: str,
+    discriminator: str,
+    explicit_id: str | None,
+) -> str:
+    if explicit_id:
+        return hashlib.sha256(
+            f"{project}\0{run_id}\0{explicit_id}".encode()
+        ).hexdigest()
+    return hashlib.sha256(
+        f"{project}\0{run_id}\0{timestamp}\0{discriminator}".encode()
+    ).hexdigest()
+
+
+class DorisStorage:
+    """Logical Trackio storage operations backed by Apache Doris.
+
+    The class preserves the static-call shape of ``SQLiteStorage`` while the
+    server migrates to an explicit provider object.
+    """
+
+    _schema_lock = threading.Lock()
+    _artifact_lock = threading.Lock()
+    _schema_ready = False
+    _schema_target: tuple[str, int, str, str] | None = None
+    _dataset_import_attempted = True
+
+    @classmethod
+    def _settings(cls) -> dict[str, Any]:
+        database = _required_env("TRACKIO_DORIS_DATABASE")
+        if not _DATABASE_RE.fullmatch(database):
+            raise RuntimeError("TRACKIO_DORIS_DATABASE must be a simple SQL identifier")
+        port_text = os.environ.get("TRACKIO_DORIS_PORT", "9030").strip()
+        try:
+            port = int(port_text)
+        except ValueError as error:
+            raise RuntimeError("TRACKIO_DORIS_PORT must be an integer") from error
+        settings: dict[str, Any] = {
+            "host": _required_env("TRACKIO_DORIS_HOST"),
+            "port": port,
+            "user": _required_env("TRACKIO_DORIS_USER"),
+            "password": os.environ.get("TRACKIO_DORIS_PASSWORD", ""),
+            "database": database,
+            "connect_timeout": int(
+                os.environ.get("TRACKIO_DORIS_CONNECT_TIMEOUT", "10")
+            ),
+            "read_timeout": int(os.environ.get("TRACKIO_DORIS_READ_TIMEOUT", "30")),
+            "write_timeout": int(os.environ.get("TRACKIO_DORIS_WRITE_TIMEOUT", "30")),
+            "autocommit": True,
+            "cursorclass": DictCursor,
+            "charset": "utf8mb4",
+        }
+        ca = os.environ.get("TRACKIO_DORIS_SSL_CA", "").strip()
+        if ca:
+            settings["ssl"] = {"ca": ca}
+        return settings
+
+    @classmethod
+    @contextmanager
+    def _connection(
+        cls, *, initialize: bool = True, include_database: bool = True
+    ) -> Iterator[pymysql.Connection]:
+        if initialize:
+            cls._ensure_schema()
+        settings = cls._settings()
+        if not include_database:
+            settings.pop("database")
+        connection = pymysql.connect(**settings)
+        try:
+            yield connection
+        finally:
+            connection.close()
+
+    @classmethod
+    def _ensure_schema(cls) -> None:
+        settings = cls._settings()
+        target = (
+            str(settings["host"]),
+            int(settings["port"]),
+            str(settings["database"]),
+            str(settings["user"]),
+        )
+        if cls._schema_ready and cls._schema_target == target:
+            return
+        with cls._schema_lock:
+            if cls._schema_ready and cls._schema_target == target:
+                return
+            database = settings.pop("database")
+            connection = pymysql.connect(**settings)
+            try:
+                with connection.cursor() as cursor:
+                    cursor.execute(
+                        """
+                        SELECT TABLE_NAME AS table_name
+                        FROM information_schema.tables
+                        WHERE table_schema = %s
+                        """,
+                        (database,),
+                    )
+                    tables = {
+                        str(row["table_name"])
+                        for row in cursor.fetchall()
+                        if str(row["table_name"]) in MANAGED_TABLES
+                    }
+                    recorded_version = None
+                    if "schema_versions" in tables:
+                        cursor.execute(f"USE `{database}`")
+                        cursor.execute(
+                            """
+                            SELECT version FROM schema_versions
+                            WHERE component = %s
+                            LIMIT 1
+                            """,
+                            ("trackio",),
+                        )
+                        row = cursor.fetchone()
+                        if row is not None:
+                            recorded_version = int(row["version"])
+                    action = negotiate_schema(tables, recorded_version)
+                    if action == "bootstrap":
+                        cursor.execute(f"CREATE DATABASE IF NOT EXISTS `{database}`")
+                        cursor.execute(f"USE `{database}`")
+                        replication = int(
+                            os.environ.get("TRACKIO_DORIS_REPLICATION_NUM", "1")
+                        )
+                        for statement in schema_statements(replication):
+                            cursor.execute(statement)
+                        cursor.execute(
+                            """
+                            INSERT INTO schema_versions
+                                (component, version, applied_at)
+                            VALUES (%s, %s, %s)
+                            """,
+                            (
+                                "trackio",
+                                SCHEMA_VERSION,
+                                datetime.now(timezone.utc).isoformat(),
+                            ),
+                        )
+                cls._schema_ready = True
+                cls._schema_target = target
+            finally:
+                connection.close()
+
+    @classmethod
+    def initialize(cls) -> None:
+        cls._ensure_schema()
+
+    @staticmethod
+    def validate_project_name(project: str) -> None:
+        if not isinstance(project, str) or not project.strip():
+            raise ValueError("project must be a non-empty string")
+        if len(project) > 255:
+            raise ValueError("project cannot exceed 255 characters")
+
+    @classmethod
+    def _resolve_run_id(
+        cls,
+        cursor: DictCursor,
+        project: str,
+        run: str | None,
+        run_id: str | None,
+        table: str = "metrics",
+    ) -> str | None:
+        if run_id is not None:
+            return run_id
+        if run is None:
+            return None
+        cursor.execute(
+            f"""
+            SELECT run_id, MIN(timestamp) AS created_at
+            FROM {table}
+            WHERE project_id = %s AND run_name = %s
+            GROUP BY run_id
+            ORDER BY created_at DESC
+            LIMIT 1
+            """,
+            (project, run),
+        )
+        row = cursor.fetchone()
+        if row is not None:
+            return str(row["run_id"])
+        cursor.execute(
+            """
+            SELECT run_id
+            FROM configs
+            WHERE project_id = %s AND run_name = %s
+            ORDER BY created_at DESC
+            LIMIT 1
+            """,
+            (project, run),
+        )
+        row = cursor.fetchone()
+        return str(row["run_id"]) if row is not None else None
+
+    @staticmethod
+    def _run_exists(cursor: DictCursor, project: str, run_id: str) -> bool:
+        cursor.execute(
+            """
+            SELECT 1 AS present FROM (
+                SELECT run_id FROM metrics WHERE project_id = %s
+                UNION ALL
+                SELECT run_id FROM configs WHERE project_id = %s
+                UNION ALL
+                SELECT run_id FROM system_metrics WHERE project_id = %s
+                UNION ALL
+                SELECT run_id FROM traces WHERE project_id = %s
+                UNION ALL
+                SELECT run_id FROM alerts WHERE project_id = %s
+                UNION ALL
+                SELECT run_id FROM run_artifact_links WHERE project_id = %s
+            ) evidence
+            WHERE run_id = %s
+            LIMIT 1
+            """,
+            (project, project, project, project, project, project, run_id),
+        )
+        return cursor.fetchone() is not None
+
+    @staticmethod
+    def _subsample(rows: list[Any], max_points: int | None) -> list[Any]:
+        if max_points is None or max_points < 1 or len(rows) <= max_points:
+            return rows
+        stride = len(rows) / max_points
+        indices = {int(i * stride) for i in range(max_points)}
+        indices.add(len(rows) - 1)
+        return [rows[index] for index in sorted(indices)]
+
+    @staticmethod
+    def _optional_str(value: Any) -> str | None:
+        return None if value is None else str(value)
+
+    @staticmethod
+    def _run_records_from_evidence(
+        metric_rows: list[dict[str, Any]],
+        link_rows: list[dict[str, Any]],
+    ) -> list[dict[str, str | None]]:
+        """Apply the same run-discovery rules as ``SQLiteStorage``.
+
+        Metrics are the run-record authority. Artifact links only introduce
+        artifact-only runs, and legacy name-only links are suppressed when an
+        id-bearing link already identifies the same name.
+        """
+
+        metrics: dict[tuple[str | None, str], str] = {}
+        for row in metric_rows:
+            run_name = DorisStorage._optional_str(row.get("run_name"))
+            if run_name is None:
+                continue
+            key = (DorisStorage._optional_str(row.get("run_id")), run_name)
+            created_at = str(row["created_at"])
+            metrics[key] = min(created_at, metrics.get(key, created_at))
+
+        metric_ids = {run_id for run_id, _ in metrics if run_id is not None}
+        metric_names = {run_name for _, run_name in metrics}
+        id_bearing_link_names = {
+            str(row["run_name"])
+            for row in link_rows
+            if row.get("run_id") is not None and row.get("run_name") is not None
+        }
+        records = dict(metrics)
+        for row in link_rows:
+            run_name = DorisStorage._optional_str(row.get("run_name"))
+            if run_name is None or run_name in metric_names:
+                continue
+            run_id = DorisStorage._optional_str(row.get("run_id"))
+            if run_id is not None and run_id in metric_ids:
+                continue
+            if run_id is None and run_name in id_bearing_link_names:
+                continue
+            key = (run_id, run_name)
+            created_at = str(row["created_at"])
+            records[key] = min(created_at, records.get(key, created_at))
+
+        result = [
+            {"id": run_id, "name": run_name, "created_at": created_at}
+            for (run_id, run_name), created_at in records.items()
+        ]
+        return sorted(
+            result,
+            key=lambda row: (
+                str(row["created_at"]),
+                str(row["name"]),
+                row["id"] or "",
+            ),
+        )
+
+    @staticmethod
+    def _artifact_link_counts_from_rows(
+        rows: list[dict[str, Any]],
+        records: list[dict[str, str | None]],
+    ) -> list[dict[str, Any]]:
+        """Fold legacy/orphan artifact links into an unambiguous run."""
+
+        record_ids = {record["id"] for record in records if record["id"] is not None}
+        ids_by_name: dict[str, set[str]] = {}
+        for record in records:
+            if record["id"] is not None and record["name"] is not None:
+                ids_by_name.setdefault(record["name"], set()).add(record["id"])
+
+        counts: dict[tuple[str | None, str | None], dict[str, Any]] = {}
+        links_by_key: dict[tuple[str | None, str | None], set[tuple[int, str]]] = {}
+        for row in rows:
+            run_id = DorisStorage._optional_str(row.get("run_id"))
+            run_name = DorisStorage._optional_str(row.get("run_name"))
+            if run_id is None or run_id not in record_ids:
+                owners = ids_by_name.get(run_name or "", set())
+                run_id = next(iter(owners)) if len(owners) == 1 else None
+            key = (run_id, run_name)
+            entry = counts.setdefault(
+                key,
+                {
+                    "run_id": run_id,
+                    "run_name": run_name,
+                    "input": 0,
+                    "output": 0,
+                },
+            )
+            direction = str(row["direction"])
+            if direction not in {"input", "output"}:
+                continue
+            link = (int(row["version_id"]), direction)
+            seen = links_by_key.setdefault(key, set())
+            if link in seen:
+                continue
+            seen.add(link)
+            entry[direction] += 1
+
+        return sorted(
+            counts.values(),
+            key=lambda row: (
+                str(row["run_name"] or ""),
+                str(row["run_id"] or ""),
+            ),
+        )
+
+    @staticmethod
+    def _filter_metric_rows(
+        rows: list[dict[str, Any]],
+        *,
+        step: int | None,
+        around_step: int | None,
+        at_time: str | None,
+        window: int | float | None,
+    ) -> list[dict[str, Any]]:
+        if step is not None:
+            return [row for row in rows if row["step"] == step]
+        if around_step is not None and window is not None:
+            lower, upper = around_step - int(window), around_step + int(window)
+            return [row for row in rows if lower <= row["step"] <= upper]
+        if at_time is None or window is None:
+            return rows
+
+        def parse(value: Any) -> datetime | None:
+            try:
+                parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+            except ValueError:
+                return None
+            if parsed.tzinfo is None:
+                parsed = parsed.replace(tzinfo=timezone.utc)
+            return parsed.astimezone(timezone.utc)
+
+        target = parse(at_time)
+        if target is None:
+            return []
+        radius = timedelta(seconds=int(window))
+        lower, upper = target - radius, target + radius
+        return [
+            row
+            for row in rows
+            if (timestamp := parse(row["timestamp"])) is not None
+            and lower <= timestamp <= upper
+        ]
+
+    @staticmethod
+    def _stable_int(*parts: Any) -> int:
+        payload = "\0".join(str(part) for part in parts).encode()
+        return int(hashlib.sha256(payload).hexdigest()[:15], 16)
+
+    @staticmethod
+    def _canonical_manifest(
+        manifest: list[dict[str, Any]],
+    ) -> tuple[list[dict[str, Any]], str, int]:
+        canonical = []
+        size_bytes = 0
+        for entry in manifest:
+            normalized = {
+                "path": entry["path"],
+                "digest": entry["digest"],
+                "size": int(entry["size"]),
+            }
+            if references.is_reference_entry(entry):
+                normalized["ref"] = entry["ref"]
+            canonical.append(normalized)
+            size_bytes += int(entry["size"])
+        canonical.sort(key=lambda entry: entry["path"])
+        payload = orjson.dumps(canonical, option=orjson.OPT_SORT_KEYS)
+        return canonical, hashlib.sha256(payload).hexdigest(), size_bytes
+
+    @classmethod
+    def log(
+        cls,
+        project: str,
+        run: str,
+        metrics: dict,
+        step: int | None = None,
+        run_id: str | None = None,
+    ) -> None:
+        cls.bulk_log(
+            project=project,
+            run=run,
+            run_id=run_id,
+            metrics_list=[metrics],
+            steps=[step],
+        )
+
+    @classmethod
+    def bulk_log(
+        cls,
+        project: str,
+        run: str,
+        metrics_list: list[dict],
+        steps: list[int | None] | None = None,
+        timestamps: list[str] | None = None,
+        config: dict | None = None,
+        log_ids: list[str | None] | None = None,
+        space_id: str | None = None,
+        run_id: str | None = None,
+    ) -> None:
+        if not metrics_list:
+            return
+        cls.validate_project_name(project)
+        resolved_run_id = run_id or run
+        timestamps = timestamps or [
+            datetime.now(timezone.utc).isoformat() for _ in metrics_list
+        ]
+        if steps is None:
+            steps = list(range(len(metrics_list)))
+        if not (
+            len(metrics_list) == len(steps) == len(timestamps)
+            and (log_ids is None or len(log_ids) == len(metrics_list))
+        ):
+            raise ValueError(
+                "metrics_list, steps, timestamps, and log_ids must have equal length"
+            )
+        with cls._connection() as connection, connection.cursor() as cursor:
+            if any(step is None for step in steps):
+                cursor.execute(
+                    """
+                    SELECT MAX(step) AS max_step FROM metrics
+                    WHERE project_id = %s AND run_id = %s
+                    """,
+                    (project, resolved_run_id),
+                )
+                row = cursor.fetchone()
+                next_step = 0 if row["max_step"] is None else int(row["max_step"]) + 1
+                normalized_steps: list[int] = []
+                for step in steps:
+                    if step is None:
+                        normalized_steps.append(next_step)
+                        next_step += 1
+                    else:
+                        normalized_steps.append(step)
+                steps = normalized_steps
+
+            metric_rows = []
+            trace_rows = []
+            for index, metrics in enumerate(metrics_list):
+                log_id = log_ids[index] if log_ids else None
+                clean_metrics, extracted = SQLiteStorage._split_trace_metrics(
+                    metrics,
+                    run=run,
+                    run_id=resolved_run_id,
+                    step=int(steps[index]),
+                    timestamp=timestamps[index],
+                    log_id=log_id,
+                    space_id=space_id,
+                )
+                trace_rows.extend(extracted)
+                event_id = _event_id(
+                    project,
+                    resolved_run_id,
+                    timestamps[index],
+                    f"{steps[index]}\0{_json(clean_metrics)}",
+                    log_id,
+                )
+                metric_rows.append(
+                    (
+                        project,
+                        event_id,
+                        resolved_run_id,
+                        timestamps[index],
+                        run,
+                        int(steps[index]),
+                        _json(clean_metrics),
+                        log_id,
+                        space_id,
+                    )
+                )
+
+            cursor.executemany(
+                """
+                INSERT INTO metrics
+                    (project_id, event_id, run_id, timestamp, run_name, step,
+                     metrics, log_id, space_id)
+                VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
+                """,
+                metric_rows,
+            )
+            if trace_rows:
+                cursor.executemany(
+                    """
+                    INSERT INTO traces
+                        (project_id, trace_id, run_id, timestamp, run_name, step,
+                         metric_key, trace_index, messages, metadata, search_text,
+                         log_id, space_id, trace_type, external_id, schema_version,
+                         payload)
+                    VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s,
+                            %s, %s, %s, %s, %s, %s)
+                    """,
+                    [
+                        (
+                            project,
+                            row["id"],
+                            row["run_id"],
+                            row["timestamp"],
+                            row["run_name"],
+                            row["step"],
+                            row["key"],
+                            row["trace_index"],
+                            _json(row["messages"]),
+                            _json(row["metadata"]),
+                            row["search_text"],
+                            row["log_id"],
+                            row["space_id"],
+                            row["trace_type"],
+                            row["external_id"],
+                            row["schema_version"],
+                            _json(row["payload"])
+                            if row["payload"] is not None
+                            else None,
+                        )
+                        for row in trace_rows
+                    ],
+                )
+            if config:
+                cursor.execute(
+                    """
+                    INSERT INTO configs
+                        (project_id, run_id, run_name, config, created_at)
+                    VALUES (%s, %s, %s, %s, %s)
+                    """,
+                    (
+                        project,
+                        resolved_run_id,
+                        run,
+                        _json(config),
+                        datetime.now(timezone.utc).isoformat(),
+                    ),
+                )
+
+    @classmethod
+    def bulk_log_system(
+        cls,
+        project: str,
+        run: str,
+        metrics_list: list[dict],
+        timestamps: list[str] | None = None,
+        log_ids: list[str | None] | None = None,
+        space_id: str | None = None,
+        run_id: str | None = None,
+    ) -> None:
+        if not metrics_list:
+            return
+        resolved_run_id = run_id or run
+        timestamps = timestamps or [
+            datetime.now(timezone.utc).isoformat() for _ in metrics_list
+        ]
+        if len(metrics_list) != len(timestamps):
+            raise ValueError("metrics_list and timestamps must have the same length")
+        rows = []
+        for index, metrics in enumerate(metrics_list):
+            log_id = log_ids[index] if log_ids else None
+            rows.append(
+                (
+                    project,
+                    _event_id(
+                        project,
+                        resolved_run_id,
+                        timestamps[index],
+                        _json(metrics),
+                        log_id,
+                    ),
+                    resolved_run_id,
+                    timestamps[index],
+                    run,
+                    _json(metrics),
+                    log_id,
+                    space_id,
+                )
+            )
+        with cls._connection() as connection, connection.cursor() as cursor:
+            cursor.executemany(
+                """
+                INSERT INTO system_metrics
+                    (project_id, event_id, run_id, timestamp, run_name, metrics,
+                     log_id, space_id)
+                VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+                """,
+                rows,
+            )
+
+    @classmethod
+    def upsert_run_config(
+        cls,
+        project: str,
+        run: str,
+        run_id: str,
+        config: dict[str, Any],
+        created_at: str,
+    ) -> None:
+        with cls._connection() as connection, connection.cursor() as cursor:
+            cursor.execute(
+                """
+                INSERT INTO configs
+                    (project_id, run_id, run_name, config, created_at)
+                VALUES (%s, %s, %s, %s, %s)
+                """,
+                (project, run_id, run, _json(config), created_at),
+            )
+
+    @classmethod
+    def import_trace_rows(cls, project: str, rows: list[dict[str, Any]]) -> None:
+        if not rows:
+            return
+        values = []
+        for row in rows:
+            values.append(
+                (
+                    project,
+                    row["id"],
+                    row["run_id"],
+                    row["timestamp"],
+                    row["run_name"],
+                    int(row["step"]),
+                    row["key"],
+                    row.get("trace_index"),
+                    _json(row.get("messages") or []),
+                    _json(row.get("metadata") or {}),
+                    row.get("search_text") or "",
+                    row.get("log_id"),
+                    row.get("space_id"),
+                    row.get("trace_type") or "trackio",
+                    row.get("external_id"),
+                    row.get("schema_version"),
+                    _json(row["payload"]) if row.get("payload") is not None else None,
+                )
+            )
+        with cls._connection() as connection, connection.cursor() as cursor:
+            cursor.executemany(
+                """
+                INSERT INTO traces
+                    (project_id, trace_id, run_id, timestamp, run_name, step,
+                     metric_key, trace_index, messages, metadata, search_text,
+                     log_id, space_id, trace_type, external_id, schema_version,
+                     payload)
+                VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s,
+                        %s, %s, %s, %s, %s, %s)
+                """,
+                values,
+            )
+
+    @classmethod
+    def import_artifact_graph(
+        cls,
+        project: str,
+        *,
+        artifacts: list[dict[str, Any]],
+        versions: list[dict[str, Any]],
+        aliases: list[dict[str, Any]],
+        links: list[dict[str, Any]],
+    ) -> None:
+        """Import retained artifact lineage without changing logical history.
+
+        Source SQLite integer identifiers are translated to deterministic Doris
+        identifiers. Version numbers and lineage timestamps remain the source
+        values so migration reconciliation can compare logical records exactly.
+        """
+
+        artifacts_by_source_id = {
+            int(artifact["id"]): artifact for artifact in artifacts
+        }
+        target_artifact_ids = {
+            source_id: cls._stable_int(project, artifact["name"])
+            for source_id, artifact in artifacts_by_source_id.items()
+        }
+        versions_by_source_id = {int(version["id"]): version for version in versions}
+        target_version_ids: dict[int, int] = {}
+
+        with cls._artifact_lock:
+            with cls._connection() as connection, connection.cursor() as cursor:
+                for source_id, artifact in artifacts_by_source_id.items():
+                    cursor.execute(
+                        """
+                        INSERT INTO artifacts
+                            (project_id, artifact_id, name, artifact_type,
+                             description, created_at)
+                        VALUES (%s, %s, %s, %s, %s, %s)
+                        """,
+                        (
+                            project,
+                            target_artifact_ids[source_id],
+                            artifact["name"],
+                            artifact["type"],
+                            artifact.get("description"),
+                            artifact["created_at"],
+                        ),
+                    )
+
+                for source_version_id, version in sorted(
+                    versions_by_source_id.items(),
+                    key=lambda item: (
+                        int(item[1]["artifact_id"]),
+                        int(item[1]["version"]),
+                    ),
+                ):
+                    source_artifact_id = int(version["artifact_id"])
+                    if source_artifact_id not in target_artifact_ids:
+                        raise RuntimeError(
+                            "artifact version references an unmigrated artifact"
+                        )
+                    canonical, digest, size_bytes = cls._canonical_manifest(
+                        version["manifest"]
+                    )
+                    if digest != str(version["manifest_digest"]):
+                        raise RuntimeError(
+                            "artifact version manifest digest does not match its "
+                            "canonical manifest"
+                        )
+                    if size_bytes != int(version["size_bytes"]):
+                        raise RuntimeError(
+                            "artifact version size does not match its manifest"
+                        )
+                    target_version_id = cls._stable_int(
+                        project,
+                        artifacts_by_source_id[source_artifact_id]["name"],
+                        digest,
+                    )
+                    target_version_ids[source_version_id] = target_version_id
+                    cursor.execute(
+                        """
+                        INSERT INTO artifact_versions
+                            (project_id, version_id, artifact_id, version_number,
+                             manifest_digest, manifest, metadata, size_bytes,
+                             producer_run_id, producer_run_name, created_at)
+                        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                        """,
+                        (
+                            project,
+                            target_version_id,
+                            target_artifact_ids[source_artifact_id],
+                            int(version["version"]),
+                            digest,
+                            _json(canonical),
+                            _json(version["metadata"])
+                            if version.get("metadata") is not None
+                            else None,
+                            size_bytes,
+                            version.get("producer_run_id"),
+                            version.get("producer_run_name"),
+                            version["created_at"],
+                        ),
+                    )
+
+                for alias in aliases:
+                    source_artifact_id = int(alias["artifact_id"])
+                    source_version_id = int(alias["artifact_version_id"])
+                    if (
+                        source_artifact_id not in target_artifact_ids
+                        or source_version_id not in target_version_ids
+                    ):
+                        raise RuntimeError(
+                            "artifact alias references unmigrated artifact data"
+                        )
+                    version = versions_by_source_id[source_version_id]
+                    if int(version["artifact_id"]) != source_artifact_id:
+                        raise RuntimeError(
+                            "artifact alias references a version from another artifact"
+                        )
+                    cursor.execute(
+                        """
+                        INSERT INTO artifact_aliases
+                            (project_id, artifact_id, alias, version_id,
+                             version_number, updated_at)
+                        VALUES (%s, %s, %s, %s, %s, %s)
+                        """,
+                        (
+                            project,
+                            target_artifact_ids[source_artifact_id],
+                            alias["alias"],
+                            target_version_ids[source_version_id],
+                            int(version["version"]),
+                            version["created_at"],
+                        ),
+                    )
+
+                for link in links:
+                    source_version_id = int(link["artifact_version_id"])
+                    if source_version_id not in target_version_ids:
+                        raise RuntimeError(
+                            "run artifact link references an unmigrated artifact version"
+                        )
+                    if link["direction"] not in {"input", "output"}:
+                        raise RuntimeError(
+                            "run artifact link has an unsupported direction"
+                        )
+                    target_version_id = target_version_ids[source_version_id]
+                    link_id = cls._stable_int(
+                        project,
+                        link.get("run_id") or "",
+                        link.get("run_name") or "",
+                        target_version_id,
+                        link["direction"],
+                    )
+                    cursor.execute(
+                        """
+                        INSERT INTO run_artifact_links
+                            (project_id, link_id, run_id, run_name, version_id,
+                             direction, created_at)
+                        VALUES (%s, %s, %s, %s, %s, %s, %s)
+                        """,
+                        (
+                            project,
+                            link_id,
+                            link.get("run_id"),
+                            link.get("run_name"),
+                            target_version_id,
+                            link["direction"],
+                            link["created_at"],
+                        ),
+                    )
+
+    @classmethod
+    def bulk_alert(
+        cls,
+        project: str,
+        run: str,
+        titles: list[str],
+        texts: list[str | None],
+        levels: list[str],
+        steps: list[int | None],
+        timestamps: list[str] | None = None,
+        alert_ids: list[str | None] | None = None,
+        run_id: str | None = None,
+    ) -> None:
+        if not titles:
+            return
+        resolved_run_id = run_id or run
+        timestamps = timestamps or [
+            datetime.now(timezone.utc).isoformat() for _ in titles
+        ]
+        rows = []
+        for index, title in enumerate(titles):
+            alert_id = alert_ids[index] if alert_ids else None
+            rows.append(
+                (
+                    project,
+                    _event_id(
+                        project,
+                        resolved_run_id,
+                        timestamps[index],
+                        f"{title}\0{steps[index]}",
+                        alert_id,
+                    ),
+                    resolved_run_id,
+                    timestamps[index],
+                    run,
+                    title,
+                    texts[index],
+                    levels[index],
+                    steps[index],
+                    alert_id,
+                )
+            )
+        with cls._connection() as connection, connection.cursor() as cursor:
+            cursor.executemany(
+                """
+                INSERT INTO alerts
+                    (project_id, event_id, run_id, timestamp, run_name, title,
+                     text, level, step, alert_id)
+                VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                """,
+                rows,
+            )
+
+    @classmethod
+    def get_projects(cls) -> list[str]:
+        with cls._connection() as connection, connection.cursor() as cursor:
+            cursor.execute(
+                """
+                SELECT project_id FROM (
+                    SELECT project_id FROM metrics
+                    UNION ALL SELECT project_id FROM configs
+                    UNION ALL SELECT project_id FROM system_metrics
+                    UNION ALL SELECT project_id FROM traces
+                    UNION ALL SELECT project_id FROM alerts
+                    UNION ALL SELECT project_id FROM artifacts
+                    UNION ALL SELECT project_id FROM run_artifact_links
+                ) projects
+                GROUP BY project_id
+                ORDER BY project_id
+                """
+            )
+            return [str(row["project_id"]) for row in cursor.fetchall()]
+
+    @classmethod
+    def get_run_records(cls, project: str) -> list[dict[str, str | None]]:
+        with cls._connection() as connection, connection.cursor() as cursor:
+            cursor.execute(
+                """
+                SELECT run_id, run_name, MIN(timestamp) AS created_at
+                FROM metrics WHERE project_id = %s
+                GROUP BY run_id, run_name
+                """,
+                (project,),
+            )
+            metric_rows = list(cursor.fetchall())
+            cursor.execute(
+                """
+                SELECT run_id, run_name, MIN(created_at) AS created_at
+                FROM run_artifact_links WHERE project_id = %s
+                GROUP BY run_id, run_name
+                """,
+                (project,),
+            )
+            link_rows = list(cursor.fetchall())
+        return cls._run_records_from_evidence(metric_rows, link_rows)
+
+    @classmethod
+    def get_runs(cls, project: str) -> list[str]:
+        return [str(record["name"]) for record in cls.get_run_records(project)]
+
+    @classmethod
+    def get_all_run_configs(cls, project: str) -> dict[str, dict]:
+        with cls._connection() as connection, connection.cursor() as cursor:
+            cursor.execute(
+                "SELECT run_id, config FROM configs WHERE project_id = %s",
+                (project,),
+            )
+            return {
+                str(row["run_id"]): _decode(row["config"]) for row in cursor.fetchall()
+            }
+
+    @classmethod
+    def get_run_config(
+        cls, project: str, run: str | None = None, run_id: str | None = None
+    ) -> dict | None:
+        with cls._connection() as connection, connection.cursor() as cursor:
+            resolved = cls._resolve_run_id(cursor, project, run, run_id)
+            if resolved is None:
+                return None
+            cursor.execute(
+                """
+                SELECT config FROM configs
+                WHERE project_id = %s AND run_id = %s
+                LIMIT 1
+                """,
+                (project, resolved),
+            )
+            row = cursor.fetchone()
+            return _decode(row["config"]) if row is not None else None
+
+    @classmethod
+    def get_logs(
+        cls,
+        project: str,
+        run: str | None = None,
+        max_points: int | None = None,
+        run_id: str | None = None,
+        scalar_only: bool = False,
+    ) -> list[dict]:
+        with cls._connection() as connection, connection.cursor() as cursor:
+            resolved = cls._resolve_run_id(cursor, project, run, run_id)
+            if resolved is None:
+                return []
+            cursor.execute(
+                """
+                SELECT timestamp, step, metrics FROM metrics
+                WHERE project_id = %s AND run_id = %s
+                ORDER BY timestamp, event_id
+                """,
+                (project, resolved),
+            )
+            rows = cls._subsample(list(cursor.fetchall()), max_points)
+        result = []
+        for row in rows:
+            metrics = orjson.loads(row["metrics"])
+            if scalar_only:
+                metrics = {
+                    key: value
+                    for key, value in metrics.items()
+                    if isinstance(value, int | float) and not isinstance(value, bool)
+                }
+            else:
+                metrics = deserialize_values(metrics)
+            metrics["timestamp"] = str(row["timestamp"])
+            metrics["step"] = int(row["step"])
+            result.append(metrics)
+        return result
+
+    @classmethod
+    def get_logs_batch(
+        cls,
+        project: str,
+        runs: list[dict[str, Any]] | None = None,
+        max_points: int | None = None,
+        scalar_only: bool = False,
+    ) -> list[dict[str, Any]]:
+        return [
+            {
+                "run": item.get("run"),
+                "run_id": item.get("run_id"),
+                "logs": cls.get_logs(
+                    project,
+                    item.get("run"),
+                    run_id=item.get("run_id"),
+                    max_points=max_points,
+                    scalar_only=scalar_only,
+                ),
+            }
+            for item in (runs or [])
+        ]
+
+    @classmethod
+    def get_system_logs(
+        cls,
+        project: str,
+        run: str | None = None,
+        run_id: str | None = None,
+        max_points: int | None = None,
+    ) -> list[dict]:
+        with cls._connection() as connection, connection.cursor() as cursor:
+            resolved = cls._resolve_run_id(
+                cursor, project, run, run_id, table="system_metrics"
+            )
+            if resolved is None:
+                return []
+            cursor.execute(
+                """
+                SELECT timestamp, metrics FROM system_metrics
+                WHERE project_id = %s AND run_id = %s
+                ORDER BY timestamp, event_id
+                """,
+                (project, resolved),
+            )
+            rows = cls._subsample(list(cursor.fetchall()), max_points)
+        result = []
+        for row in rows:
+            metrics = _decode(row["metrics"])
+            metrics["timestamp"] = str(row["timestamp"])
+            result.append(metrics)
+        return result
+
+    @classmethod
+    def get_system_logs_batch(
+        cls,
+        project: str,
+        runs: list[dict[str, Any]] | None = None,
+        max_points: int | None = None,
+    ) -> list[dict[str, Any]]:
+        return [
+            {
+                "run": item.get("run"),
+                "run_id": item.get("run_id"),
+                "logs": cls.get_system_logs(
+                    project,
+                    item.get("run"),
+                    run_id=item.get("run_id"),
+                    max_points=max_points,
+                ),
+            }
+            for item in (runs or [])
+        ]
+
+    @classmethod
+    def _metric_names(
+        cls,
+        project: str,
+        run: str | None,
+        run_id: str | None,
+        table: str,
+    ) -> list[str]:
+        logs = (
+            cls.get_logs(project, run, run_id=run_id)
+            if table == "metrics"
+            else cls.get_system_logs(project, run, run_id=run_id)
+        )
+        ignored = {"timestamp", "step"}
+        return sorted({key for log in logs for key in log if key not in ignored})
+
+    @classmethod
+    def get_all_metrics_for_run(
+        cls, project: str, run: str | None = None, run_id: str | None = None
+    ) -> list[str]:
+        return cls._metric_names(project, run, run_id, "metrics")
+
+    @classmethod
+    def get_all_system_metrics_for_run(
+        cls, project: str, run: str | None = None, run_id: str | None = None
+    ) -> list[str]:
+        return cls._metric_names(project, run, run_id, "system_metrics")
+
+    @classmethod
+    def get_log_count(
+        cls, project: str, run: str | None = None, run_id: str | None = None
+    ) -> int:
+        with cls._connection() as connection, connection.cursor() as cursor:
+            resolved = cls._resolve_run_id(cursor, project, run, run_id)
+            if resolved is None:
+                return 0
+            cursor.execute(
+                """
+                SELECT COUNT(*) AS count FROM metrics
+                WHERE project_id = %s AND run_id = %s
+                """,
+                (project, resolved),
+            )
+            return int(cursor.fetchone()["count"])
+
+    @classmethod
+    def get_last_step(
+        cls, project: str, run: str | None = None, run_id: str | None = None
+    ) -> int | None:
+        with cls._connection() as connection, connection.cursor() as cursor:
+            resolved = cls._resolve_run_id(cursor, project, run, run_id)
+            if resolved is None:
+                return None
+            cursor.execute(
+                """
+                SELECT MAX(step) AS max_step FROM metrics
+                WHERE project_id = %s AND run_id = %s
+                """,
+                (project, resolved),
+            )
+            value = cursor.fetchone()["max_step"]
+            return int(value) if value is not None else None
+
+    get_max_step_for_run = get_last_step
+
+    @classmethod
+    def get_max_steps_for_runs(cls, project: str) -> dict[str, int]:
+        with cls._connection() as connection, connection.cursor() as cursor:
+            cursor.execute(
+                """
+                SELECT run_id, MAX(step) AS max_step FROM metrics
+                WHERE project_id = %s GROUP BY run_id
+                """,
+                (project,),
+            )
+            return {
+                str(row["run_id"]): int(row["max_step"]) for row in cursor.fetchall()
+            }
+
+    @classmethod
+    def get_alerts(
+        cls,
+        project: str,
+        run_name: str | None = None,
+        run_id: str | None = None,
+        level: str | None = None,
+        since: str | None = None,
+    ) -> list[dict]:
+        with cls._connection() as connection, connection.cursor() as cursor:
+            conditions = ["project_id = %s"]
+            params: list[Any] = [project]
+            resolved = cls._resolve_run_id(
+                cursor, project, run_name, run_id, table="alerts"
+            )
+            if run_name is not None or run_id is not None:
+                if resolved is None:
+                    return []
+                conditions.append("run_id = %s")
+                params.append(resolved)
+            if level is not None:
+                conditions.append("level = %s")
+                params.append(level)
+            if since is not None:
+                conditions.append("timestamp > %s")
+                params.append(since)
+            cursor.execute(
+                f"""
+                SELECT timestamp, run_name, title, text, level, step
+                FROM alerts WHERE {" AND ".join(conditions)}
+                ORDER BY timestamp DESC, event_id DESC
+                """,
+                params,
+            )
+            return [
+                {
+                    "timestamp": str(row["timestamp"]),
+                    "run": str(row["run_name"]),
+                    "title": row["title"],
+                    "text": row["text"],
+                    "level": str(row["level"]),
+                    "step": row["step"],
+                }
+                for row in cursor.fetchall()
+            ]
+
+    @classmethod
+    def get_traces(
+        cls,
+        project: str,
+        run: str | None = None,
+        search: str | None = None,
+        sort: str | None = None,
+        limit: int | None = None,
+        offset: int = 0,
+        run_id: str | None = None,
+        step: int | None = None,
+        trace_type: str | None = None,
+    ) -> list[dict[str, Any]]:
+        with cls._connection() as connection, connection.cursor() as cursor:
+            resolved = cls._resolve_run_id(cursor, project, run, run_id, table="traces")
+            if resolved is None:
+                return []
+            conditions = ["project_id = %s", "run_id = %s"]
+            params: list[Any] = [project, resolved]
+            if step is not None:
+                conditions.append("step = %s")
+                params.append(step)
+            if trace_type:
+                conditions.append("trace_type = %s")
+                params.append(trace_type)
+            if search and search.strip():
+                conditions.append("LOWER(search_text) LIKE %s")
+                params.append(f"%{search.strip().lower()}%")
+            order = {
+                "step_asc": "step ASC, timestamp ASC, trace_id ASC",
+                "step_desc": "step DESC, timestamp DESC, trace_id DESC",
+                "request_time_asc": "timestamp ASC, trace_id ASC",
+            }.get(sort or "", "timestamp DESC, trace_id DESC")
+            query = f"""
+                SELECT trace_id, metric_key, trace_index, run_name, run_id, step,
+                       timestamp, messages, metadata, trace_type, external_id,
+                       schema_version, payload
+                FROM traces
+                WHERE {" AND ".join(conditions)}
+                ORDER BY {order}
+            """
+            if limit is not None:
+                query += " LIMIT %s"
+                params.append(max(0, int(limit)))
+            elif offset:
+                query += " LIMIT 1000000"
+            if offset:
+                query += " OFFSET %s"
+                params.append(max(0, int(offset)))
+            cursor.execute(query, params)
+            rows = cursor.fetchall()
+        return [
+            {
+                "id": row["trace_id"],
+                "key": row["metric_key"],
+                "index": row["trace_index"],
+                "run": row["run_name"],
+                "run_id": row["run_id"],
+                "step": row["step"],
+                "timestamp": row["timestamp"],
+                "messages": _decode(row["messages"]),
+                "metadata": _decode(row["metadata"]),
+                "trace_type": row["trace_type"],
+                "external_id": row["external_id"],
+                "schema_version": row["schema_version"],
+                "payload": _decode(row["payload"])
+                if row["payload"] is not None
+                else None,
+            }
+            for row in rows
+        ]
+
+    @classmethod
+    def get_trace_steps(
+        cls,
+        project: str,
+        run: str | None = None,
+        run_id: str | None = None,
+        trace_type: str | None = None,
+    ) -> dict[str, Any]:
+        traces = cls.get_traces(
+            project, run, run_id=run_id, trace_type=trace_type, sort="step_asc"
+        )
+        counts: dict[int, int] = {}
+        for trace in traces:
+            counts[int(trace["step"])] = counts.get(int(trace["step"]), 0) + 1
+        steps = [{"step": step, "count": counts[step]} for step in sorted(counts)]
+        return {"total": len(traces), "steps": steps}
+
+    @classmethod
+    def get_tab_availability_flags(cls, project: str) -> dict[str, bool]:
+        with cls._connection() as connection, connection.cursor() as cursor:
+            flags = {}
+            for key, predicate in (
+                ("metrics", "metrics REGEXP ':[[:space:]]*-?[0-9]'"),
+                (
+                    "media",
+                    "("
+                    """metrics LIKE '%"_type":"trackio.image"%' OR """
+                    """metrics LIKE '%"_type":"trackio.video"%' OR """
+                    """metrics LIKE '%"_type":"trackio.audio"%' OR """
+                    """metrics LIKE '%"_type":"trackio.table"%'"""
+                    ")",
+                ),
+                ("reports", """metrics LIKE '%"_type":"trackio.markdown"%'"""),
+            ):
+                cursor.execute(
+                    f"""
+                    SELECT 1 AS present FROM metrics
+                    WHERE project_id = %s AND {predicate} LIMIT 1
+                    """,
+                    (project,),
+                )
+                flags[key] = cursor.fetchone() is not None
+            for key, table, predicate in (
+                ("system", "system_metrics", ""),
+                ("traces", "traces", " AND trace_type = 'trackio'"),
+                ("alerts", "alerts", ""),
+            ):
+                cursor.execute(
+                    f"""
+                    SELECT 1 AS present FROM {table}
+                    WHERE project_id = %s{predicate} LIMIT 1
+                    """,
+                    (project,),
+                )
+                flags[key] = cursor.fetchone() is not None
+            cursor.execute(
+                """
+                SELECT 1 AS present FROM traces
+                WHERE project_id = %s AND trace_type = 'verifiers' LIMIT 1
+                """,
+                (project,),
+            )
+            flags["verifiers_traces"] = cursor.fetchone() is not None
+            cursor.execute(
+                """
+                SELECT 1 AS present FROM artifact_versions
+                WHERE project_id = %s LIMIT 1
+                """,
+                (project,),
+            )
+            flags["artifacts"] = cursor.fetchone() is not None
+        return flags
+
+    @classmethod
+    def set_project_metadata(cls, project: str, key: str, value: str) -> None:
+        with cls._connection() as connection, connection.cursor() as cursor:
+            cursor.execute(
+                """
+                INSERT INTO project_metadata
+                    (project_id, metadata_key, metadata_value)
+                VALUES (%s, %s, %s)
+                """,
+                (project, key, value),
+            )
+
+    @classmethod
+    def get_project_metadata(cls, project: str, key: str) -> str | None:
+        with cls._connection() as connection, connection.cursor() as cursor:
+            cursor.execute(
+                """
+                SELECT metadata_value FROM project_metadata
+                WHERE project_id = %s AND metadata_key = %s LIMIT 1
+                """,
+                (project, key),
+            )
+            row = cursor.fetchone()
+            return str(row["metadata_value"]) if row else None
+
+    @classmethod
+    def get_space_id(cls, project: str) -> str | None:
+        return cls.get_project_metadata(project, "space_id")
+
+    @classmethod
+    def get_metric_values(
+        cls,
+        project: str,
+        run: str | None,
+        metric_name: str,
+        step: int | None = None,
+        around_step: int | None = None,
+        at_time: str | None = None,
+        window: int | float | None = None,
+        run_id: str | None = None,
+    ) -> list[dict]:
+        rows = cls.get_logs(project, run, run_id=run_id)
+        rows = cls._filter_metric_rows(
+            rows,
+            step=step,
+            around_step=around_step,
+            at_time=at_time,
+            window=window,
+        )
+        return [
+            {
+                "timestamp": row["timestamp"],
+                "step": row["step"],
+                "value": row[metric_name],
+            }
+            for row in rows
+            if metric_name in row
+        ]
+
+    @classmethod
+    def get_snapshot(
+        cls,
+        project: str,
+        run: str | None = None,
+        step: int | None = None,
+        around_step: int | None = None,
+        at_time: str | None = None,
+        window: int | float | None = None,
+        run_id: str | None = None,
+    ) -> dict[str, list[dict]]:
+        rows = cls.get_logs(project, run, run_id=run_id)
+        rows = cls._filter_metric_rows(
+            rows,
+            step=step,
+            around_step=around_step,
+            at_time=at_time,
+            window=window,
+        )
+        result: dict[str, list[dict]] = {}
+        for row in rows:
+            for key, value in row.items():
+                if key in {"timestamp", "step"}:
+                    continue
+                result.setdefault(key, []).append(
+                    {
+                        "timestamp": row["timestamp"],
+                        "step": row["step"],
+                        "value": value,
+                    }
+                )
+        return result
+
+    @classmethod
+    def query_project(
+        cls, project: str, query: str, max_rows: int = 10_000
+    ) -> dict[str, Any]:
+        del project, query, max_rows
+        raise ValueError(
+            "query_project is SQLite-specific and is not available with the Doris engine"
+        )
+
+    @classmethod
+    def rename_run(
+        cls,
+        project: str,
+        old_name: str,
+        new_name: str,
+        run_id: str | None = None,
+    ) -> None:
+        normalized = new_name.strip()
+        if not normalized:
+            raise ValueError("new run name must be a non-empty string")
+        with cls._connection() as connection, connection.cursor() as cursor:
+            resolved = cls._resolve_run_id(cursor, project, old_name, run_id)
+            if resolved is None or not cls._run_exists(cursor, project, resolved):
+                raise ValueError(f"Run '{old_name}' does not exist.")
+            cursor.execute(
+                """
+                SELECT 1 AS present FROM metrics
+                WHERE project_id = %s AND run_name = %s AND run_id != %s
+                LIMIT 1
+                """,
+                (project, normalized, resolved),
+            )
+            if cursor.fetchone() is not None:
+                raise ValueError(f"Run '{normalized}' already exists.")
+            for table in (
+                "metrics",
+                "configs",
+                "system_metrics",
+                "traces",
+                "alerts",
+                "run_artifact_links",
+            ):
+                cursor.execute(
+                    f"""
+                    UPDATE {table} SET run_name = %s
+                    WHERE project_id = %s AND run_id = %s
+                    """,
+                    (normalized, project, resolved),
+                )
+            cursor.execute(
+                """
+                UPDATE artifact_versions SET producer_run_name = %s
+                WHERE project_id = %s AND producer_run_id = %s
+                """,
+                (normalized, project, resolved),
+            )
+
+    @classmethod
+    def delete_run(
+        cls,
+        project: str,
+        run: str | None = None,
+        run_id: str | None = None,
+    ) -> bool:
+        with cls._connection() as connection, connection.cursor() as cursor:
+            resolved = cls._resolve_run_id(cursor, project, run, run_id)
+            if resolved is None or not cls._run_exists(cursor, project, resolved):
+                return False
+            cursor.execute(
+                """
+                UPDATE artifact_versions
+                SET producer_run_id = NULL, producer_run_name = NULL
+                WHERE project_id = %s AND producer_run_id = %s
+                """,
+                (project, resolved),
+            )
+            for table in (
+                "metrics",
+                "configs",
+                "system_metrics",
+                "traces",
+                "alerts",
+                "run_artifact_links",
+            ):
+                cursor.execute(
+                    f"DELETE FROM {table} WHERE project_id = %s AND run_id = %s",
+                    (project, resolved),
+                )
+        return True
+
+    @classmethod
+    def _resolve_artifact_version(
+        cls,
+        cursor: DictCursor,
+        project: str,
+        name: str,
+        spec: str | None,
+    ) -> dict[str, Any] | None:
+        cursor.execute(
+            """
+            SELECT artifact_id FROM artifacts
+            WHERE project_id = %s AND name = %s LIMIT 1
+            """,
+            (project, name),
+        )
+        artifact = cursor.fetchone()
+        if artifact is None:
+            return None
+        artifact_id = int(artifact["artifact_id"])
+        resolved_spec = spec or "latest"
+        match = cas.ARTIFACT_VERSION_SPEC_RE.match(resolved_spec)
+        if match:
+            cursor.execute(
+                """
+                SELECT version_id, version_number FROM artifact_versions
+                WHERE project_id = %s AND artifact_id = %s
+                  AND version_number = %s
+                LIMIT 1
+                """,
+                (project, artifact_id, int(match.group(1))),
+            )
+        else:
+            cursor.execute(
+                """
+                SELECT version_id, version_number FROM artifact_aliases
+                WHERE project_id = %s AND artifact_id = %s AND alias = %s
+                LIMIT 1
+                """,
+                (project, artifact_id, resolved_spec),
+            )
+        version = cursor.fetchone()
+        if version is None:
+            return None
+        return {
+            "artifact_id": artifact_id,
+            "version_id": int(version["version_id"]),
+            "version": int(version["version_number"]),
+        }
+
+    @classmethod
+    def commit_artifact_version(
+        cls,
+        project: str,
+        name: str,
+        type: str,
+        description: str | None,
+        manifest: list[dict[str, Any]],
+        metadata: dict | None,
+        aliases: list[str] | None,
+        run_name: str | None,
+        run_id: str | None,
+    ) -> dict:
+        canonical, manifest_digest, size_bytes = cls._canonical_manifest(manifest)
+        now = datetime.now(timezone.utc).isoformat()
+        artifact_id = cls._stable_int(project, name)
+        version_id = cls._stable_int(project, name, manifest_digest)
+        with cls._artifact_lock:
+            with cls._connection() as connection, connection.cursor() as cursor:
+                cursor.execute(
+                    """
+                    SELECT artifact_type FROM artifacts
+                    WHERE project_id = %s AND artifact_id = %s LIMIT 1
+                    """,
+                    (project, artifact_id),
+                )
+                existing_artifact = cursor.fetchone()
+                if (
+                    existing_artifact is not None
+                    and existing_artifact["artifact_type"] != type
+                ):
+                    raise ValueError(
+                        f"Artifact '{name}' already exists with type "
+                        f"'{existing_artifact['artifact_type']}'; cannot relog "
+                        f"with type '{type}'."
+                    )
+                if existing_artifact is None:
+                    cursor.execute(
+                        """
+                        INSERT INTO artifacts
+                            (project_id, artifact_id, name, artifact_type,
+                             description, created_at)
+                        VALUES (%s, %s, %s, %s, %s, %s)
+                        """,
+                        (project, artifact_id, name, type, description, now),
+                    )
+                elif description is not None:
+                    cursor.execute(
+                        """
+                        UPDATE artifacts SET description = %s
+                        WHERE project_id = %s AND artifact_id = %s
+                        """,
+                        (description, project, artifact_id),
+                    )
+                cursor.execute(
+                    """
+                    SELECT version_id, version_number FROM artifact_versions
+                    WHERE project_id = %s AND artifact_id = %s
+                      AND manifest_digest = %s LIMIT 1
+                    """,
+                    (project, artifact_id, manifest_digest),
+                )
+                existing_version = cursor.fetchone()
+                created = existing_version is None
+                if created:
+                    cursor.execute(
+                        """
+                        SELECT MAX(version_number) AS max_version
+                        FROM artifact_versions
+                        WHERE project_id = %s AND artifact_id = %s
+                        """,
+                        (project, artifact_id),
+                    )
+                    maximum = cursor.fetchone()["max_version"]
+                    version_number = 0 if maximum is None else int(maximum) + 1
+                    cursor.execute(
+                        """
+                        INSERT INTO artifact_versions
+                            (project_id, version_id, artifact_id, version_number,
+                             manifest_digest, manifest, metadata, size_bytes,
+                             producer_run_id, producer_run_name, created_at)
+                        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                        """,
+                        (
+                            project,
+                            version_id,
+                            artifact_id,
+                            version_number,
+                            manifest_digest,
+                            _json(canonical),
+                            _json(metadata) if metadata is not None else None,
+                            size_bytes,
+                            run_id,
+                            run_name,
+                            now,
+                        ),
+                    )
+                else:
+                    version_id = int(existing_version["version_id"])
+                    version_number = int(existing_version["version_number"])
+                    if metadata:
+                        cursor.execute(
+                            """
+                            UPDATE artifact_versions SET metadata = %s
+                            WHERE project_id = %s AND version_id = %s
+                            """,
+                            (_json(metadata), project, version_id),
+                        )
+
+                requested_aliases = list(aliases or [])
+                if created:
+                    requested_aliases.append("latest")
+                for alias in requested_aliases:
+                    if cas.ARTIFACT_VERSION_SPEC_RE.match(alias):
+                        raise ValueError(
+                            f"Alias '{alias}' is reserved for version pointers (vN); "
+                            "choose another."
+                        )
+                    cursor.execute(
+                        """
+                        SELECT version_number FROM artifact_aliases
+                        WHERE project_id = %s AND artifact_id = %s AND alias = %s
+                        LIMIT 1
+                        """,
+                        (project, artifact_id, alias),
+                    )
+                    current = cursor.fetchone()
+                    if (
+                        current is not None
+                        and int(current["version_number"]) > version_number
+                    ):
+                        continue
+                    cursor.execute(
+                        """
+                        INSERT INTO artifact_aliases
+                            (project_id, artifact_id, alias, version_id,
+                             version_number, updated_at)
+                        VALUES (%s, %s, %s, %s, %s, %s)
+                        """,
+                        (
+                            project,
+                            artifact_id,
+                            alias,
+                            version_id,
+                            version_number,
+                            now,
+                        ),
+                    )
+                cls._insert_run_artifact_link_with_cursor(
+                    cursor,
+                    project=project,
+                    run_name=run_name,
+                    run_id=run_id,
+                    version_id=version_id,
+                    direction="output",
+                    now=now,
+                )
+        result = cls.get_artifact_manifest(project, name, f"v{version_number}")
+        if result is None:
+            raise RuntimeError("Doris artifact commit was not visible after write")
+        return result
+
+    @classmethod
+    def get_artifact_manifest(
+        cls, project: str, name: str, spec: str | None
+    ) -> dict | None:
+        with cls._connection() as connection, connection.cursor() as cursor:
+            resolved = cls._resolve_artifact_version(cursor, project, name, spec)
+            if resolved is None:
+                return None
+            cursor.execute(
+                """
+                SELECT av.version_id, av.version_number, av.manifest,
+                       av.manifest_digest, av.metadata, av.size_bytes,
+                       av.producer_run_id, av.producer_run_name, av.created_at,
+                       a.name, a.artifact_type, a.description
+                FROM artifact_versions av
+                JOIN artifacts a
+                  ON a.project_id = av.project_id
+                 AND a.artifact_id = av.artifact_id
+                WHERE av.project_id = %s AND av.version_id = %s
+                LIMIT 1
+                """,
+                (project, resolved["version_id"]),
+            )
+            row = cursor.fetchone()
+            if row is None:
+                return None
+            cursor.execute(
+                """
+                SELECT alias FROM artifact_aliases
+                WHERE project_id = %s AND version_id = %s
+                ORDER BY alias
+                """,
+                (project, resolved["version_id"]),
+            )
+            aliases = [str(item["alias"]) for item in cursor.fetchall()]
+            return {
+                "artifact_id": resolved["artifact_id"],
+                "version_id": int(row["version_id"]),
+                "version": int(row["version_number"]),
+                "name": row["name"],
+                "type": row["artifact_type"],
+                "description": row["description"],
+                "manifest": _decode(row["manifest"]),
+                "manifest_digest": row["manifest_digest"],
+                "metadata": _decode(row["metadata"])
+                if row["metadata"] is not None
+                else None,
+                "size_bytes": int(row["size_bytes"]),
+                "producer_run_id": row["producer_run_id"],
+                "producer_run_name": row["producer_run_name"],
+                "created_at": row["created_at"],
+                "aliases": aliases,
+            }
+
+    @classmethod
+    def list_artifacts(cls, project: str) -> list[dict]:
+        with cls._connection() as connection, connection.cursor() as cursor:
+            cursor.execute(
+                """
+                SELECT artifact_id, name, artifact_type, description, created_at
+                FROM artifacts WHERE project_id = %s
+                ORDER BY artifact_type, name
+                """,
+                (project,),
+            )
+            artifacts = cursor.fetchall()
+            cursor.execute(
+                """
+                SELECT version_id, artifact_id, version_number, manifest,
+                       size_bytes, created_at
+                FROM artifact_versions WHERE project_id = %s
+                ORDER BY artifact_id, version_number DESC
+                """,
+                (project,),
+            )
+            versions = cursor.fetchall()
+            cursor.execute(
+                """
+                SELECT alias, version_id FROM artifact_aliases
+                WHERE project_id = %s
+                """,
+                (project,),
+            )
+            aliases = cursor.fetchall()
+        aliases_by_version: dict[int, list[str]] = {}
+        for row in aliases:
+            aliases_by_version.setdefault(int(row["version_id"]), []).append(
+                str(row["alias"])
+            )
+        versions_by_artifact: dict[int, list[dict[str, Any]]] = {}
+        for row in versions:
+            manifest = _decode(row["manifest"])
+            versions_by_artifact.setdefault(int(row["artifact_id"]), []).append(
+                {
+                    "version_id": int(row["version_id"]),
+                    "version": int(row["version_number"]),
+                    "aliases": aliases_by_version.get(int(row["version_id"]), []),
+                    "size_bytes": int(row["size_bytes"]),
+                    "num_files": len(manifest),
+                    "created_at": row["created_at"],
+                }
+            )
+        return [
+            {
+                "name": artifact["name"],
+                "type": artifact["artifact_type"],
+                "description": artifact["description"],
+                "created_at": artifact["created_at"],
+                "num_versions": len(
+                    versions_by_artifact.get(int(artifact["artifact_id"]), [])
+                ),
+                "latest_version": (
+                    versions_by_artifact[int(artifact["artifact_id"])][0]["version"]
+                    if versions_by_artifact.get(int(artifact["artifact_id"]))
+                    else None
+                ),
+                "versions": versions_by_artifact.get(int(artifact["artifact_id"]), []),
+            }
+            for artifact in artifacts
+        ]
+
+    @classmethod
+    def get_artifacts(cls, project: str) -> list[dict]:
+        return [
+            {
+                "name": artifact["name"],
+                "type": artifact["type"],
+                "description": artifact["description"],
+                "num_versions": artifact["num_versions"],
+                "latest_version": artifact["latest_version"],
+                "size_bytes": (
+                    artifact["versions"][0]["size_bytes"]
+                    if artifact["versions"]
+                    else None
+                ),
+                "aliases": sorted(
+                    {
+                        alias
+                        for version in artifact["versions"]
+                        for alias in version["aliases"]
+                    }
+                ),
+                "created_at": artifact["created_at"],
+            }
+            for artifact in cls.list_artifacts(project)
+        ]
+
+    @classmethod
+    def _insert_run_artifact_link_with_cursor(
+        cls,
+        cursor: DictCursor,
+        *,
+        project: str,
+        run_name: str | None,
+        run_id: str | None,
+        version_id: int,
+        direction: str,
+        now: str,
+    ) -> None:
+        if direction not in {"input", "output"}:
+            raise ValueError(
+                f"direction must be 'input' or 'output', got {direction!r}"
+            )
+        link_id = cls._stable_int(
+            project, run_id or "", run_name or "", version_id, direction
+        )
+        cursor.execute(
+            """
+            INSERT INTO run_artifact_links
+                (project_id, link_id, run_id, run_name, version_id, direction,
+                 created_at)
+            VALUES (%s, %s, %s, %s, %s, %s, %s)
+            """,
+            (project, link_id, run_id, run_name, version_id, direction, now),
+        )
+
+    @classmethod
+    def insert_run_artifact_link(
+        cls,
+        project: str,
+        run_name: str | None,
+        run_id: str | None,
+        version_id: int,
+        direction: str,
+    ) -> None:
+        with cls._connection() as connection, connection.cursor() as cursor:
+            cls._insert_run_artifact_link_with_cursor(
+                cursor,
+                project=project,
+                run_name=run_name,
+                run_id=run_id,
+                version_id=version_id,
+                direction=direction,
+                now=datetime.now(timezone.utc).isoformat(),
+            )
+
+    @classmethod
+    def get_run_artifacts(
+        cls,
+        project: str,
+        run_name: str | None = None,
+        run_id: str | None = None,
+    ) -> dict[str, list[dict]]:
+        with cls._connection() as connection, connection.cursor() as cursor:
+            resolved = cls._resolve_run_id(cursor, project, run_name, run_id)
+            if resolved is None:
+                resolved = run_id
+            if resolved is not None:
+                where = "links.run_id = %s"
+                identity: Any = resolved
+            elif run_name is not None:
+                where = "links.run_name = %s"
+                identity = run_name
+            else:
+                return {"input": [], "output": []}
+            cursor.execute(
+                f"""
+                SELECT links.direction, links.created_at, versions.version_id,
+                       versions.version_number, versions.size_bytes,
+                       artifacts.name, artifacts.artifact_type
+                FROM run_artifact_links links
+                JOIN artifact_versions versions
+                  ON versions.project_id = links.project_id
+                 AND versions.version_id = links.version_id
+                JOIN artifacts
+                  ON artifacts.project_id = versions.project_id
+                 AND artifacts.artifact_id = versions.artifact_id
+                WHERE links.project_id = %s AND {where}
+                ORDER BY links.created_at, versions.version_id, links.direction
+                """,
+                (project, identity),
+            )
+            result: dict[str, list[dict]] = {"input": [], "output": []}
+            for row in cursor.fetchall():
+                result[str(row["direction"])].append(
+                    {
+                        "version_id": int(row["version_id"]),
+                        "name": row["name"],
+                        "type": row["artifact_type"],
+                        "version": int(row["version_number"]),
+                        "size_bytes": int(row["size_bytes"]),
+                        "created_at": row["created_at"],
+                    }
+                )
+            return result
+
+    @classmethod
+    def get_run_artifact_counts(cls, project: str) -> list[dict]:
+        with cls._connection() as connection, connection.cursor() as cursor:
+            cursor.execute(
+                """
+                SELECT DISTINCT run_id, run_name, version_id, direction
+                FROM run_artifact_links
+                WHERE project_id = %s
+                """,
+                (project,),
+            )
+            rows = list(cursor.fetchall())
+        return cls._artifact_link_counts_from_rows(rows, cls.get_run_records(project))
+
+    @classmethod
+    def get_artifact_consumers(cls, project: str, version_id: int) -> list[dict]:
+        with cls._connection() as connection, connection.cursor() as cursor:
+            cursor.execute(
+                """
+                SELECT run_name, run_id, created_at
+                FROM run_artifact_links
+                WHERE project_id = %s AND version_id = %s
+                  AND direction = 'input'
+                ORDER BY created_at, run_name, run_id
+                """,
+                (project, version_id),
+            )
+            return list(cursor.fetchall())
+
+    @classmethod
+    def force_sync(cls) -> bool:
+        return True
+
+    @classmethod
+    def export_to_parquet(cls) -> None:
+        return None
+
+    @classmethod
+    def get_scheduler(cls) -> Any:
+        return DummyCommitScheduler()
+
+    @classmethod
+    def get_project_db_path(cls, project: str) -> Any:
+        del project
+        raise RuntimeError("Doris projects do not have local database files")
+
+    @classmethod
+    def list_artifact_blobs_present(cls, project: str, digests: list[str]) -> list[str]:
+        return [
+            digest for digest in digests if cas.blob_path(project, digest).is_file()
+        ]
+
+    @classmethod
+    def _unsupported(cls, *args: Any, **kwargs: Any) -> Any:
+        del args, kwargs
+        raise NotImplementedError(
+            "This Trackio operation is not implemented by the Doris engine yet"
+        )

--- a/trackio/fragments.py
+++ b/trackio/fragments.py
@@ -185,7 +185,7 @@ def _group_by_run(records: list[dict]) -> dict[tuple, list[dict]]:
 
 
 def import_records(records: list[dict]) -> int:
-    from trackio.sqlite_storage import SQLiteStorage  # noqa: PLC0415
+    from trackio.storage import Storage  # noqa: PLC0415
 
     metric_records = [r for r in records if r.get("kind") == METRIC_KIND]
     system_records = [r for r in records if r.get("kind") == SYSTEM_METRIC_KIND]
@@ -197,7 +197,7 @@ def import_records(records: list[dict]) -> int:
             continue
         config = next((r["config"] for r in group if r.get("config")), None)
         has_timestamps = all(r.get("timestamp") for r in group)
-        SQLiteStorage.bulk_log(
+        Storage.bulk_log(
             project=project,
             run=run,
             run_id=run_id,
@@ -213,7 +213,7 @@ def import_records(records: list[dict]) -> int:
         if not project or not run:
             continue
         has_timestamps = all(r.get("timestamp") for r in group)
-        SQLiteStorage.bulk_log_system(
+        Storage.bulk_log_system(
             project=project,
             run=run,
             run_id=run_id,
@@ -227,7 +227,7 @@ def import_records(records: list[dict]) -> int:
         if not project or not run:
             continue
         has_timestamps = all(r.get("timestamp") for r in group)
-        SQLiteStorage.bulk_alert(
+        Storage.bulk_alert(
             project=project,
             run=run,
             run_id=run_id,

--- a/trackio/frontend/package-lock.json
+++ b/trackio/frontend/package-lock.json
@@ -9,9 +9,9 @@
       "version": "0.0.1",
       "dependencies": {
         "hyparquet": "^1.7.0",
-        "vega": "^5.30.0",
-        "vega-embed": "^6.26.0",
-        "vega-lite": "^5.21.0"
+        "vega": "^6.3.1",
+        "vega-embed": "^7.1.0",
+        "vega-lite": "^6.4.3"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -19,10 +19,10 @@
         "eslint": "^10.1.0",
         "eslint-plugin-svelte": "^3.16.0",
         "globals": "^17.4.0",
-        "svelte": "^5.0.0",
+        "svelte": "^5.56.8",
         "svelte-eslint-parser": "^1.6.0",
-        "vite": "^6.0.0",
-        "vitest": "^3.2.4"
+        "vite": "^6.4.3",
+        "vitest": "^3.2.7"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -942,6 +942,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1047,9 +1048,9 @@
       ]
     },
     "node_modules/@sveltejs/acorn-typescript": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.9.tgz",
-      "integrity": "sha512-lVJX6qEgs/4DOcRTpo56tmKzVPtoWAaVbL4hfO7t7NVwl9AAXzQR6cihesW1BmNMPl+bK6dreu2sOKBP2Q9CIA==",
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.11.tgz",
+      "integrity": "sha512-LFuZUkjJ9iF7JZye/aG5XM0SFcQ5VyL0oVX4WJ9dc0Va3R3s0OauX1BESVCb+YN/ol8TAfqGDDAQsTG627Y5kw==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -1128,9 +1129,9 @@
       "license": "MIT"
     },
     "node_modules/@types/geojson": {
-      "version": "7946.0.4",
-      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.4.tgz",
-      "integrity": "sha512-MHmwBtCb7OCv1DSivz2UNJXPGU/1btAWRKlqJ2saEhVJkpkvqHMMaOpKg0v4sAbDWSQekHGvPVMM8nQ+Jen03Q==",
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
       "license": "MIT"
     },
     "node_modules/@types/json-schema": {
@@ -1148,15 +1149,15 @@
       "license": "MIT"
     },
     "node_modules/@vitest/expect": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
-      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.7.tgz",
+      "integrity": "sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "3.2.4",
-        "@vitest/utils": "3.2.4",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
         "chai": "^5.2.0",
         "tinyrainbow": "^2.0.0"
       },
@@ -1165,13 +1166,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
-      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.7.tgz",
+      "integrity": "sha512-Trr0hYO9CM3Wj6ksWHRhK9IZpIY6wTMO5u/MqXurMxT57sWBaOPEtP3Oq60ihZuh5JsiagKfz95OcxdEP6dBrA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "3.2.4",
+        "@vitest/spy": "3.2.7",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.17"
       },
@@ -1192,9 +1193,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
-      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.7.tgz",
+      "integrity": "sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1205,13 +1206,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
-      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.7.tgz",
+      "integrity": "sha512-sB9y4ovltoQP+WaUPwmSxO9WIg9Ig694Di5PalVPsYHklAdE027mehpWF2SQSVq+k6sFgaivbTjTJwZLSHbedA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "3.2.4",
+        "@vitest/utils": "3.2.7",
         "pathe": "^2.0.3",
         "strip-literal": "^3.0.0"
       },
@@ -1220,13 +1221,13 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
-      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.7.tgz",
+      "integrity": "sha512-7C+MwShwtBSI5Buwoyg3s/iY1eHL9PKAf+O1wVh/TdnjXUtkoL/9YQtre90i4MtNXM6edP1wJ2zOBpfCyhIS7g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "3.2.4",
+        "@vitest/pretty-format": "3.2.7",
         "magic-string": "^0.30.17",
         "pathe": "^2.0.3"
       },
@@ -1235,9 +1236,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
-      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.7.tgz",
+      "integrity": "sha512-Q2eQGI6d2L/hBtZ0qNuKcAGid68XK6cv1xsoaIma6PaJhHPoqcEJhYpXZ/5myCMqkNgtP6UKuBhbc0nHKnrkuQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1248,13 +1249,13 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
-      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.7.tgz",
+      "integrity": "sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "3.2.4",
+        "@vitest/pretty-format": "3.2.7",
         "loupe": "^3.1.4",
         "tinyrainbow": "^2.0.0"
       },
@@ -1303,24 +1304,24 @@
       }
     },
     "node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
       "license": "MIT",
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
       }
     },
     "node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
       "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
@@ -1367,16 +1368,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/cac": {
@@ -1417,17 +1418,17 @@
       }
     },
     "node_modules/cliui": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+      "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
       "license": "ISC",
       "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.1",
-        "wrap-ansi": "^7.0.0"
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=20"
       }
     },
     "node_modules/clsx": {
@@ -1439,24 +1440,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "license": "MIT"
     },
     "node_modules/commander": {
       "version": "7.2.0",
@@ -1777,25 +1760,25 @@
       }
     },
     "node_modules/delaunator": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.0.1.tgz",
-      "integrity": "sha512-8nvh+XBe96aCESrGOqMp/84b13H9cdKbG5P2ejQCh4d4sK9RL4371qou9drQjMhvnPmhWl5hnmqbEE0fXr9Xnw==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.1.0.tgz",
+      "integrity": "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==",
       "license": "ISC",
       "dependencies": {
         "robust-predicates": "^3.0.2"
       }
     },
     "node_modules/devalue": {
-      "version": "5.6.4",
-      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.6.4.tgz",
-      "integrity": "sha512-Gp6rDldRsFh/7XuouDbxMH3Mx8GMCcgzIb1pDTvNyn8pZGQ22u+Wa+lGV9dQCltFQ7uVw0MhRyb8XDskNFOReA==",
+      "version": "5.8.2",
+      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.8.2.tgz",
+      "integrity": "sha512-DObPPAfdtFbXjxLqK8s2Xk9ZuWz5+ZoFEhC7J76es4GU/rEiXwHTmbImoCdyoCOcBH1UF3+Cz6Z2sYD4hyl5TA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
       "license": "MIT"
     },
     "node_modules/es-module-lexer": {
@@ -2043,13 +2026,21 @@
       }
     },
     "node_modules/esrap": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/esrap/-/esrap-2.2.3.tgz",
-      "integrity": "sha512-8fOS+GIGCQZl/ZIlhl59htOlms6U8NvX6ZYgYHpRU/b6tVSh3uHkOHZikl3D4cMbYM0JlpBe+p/BkZEi8J9XIQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/esrap/-/esrap-2.3.0.tgz",
+      "integrity": "sha512-GQ/7RN8uOtEfNpzZzBMTzW9JBcX42oaSVtPzdF+6cEL8pqIL094iUpr9jzYGn4O4P/1S60dJ6izyT8F4LYARng==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.4.15"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/types": "^8.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@typescript-eslint/types": {
+          "optional": true
+        }
       }
     },
     "node_modules/esrecurse": {
@@ -2225,6 +2216,18 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -2306,15 +2309,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/is-glob": {
@@ -2496,9 +2490,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -2520,26 +2514,6 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -2636,9 +2610,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2649,9 +2623,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "dev": true,
       "funding": [
         {
@@ -2669,7 +2643,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -2805,19 +2779,10 @@
         "node": ">=6"
       }
     },
-    "node_modules/require-directory": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/robust-predicates": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.2.tgz",
-      "integrity": "sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.3.tgz",
+      "integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==",
       "license": "Unlicense"
     },
     "node_modules/rollup": {
@@ -2944,29 +2909,35 @@
       "license": "MIT"
     },
     "node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
       "license": "MIT",
       "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
       "license": "MIT",
       "dependencies": {
-        "ansi-regex": "^5.0.1"
+        "ansi-regex": "^6.2.2"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "node_modules/strip-literal": {
@@ -2983,24 +2954,24 @@
       }
     },
     "node_modules/svelte": {
-      "version": "5.53.10",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.53.10.tgz",
-      "integrity": "sha512-UcNfWzbrjvYXYSk+U2hME25kpb87oq6/WVLeBF4khyQrb3Ob/URVlN23khal+RbdCUTMfg4qWjI9KZjCNFtYMQ==",
+      "version": "5.56.8",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.56.8.tgz",
+      "integrity": "sha512-PY8LOw7xP6c8IOiVqdo0sbbZVYhXRSfklOQLAUyGBKqjTX0wx/z4l/9J+PmBpmlLnxzEb1NqltxQ5/wZme/Cmg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/remapping": "^2.3.4",
         "@jridgewell/sourcemap-codec": "^1.5.0",
-        "@sveltejs/acorn-typescript": "^1.0.5",
+        "@sveltejs/acorn-typescript": "^1.0.10",
         "@types/estree": "^1.0.5",
         "@types/trusted-types": "^2.0.7",
         "acorn": "^8.12.1",
         "aria-query": "5.3.1",
         "axobject-query": "^4.1.0",
         "clsx": "^2.1.1",
-        "devalue": "^5.6.3",
+        "devalue": "^5.8.1",
         "esm-env": "^1.2.1",
-        "esrap": "^2.2.2",
+        "esrap": "^2.2.12",
         "is-reference": "^3.0.3",
         "locate-character": "^3.0.0",
         "magic-string": "^0.30.11",
@@ -3170,12 +3141,6 @@
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "license": "MIT"
     },
-    "node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "license": "MIT"
-    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -3213,220 +3178,232 @@
       "license": "MIT"
     },
     "node_modules/vega": {
-      "version": "5.33.1",
-      "resolved": "https://registry.npmjs.org/vega/-/vega-5.33.1.tgz",
-      "integrity": "sha512-1fArfVDUqVbb5z8n+/nVQb+VNBzx8svY6CrsyTK4Ujm4yrd9I1auoKxBAPXLCavY1LcrbHUskQbGUP8gXOzyQw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/vega/-/vega-6.3.1.tgz",
+      "integrity": "sha512-mX5tvY3ISCSiPPmunuZyQfccq0XlUvJd2t5oyc6SNS0N0TwnPNoklx0mVod5n+qbzuUoiuxl7Ve/SvoRqH4RzA==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "vega-crossfilter": "~4.1.4",
-        "vega-dataflow": "~5.7.8",
-        "vega-encode": "~4.10.3",
-        "vega-event-selector": "~3.0.1",
-        "vega-expression": "~5.2.1",
-        "vega-force": "~4.2.3",
-        "vega-format": "~1.1.4",
-        "vega-functions": "~5.18.1",
-        "vega-geo": "~4.4.4",
-        "vega-hierarchy": "~4.1.4",
-        "vega-label": "~1.3.2",
-        "vega-loader": "~4.5.4",
-        "vega-parser": "~6.6.1",
-        "vega-projection": "~1.6.3",
-        "vega-regression": "~1.3.2",
-        "vega-runtime": "~6.2.2",
-        "vega-scale": "~7.4.3",
-        "vega-scenegraph": "~4.13.2",
-        "vega-statistics": "~1.9.0",
-        "vega-time": "~2.1.4",
-        "vega-transforms": "~4.12.2",
-        "vega-typings": "~1.5.1",
-        "vega-util": "~1.17.4",
-        "vega-view": "~5.16.1",
-        "vega-view-transforms": "~4.6.2",
-        "vega-voronoi": "~4.2.5",
-        "vega-wordcloud": "~4.1.7"
+        "vega-crossfilter": "~5.1.2",
+        "vega-dataflow": "~6.1.2",
+        "vega-encode": "~5.2.1",
+        "vega-event-selector": "~4.0.0",
+        "vega-expression": "~6.2.1",
+        "vega-force": "~5.1.2",
+        "vega-format": "~2.1.2",
+        "vega-functions": "~6.1.3",
+        "vega-geo": "~5.1.2",
+        "vega-hierarchy": "~5.1.2",
+        "vega-label": "~2.1.2",
+        "vega-loader": "~5.1.2",
+        "vega-parser": "~7.1.2",
+        "vega-projection": "~2.1.2",
+        "vega-regression": "~2.1.2",
+        "vega-runtime": "~7.1.2",
+        "vega-scale": "~8.1.2",
+        "vega-scenegraph": "~5.2.1",
+        "vega-statistics": "~2.0.0",
+        "vega-time": "~3.2.1",
+        "vega-transforms": "~5.2.1",
+        "vega-typings": "~2.2.0",
+        "vega-util": "~2.1.0",
+        "vega-view": "~6.1.2",
+        "vega-view-transforms": "~5.2.1",
+        "vega-voronoi": "~5.1.2",
+        "vega-wordcloud": "~5.1.2"
+      },
+      "funding": {
+        "url": "https://app.hubspot.com/payments/GyPC972GD9Rt"
       }
     },
     "node_modules/vega-canvas": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/vega-canvas/-/vega-canvas-1.2.7.tgz",
-      "integrity": "sha512-OkJ9CACVcN9R5Pi9uF6MZBF06pO6qFpDYHWSKBJsdHP5o724KrsgR6UvbnXFH82FdsiTOff/HqjuaG8C7FL+9Q==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/vega-canvas/-/vega-canvas-2.0.0.tgz",
+      "integrity": "sha512-9x+4TTw/USYST5nx4yN272sy9WcqSRjAR0tkQYZJ4cQIeon7uVsnohvoPQK1JZu7K1QXGUqzj08z0u/UegBVMA==",
       "license": "BSD-3-Clause"
     },
     "node_modules/vega-crossfilter": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/vega-crossfilter/-/vega-crossfilter-4.1.4.tgz",
-      "integrity": "sha512-5E/i60Y80CUt+4O+U89X8ZnauaFuq0ztq/Hx4i4sT/crk4Lfn1oplRAjNOo7dFEZ04TahyBbYiJKIhR0yvmHpw==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/vega-crossfilter/-/vega-crossfilter-5.1.2.tgz",
+      "integrity": "sha512-K14PtfBxQzb7UJq5rL1IuwDdPov6lucoHVzRaraGiBBnfc963jkWHQNfRFAuEj/nIt5BIixXBiqIrGKgfScjSA==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "d3-array": "^3.2.2",
-        "vega-dataflow": "^5.7.8",
-        "vega-util": "^1.17.4"
+        "d3-array": "^3.2.4",
+        "vega-dataflow": "^6.1.2",
+        "vega-util": "^2.1.0"
       }
     },
     "node_modules/vega-dataflow": {
-      "version": "5.7.8",
-      "resolved": "https://registry.npmjs.org/vega-dataflow/-/vega-dataflow-5.7.8.tgz",
-      "integrity": "sha512-jrllcIjSYU5Jh130RDR44o/SbUbJndLuoiM9IsKWW+a7HayKnfmbdHWm7MvCrj/YLupFZVojRaS1tTs53EXTdA==",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/vega-dataflow/-/vega-dataflow-6.1.2.tgz",
+      "integrity": "sha512-0/HBBlzPERh0wV5kUOh/N4aAAmb3rB18Kfpej+nWvDIjPk3dixTapNkVVkoA9CsB5dY5bY+HNqiM/Pp4XPduGQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "vega-format": "^1.1.4",
-        "vega-loader": "^4.5.4",
-        "vega-util": "^1.17.4"
+        "vega-format": "^2.1.2",
+        "vega-loader": "^5.1.2",
+        "vega-util": "^2.1.0"
       }
     },
     "node_modules/vega-embed": {
-      "version": "6.29.0",
-      "resolved": "https://registry.npmjs.org/vega-embed/-/vega-embed-6.29.0.tgz",
-      "integrity": "sha512-PmlshTLtLFLgWtF/b23T1OwX53AugJ9RZ3qPE2c01VFAbgt3/GSNI/etzA/GzdrkceXFma+FDHNXUppKuM0U6Q==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/vega-embed/-/vega-embed-7.1.0.tgz",
+      "integrity": "sha512-ZmEIn5XJrQt7fSh2lwtSdXG/9uf3yIqZnvXFEwBJRppiBgrEWZcZbj6VK3xn8sNTFQ+sQDXW5sl/6kmbAW3s5A==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "fast-json-patch": "^3.1.1",
         "json-stringify-pretty-compact": "^4.0.0",
-        "semver": "^7.6.3",
+        "semver": "^7.7.2",
         "tslib": "^2.8.1",
-        "vega-interpreter": "^1.0.5",
-        "vega-schema-url-parser": "^2.2.0",
-        "vega-themes": "^2.15.0",
-        "vega-tooltip": "^0.35.2"
+        "vega-interpreter": "^2.0.0",
+        "vega-schema-url-parser": "^3.0.2",
+        "vega-themes": "3.0.0",
+        "vega-tooltip": "1.0.0"
+      },
+      "funding": {
+        "url": "https://app.hubspot.com/payments/GyPC972GD9Rt"
       },
       "peerDependencies": {
-        "vega": "^5.21.0",
+        "vega": "*",
         "vega-lite": "*"
       }
     },
     "node_modules/vega-encode": {
-      "version": "4.10.3",
-      "resolved": "https://registry.npmjs.org/vega-encode/-/vega-encode-4.10.3.tgz",
-      "integrity": "sha512-245ebBuN1TjwVVDFG7JZaZ/ExLAhZ4kDTK2zlIoXs/g2P5rRgL4Q6oRixr+Pgr43G7ISCEHrUBgUjRcSoG8eEA==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/vega-encode/-/vega-encode-5.2.1.tgz",
+      "integrity": "sha512-YuvJ66z6FQRtu0n0IYxsJp7BpliXVgaxNsur0Fqic10/a5TLMQmDYURPUcrtWViAMpqKgdNMyxnmr0ZQ4bjwCA==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "d3-array": "^3.2.2",
+        "d3-array": "^3.2.4",
         "d3-interpolate": "^3.0.1",
-        "vega-dataflow": "^5.7.8",
-        "vega-scale": "^7.4.3",
-        "vega-util": "^1.17.4"
+        "vega-dataflow": "^6.1.2",
+        "vega-scale": "^8.1.2",
+        "vega-util": "^2.1.0"
       }
     },
     "node_modules/vega-event-selector": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/vega-event-selector/-/vega-event-selector-3.0.1.tgz",
-      "integrity": "sha512-K5zd7s5tjr1LiOOkjGpcVls8GsH/f2CWCrWcpKy74gTCp+llCdwz0Enqo013ZlGaRNjfgD/o1caJRt3GSaec4A==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/vega-event-selector/-/vega-event-selector-4.0.0.tgz",
+      "integrity": "sha512-CcWF4m4KL/al1Oa5qSzZ5R776q8lRxCj3IafCHs5xipoEHrkgu1BWa7F/IH5HrDNXeIDnqOpSV1pFsAWRak4gQ==",
       "license": "BSD-3-Clause"
     },
     "node_modules/vega-expression": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/vega-expression/-/vega-expression-5.2.1.tgz",
-      "integrity": "sha512-9KKbI2q9qTI55NSjD/dVWg3aeCtw+gwyWCiLMM47ha6iXrAN9pQ+EKRJfxOHuoDfCTlJJTaUfnnXgbqm0HEszg==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/vega-expression/-/vega-expression-6.2.1.tgz",
+      "integrity": "sha512-AK4EYh9ErCC7KU8vGigsetwG66S1wLLfPFnfjkOdydRaN4kNJp129qp4jos0wA/r7F/lIlhM3uIzw+KSA2cZEg==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@types/estree": "^1.0.0",
-        "vega-util": "^1.17.4"
+        "@types/estree": "^1.0.9",
+        "vega-util": "^2.1.0"
       }
     },
+    "node_modules/vega-expression/node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "license": "MIT"
+    },
     "node_modules/vega-force": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/vega-force/-/vega-force-4.2.3.tgz",
-      "integrity": "sha512-7Yp1uOPy3eyzK/hnAIU0v/yQ9mIhtoJ+tq8AMaZiWqy67SUYsE3olmgdllY6R9M81D/n/rv8K+8JjbHMU5/sUA==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/vega-force/-/vega-force-5.1.2.tgz",
+      "integrity": "sha512-693paaBvACvAtUO8vp4m/KUJ0F3tKaoXixzw+ExpP4qKkqJ/Me2MGWsVrEJh/f6KuU9bp7xv+g7OPNhqnVrpoQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "d3-force": "^3.0.0",
-        "vega-dataflow": "^5.7.8",
-        "vega-util": "^1.17.4"
+        "vega-dataflow": "^6.1.2",
+        "vega-util": "^2.1.0"
       }
     },
     "node_modules/vega-format": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/vega-format/-/vega-format-1.1.4.tgz",
-      "integrity": "sha512-+oz6UvXjQSbweW9P8q+1o2qFYyBYPFax94j6a9PQMnCIWMovFSss1wEElljOT8CEpnHyS15yiGlmz4qbWTQwnQ==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/vega-format/-/vega-format-2.1.2.tgz",
+      "integrity": "sha512-cJ2oqGEGYJ2NbkIIUDic03ZZX1meE+sq330gq4HFf3CvzSupTwHLWQj3/H5zug5DrqEQhLCLkiRwvmMe4pEqfg==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "d3-array": "^3.2.2",
-        "d3-format": "^3.1.0",
+        "d3-array": "^3.2.4",
+        "d3-format": "^3.1.2",
         "d3-time-format": "^4.1.0",
-        "vega-time": "^2.1.4",
-        "vega-util": "^1.17.4"
+        "vega-time": "^3.2.1",
+        "vega-util": "^2.1.0"
       }
     },
     "node_modules/vega-functions": {
-      "version": "5.18.1",
-      "resolved": "https://registry.npmjs.org/vega-functions/-/vega-functions-5.18.1.tgz",
-      "integrity": "sha512-qEBAbo0jxGGebRvbX1zmxzmjwFz8/UtncRhzwk9/KcI0WudULNmCM1iTu+DGFRnNHdcKi6kUlwJBPIp7zDu3HQ==",
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/vega-functions/-/vega-functions-6.1.3.tgz",
+      "integrity": "sha512-WOgWVxGg1T1tuICyylIppxXWXWEtl7P81Xnj0vQtoIn11VvQ0mrsBZr1aia4g8Sw0fEH1mUO7Dtj7v3o8BgBmQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "d3-array": "^3.2.2",
+        "d3-array": "^3.2.4",
         "d3-color": "^3.1.0",
-        "d3-geo": "^3.1.0",
-        "vega-dataflow": "^5.7.8",
-        "vega-expression": "^5.2.1",
-        "vega-scale": "^7.4.3",
-        "vega-scenegraph": "^4.13.2",
-        "vega-selections": "^5.6.1",
-        "vega-statistics": "^1.9.0",
-        "vega-time": "^2.1.4",
-        "vega-util": "^1.17.4"
+        "d3-geo": "^3.1.1",
+        "vega-dataflow": "^6.1.2",
+        "vega-expression": "^6.2.1",
+        "vega-scale": "^8.1.2",
+        "vega-scenegraph": "^5.2.1",
+        "vega-selections": "^6.1.4",
+        "vega-statistics": "^2.0.0",
+        "vega-time": "^3.2.1",
+        "vega-util": "^2.1.0"
       }
     },
     "node_modules/vega-geo": {
-      "version": "4.4.4",
-      "resolved": "https://registry.npmjs.org/vega-geo/-/vega-geo-4.4.4.tgz",
-      "integrity": "sha512-jTLYrDvhXJinWQCfuVLP1nSlOdFlA9blVS6K7uOcBTJ4382Aw3ALGZKluUQyJkFdrkGfqxoDJo5MLHLu2zlc6g==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/vega-geo/-/vega-geo-5.1.2.tgz",
+      "integrity": "sha512-tls2+IVuKaIOxEqdshuSk2Til8qcF7SUNaWkATKu5hwWqQEY3cp7tfdXosuTMaDTkLp+Nw84iWfe5BzfoxDYMA==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "d3-array": "^3.2.2",
+        "d3-array": "^3.2.4",
         "d3-color": "^3.1.0",
-        "d3-geo": "^3.1.0",
-        "vega-canvas": "^1.2.7",
-        "vega-dataflow": "^5.7.8",
-        "vega-projection": "^1.6.3",
-        "vega-statistics": "^1.9.0",
-        "vega-util": "^1.17.4"
+        "d3-geo": "^3.1.1",
+        "vega-canvas": "^2.0.0",
+        "vega-dataflow": "^6.1.2",
+        "vega-projection": "^2.1.2",
+        "vega-statistics": "^2.0.0",
+        "vega-util": "^2.1.0"
       }
     },
     "node_modules/vega-hierarchy": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/vega-hierarchy/-/vega-hierarchy-4.1.4.tgz",
-      "integrity": "sha512-/iSh1YqdgsHFB20QxJ6IAVzRZQBKuMpZ/GsN5sZDP3bBJdVWl3we48L/r6w7FP9NU+JzFHcDUPJ0S0UzpMhaqg==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/vega-hierarchy/-/vega-hierarchy-5.1.2.tgz",
+      "integrity": "sha512-7a72/lA6j50HU6PQe5ChbomftHi29V1oCcibaQpDozZncHuAnsQummqfiPyTMPpNMrSRtyZy18do0IEoOvrbMg==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "d3-hierarchy": "^3.1.2",
-        "vega-dataflow": "^5.7.8",
-        "vega-util": "^1.17.4"
+        "vega-dataflow": "^6.1.2",
+        "vega-util": "^2.1.0"
       }
     },
     "node_modules/vega-interpreter": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/vega-interpreter/-/vega-interpreter-1.2.1.tgz",
-      "integrity": "sha512-EMHLGxJ+SWfh1K/fHDRlHEZtLA/2ZNAXItYb5e8CxuAIm/Ha/3DHX/8VlvbTGIciUpuwmcKx4tVhJWlKreQ/Yw==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/vega-interpreter/-/vega-interpreter-2.3.1.tgz",
+      "integrity": "sha512-IYleUp+lXVIGjJUQg+5WJ/xUdteMxEGEnSyWtRhagVuUDiXD0JnERKWffIrQSCUypA86UOuyjzVDtb7oNOsaxw==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "vega-util": "^1.17.4"
+        "vega-util": "^2.1.0"
       }
     },
     "node_modules/vega-label": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/vega-label/-/vega-label-1.3.2.tgz",
-      "integrity": "sha512-YlUCUZNsp1FHkpPjOpD+aVVmVLFw6xa+bFQGBCECuY1DuRyN6l8oCRmUOjBrr70ip8fbqfGk+czHw543J1PJgg==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/vega-label/-/vega-label-2.1.2.tgz",
+      "integrity": "sha512-MFsOKOCG6a5QwP5atoFFi+R58IP/Q7//65UvgrSeankX2QrDcWjBtzIqS6JlYBOAdyjoiAAghx7pnIAj5nAO6A==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "vega-canvas": "^1.2.7",
-        "vega-dataflow": "^5.7.8",
-        "vega-scenegraph": "^4.13.2",
-        "vega-util": "^1.17.4"
+        "vega-canvas": "^2.0.0",
+        "vega-dataflow": "^6.1.2",
+        "vega-scenegraph": "^5.2.1",
+        "vega-util": "^2.1.0"
       }
     },
     "node_modules/vega-lite": {
-      "version": "5.23.0",
-      "resolved": "https://registry.npmjs.org/vega-lite/-/vega-lite-5.23.0.tgz",
-      "integrity": "sha512-l4J6+AWE3DIjvovEoHl2LdtCUkfm4zs8Xxx7INwZEAv+XVb6kR6vIN1gt3t2gN2gs/y4DYTs/RPoTeYAuEg6mA==",
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/vega-lite/-/vega-lite-6.4.3.tgz",
+      "integrity": "sha512-d/7hPjfz560UERaQuTmGgIVfXAe3g2hJWeC+igDeaGohUdEoNrHLXgR/yTOBT8vV/lIuuKnw+0/xWWblkDwkMQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "json-stringify-pretty-compact": "~4.0.0",
         "tslib": "~2.8.1",
-        "vega-event-selector": "~3.0.1",
-        "vega-expression": "~5.1.1",
-        "vega-util": "~1.17.2",
-        "yargs": "~17.7.2"
+        "vega-event-selector": "~4.0.0",
+        "vega-expression": "~6.1.0",
+        "vega-util": "~2.1.0",
+        "yargs": "~18.0.0"
       },
       "bin": {
         "vl2pdf": "bin/vl2pdf",
@@ -3435,254 +3412,259 @@
         "vl2vg": "bin/vl2vg"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://app.hubspot.com/payments/GyPC972GD9Rt"
       },
       "peerDependencies": {
-        "vega": "^5.24.0"
+        "vega": "^6.0.0"
       }
     },
     "node_modules/vega-lite/node_modules/vega-expression": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/vega-expression/-/vega-expression-5.1.2.tgz",
-      "integrity": "sha512-fFeDTh4UtOxlZWL54jf1ZqJHinyerWq/ROiqrQxqLkNJRJ86RmxYTgXwt65UoZ/l4VUv9eAd2qoJeDEf610Umw==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/vega-expression/-/vega-expression-6.1.0.tgz",
+      "integrity": "sha512-hHgNx/fQ1Vn1u6vHSamH7lRMsOa/yQeHGGcWVmh8fZafLdwdhCM91kZD9p7+AleNpgwiwzfGogtpATFaMmDFYg==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@types/estree": "^1.0.0",
-        "vega-util": "^1.17.3"
+        "@types/estree": "^1.0.8",
+        "vega-util": "^2.1.0"
       }
     },
     "node_modules/vega-loader": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/vega-loader/-/vega-loader-4.5.4.tgz",
-      "integrity": "sha512-AOJPsDVz009aTdD9hzigUaO/NFmuN1o83rzvZu/g37TJfhU+3DOvgnO0rnqJbnSOfcBkLWER6XghlKS3j77w4A==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/vega-loader/-/vega-loader-5.1.2.tgz",
+      "integrity": "sha512-O29bKHsSJBi391H88OZXH8vgUdopWMorC5ZJ/8XjTq8TIXVdeUrNnI8dMkUyv7yQg3ywMTji+5fHhov1TOkkyA==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "d3-dsv": "^3.0.1",
-        "node-fetch": "^2.6.7",
         "topojson-client": "^3.1.0",
-        "vega-format": "^1.1.4",
-        "vega-util": "^1.17.4"
+        "vega-format": "^2.1.2",
+        "vega-util": "^2.1.0"
       }
     },
     "node_modules/vega-parser": {
-      "version": "6.6.1",
-      "resolved": "https://registry.npmjs.org/vega-parser/-/vega-parser-6.6.1.tgz",
-      "integrity": "sha512-FIez+huStzgjsxLqOkxDAooTkDC2XruYCIFWhd3HuM/QrqKtj9JKGuIUJjpVVkE7by7S5ejrucpRzVVgQfbzSg==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/vega-parser/-/vega-parser-7.1.2.tgz",
+      "integrity": "sha512-88HNkVrEwWbMmbbhPCmFHPrl/ClTcvThRv2UMZqMJJ5IqgjWLUolCA1fhAvnAbvRPe+Z1j+GbV/WWjYWAjEuyw==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "vega-dataflow": "^5.7.8",
-        "vega-event-selector": "^3.0.1",
-        "vega-functions": "^5.18.1",
-        "vega-scale": "^7.4.3",
-        "vega-util": "^1.17.4"
+        "vega-dataflow": "^6.1.2",
+        "vega-event-selector": "^4.0.0",
+        "vega-functions": "^6.1.3",
+        "vega-scale": "^8.1.2",
+        "vega-util": "^2.1.0"
       }
     },
     "node_modules/vega-projection": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/vega-projection/-/vega-projection-1.6.3.tgz",
-      "integrity": "sha512-vusyaPi3EFIHrBVs0chNv2bCqxw4X+XgI1m3+yOgUD/dutsIGTcqy+PjlNlspPQvMI9JjTeIUTGt8u1V7oDwAA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/vega-projection/-/vega-projection-2.1.2.tgz",
+      "integrity": "sha512-HL+FS9AgYSOa1UOIJfhOD39RMT4tDODkMcN6MCRsdlRNnukVm1+JhrixDnciBjqiZLxDhUjESJwgLQtXx8cUyw==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "d3-geo": "^3.1.0",
+        "d3-geo": "^3.1.1",
         "d3-geo-projection": "^4.0.0",
-        "vega-scale": "^7.4.3"
+        "vega-scale": "^8.1.2"
       }
     },
     "node_modules/vega-regression": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/vega-regression/-/vega-regression-1.3.2.tgz",
-      "integrity": "sha512-DtGToopuJGmxeoymaOXTDKlWkkYiDVvZFV1IWQNuRlChTBI6YBpil4WmA3U+ECePDQuk2+/mWlw+vafrbgF8Tg==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/vega-regression/-/vega-regression-2.1.2.tgz",
+      "integrity": "sha512-2dyb2sT6cxdTK5K87uNDYpW7LbTP90lplxW62imjfLAwKUq1wL74X8y03a0W5tpRfV8+f3ai+cYTv+HXB3XmDQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "d3-array": "^3.2.2",
-        "vega-dataflow": "^5.7.8",
-        "vega-statistics": "^1.9.0",
-        "vega-util": "^1.17.4"
+        "d3-array": "^3.2.4",
+        "vega-dataflow": "^6.1.2",
+        "vega-statistics": "^2.0.0",
+        "vega-util": "^2.1.0"
       }
     },
     "node_modules/vega-runtime": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/vega-runtime/-/vega-runtime-6.2.2.tgz",
-      "integrity": "sha512-5c+i7y5XBw5phIA1mBeqF/gtOQcDjUzroUAQ0g3y3weNx0K4mzj7V360yZiBLNcuHv65xgTlijstbKQttxeY/g==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/vega-runtime/-/vega-runtime-7.1.2.tgz",
+      "integrity": "sha512-MMfm7FeWLX2XqaY26i99GrlToexO/EWYqT7MRqEkpw+0nYgKh4zpQ47j04LB3ishnSZAj2AL0HNl9uPZLxgFhg==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "vega-dataflow": "^5.7.8",
-        "vega-util": "^1.17.4"
+        "vega-dataflow": "^6.1.2",
+        "vega-util": "^2.1.0"
       }
     },
     "node_modules/vega-scale": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/vega-scale/-/vega-scale-7.4.3.tgz",
-      "integrity": "sha512-f7SSN2YJowtrdkt7nJIR6YYhjDk8oB37q5So2/OxXQv5CBHipFPQSHS1ZVw9vD3V5wLnrZCxC4Ji27gmsTefgA==",
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/vega-scale/-/vega-scale-8.1.2.tgz",
+      "integrity": "sha512-ADCGgdSmhcZyHxtHbrVcDrG76er2s2eXowO3qDg0vx2eclHdXL4YNaEjTHrosNG/1TAI5LAe7aQ2BGssJFfAXA==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "d3-array": "^3.2.2",
+        "d3-array": "^3.2.4",
         "d3-interpolate": "^3.0.1",
         "d3-scale": "^4.0.2",
         "d3-scale-chromatic": "^3.1.0",
-        "vega-time": "^2.1.4",
-        "vega-util": "^1.17.4"
+        "vega-time": "^3.2.1",
+        "vega-util": "^2.1.0"
       }
     },
     "node_modules/vega-scenegraph": {
-      "version": "4.13.2",
-      "resolved": "https://registry.npmjs.org/vega-scenegraph/-/vega-scenegraph-4.13.2.tgz",
-      "integrity": "sha512-eCutgcLzdUg23HLc6MTZ9pHCdH0hkqSmlbcoznspwT0ajjATk6M09JNyJddiaKR55HuQo03mBWsPeRCd5kOi0g==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/vega-scenegraph/-/vega-scenegraph-5.2.1.tgz",
+      "integrity": "sha512-tWolI3s/cjU5g8evEjpxJqgqKQ2IJv1FoPXqvNuviLNdylP1I/h5iF5RY08Cz4jkuP9zircSskFEBsHylD1dgQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "d3-path": "^3.1.0",
         "d3-shape": "^3.2.0",
-        "vega-canvas": "^1.2.7",
-        "vega-loader": "^4.5.4",
-        "vega-scale": "^7.4.3",
-        "vega-util": "^1.17.4"
+        "vega-canvas": "^2.0.0",
+        "vega-loader": "^5.1.2",
+        "vega-scale": "^8.1.2",
+        "vega-util": "^2.1.0"
       }
     },
     "node_modules/vega-schema-url-parser": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/vega-schema-url-parser/-/vega-schema-url-parser-2.2.0.tgz",
-      "integrity": "sha512-yAtdBnfYOhECv9YC70H2gEiqfIbVkq09aaE4y/9V/ovEFmH9gPKaEgzIZqgT7PSPQjKhsNkb6jk6XvSoboxOBw==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/vega-schema-url-parser/-/vega-schema-url-parser-3.0.2.tgz",
+      "integrity": "sha512-xAnR7KAvNPYewI3O0l5QGdT8Tv0+GCZQjqfP39cW/hbe/b3aYMAQ39vm8O2wfXUHzm04xTe7nolcsx8WQNVLRQ==",
       "license": "BSD-3-Clause"
     },
     "node_modules/vega-selections": {
-      "version": "5.6.3",
-      "resolved": "https://registry.npmjs.org/vega-selections/-/vega-selections-5.6.3.tgz",
-      "integrity": "sha512-DXd+XVKcIjBAtSCcgtPx7cXuqG/7L98SWoFh6GKNu26EBUyn3zm0GAlZxNLPoI01Jz9Fb3YpSsewk2aIAbM68g==",
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/vega-selections/-/vega-selections-6.1.4.tgz",
+      "integrity": "sha512-qR5feBL8xq5BjoG3rf7e2WKle/cn5Fa9pBFMBnzoOYp4nTA0GYDoKuOjZkftibsQcmdST0HzPjSrS14jH3TCQw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "d3-array": "3.2.4",
-        "vega-expression": "^5.2.1",
-        "vega-util": "^1.17.4"
+        "vega-expression": "^6.2.1",
+        "vega-util": "^2.1.0"
       }
     },
     "node_modules/vega-statistics": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/vega-statistics/-/vega-statistics-1.9.0.tgz",
-      "integrity": "sha512-GAqS7mkatpXcMCQKWtFu1eMUKLUymjInU0O8kXshWaQrVWjPIO2lllZ1VNhdgE0qGj4oOIRRS11kzuijLshGXQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/vega-statistics/-/vega-statistics-2.0.0.tgz",
+      "integrity": "sha512-dGPfDXnBlgXbZF3oxtkb8JfeRXd5TYHx25Z/tIoaa9jWua4Vf/AoW2wwh8J1qmMy8J03/29aowkp1yk4DOPazQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "d3-array": "^3.2.2"
+        "d3-array": "^3.2.4"
       }
     },
     "node_modules/vega-themes": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/vega-themes/-/vega-themes-2.15.0.tgz",
-      "integrity": "sha512-DicRAKG9z+23A+rH/3w3QjJvKnlGhSbbUXGjBvYGseZ1lvj9KQ0BXZ2NS/+MKns59LNpFNHGi9us/wMlci4TOA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/vega-themes/-/vega-themes-3.0.0.tgz",
+      "integrity": "sha512-1iFiI3BNmW9FrsLnDLx0ZKEddsCitRY3XmUAwp6qmp+p+IXyJYc9pfjlVj9E6KXBPfm4cQyU++s0smKNiWzO4g==",
       "license": "BSD-3-Clause",
+      "funding": {
+        "url": "https://app.hubspot.com/payments/GyPC972GD9Rt"
+      },
       "peerDependencies": {
         "vega": "*",
         "vega-lite": "*"
       }
     },
     "node_modules/vega-time": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/vega-time/-/vega-time-2.1.4.tgz",
-      "integrity": "sha512-DBMRps5myYnSAlvQ+oiX8CycJZjGQNqyGE04xaZrpOgHll7vlvezpET2FnGZC7wS3DsqMcPjnpnI1h7+qJox1Q==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/vega-time/-/vega-time-3.2.1.tgz",
+      "integrity": "sha512-SXo1klLYPsmBdSj9itYSuFMmCpwnnIvQS8jWFxsCTnyWcPaBQKz0kf2M7DqTysi34KTk+6ws4kqZg11XMWnIYA==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "d3-array": "^3.2.2",
+        "d3-array": "^3.2.4",
         "d3-time": "^3.1.0",
-        "vega-util": "^1.17.4"
+        "vega-util": "^2.1.0"
       }
     },
     "node_modules/vega-tooltip": {
-      "version": "0.35.2",
-      "resolved": "https://registry.npmjs.org/vega-tooltip/-/vega-tooltip-0.35.2.tgz",
-      "integrity": "sha512-kuYcsAAKYn39ye5wKf2fq1BAxVcjoz0alvKp/G+7BWfIb94J0PHmwrJ5+okGefeStZnbXxINZEOKo7INHaj9GA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/vega-tooltip/-/vega-tooltip-1.0.0.tgz",
+      "integrity": "sha512-P1R0JP29v0qnTuwzCQ0SPJlkjAzr6qeyj+H4VgUFSykHmHc1OBxda//XBaFDl/bZgIscEMvjKSjZpXd84x3aZQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "vega-util": "^1.17.2"
+        "vega-util": "^2.0.0"
       },
-      "optionalDependencies": {
-        "@rollup/rollup-linux-x64-gnu": "^4.24.4"
+      "funding": {
+        "url": "https://app.hubspot.com/payments/GyPC972GD9Rt"
       }
     },
     "node_modules/vega-transforms": {
-      "version": "4.12.2",
-      "resolved": "https://registry.npmjs.org/vega-transforms/-/vega-transforms-4.12.2.tgz",
-      "integrity": "sha512-VuNLzB0DavFn5GIkFvR2XvwPavjY7VXl2oPUOFvNgSfyQywmCoC7VOX+iHeOdxoZdoy+XEOGAqRs9imxVo2HVA==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/vega-transforms/-/vega-transforms-5.2.1.tgz",
+      "integrity": "sha512-csKiYXJFa0YY5lubP1wc8b99SJ8nHLG/sOWvKFpW3CfDfjp8LoB0exrxgtIoClCsngAguKiuZVDwQZxBhPJZwA==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "d3-array": "^3.2.2",
-        "vega-dataflow": "^5.7.8",
-        "vega-statistics": "^1.9.0",
-        "vega-time": "^2.1.4",
-        "vega-util": "^1.17.4"
+        "d3-array": "^3.2.4",
+        "vega-dataflow": "^6.1.2",
+        "vega-statistics": "^2.0.0",
+        "vega-time": "^3.2.1",
+        "vega-util": "^2.1.0"
       }
     },
     "node_modules/vega-typings": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/vega-typings/-/vega-typings-1.5.1.tgz",
-      "integrity": "sha512-40kRoG/jG8+4cd3kT5yw08iTlIGe57F7Go/ileSCtRtgU8RZ7tpPaE6GgYvF/HTPlCKMk9/pOdp62+o5sulhvQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/vega-typings/-/vega-typings-2.2.0.tgz",
+      "integrity": "sha512-pX7LsqgMpzMPOyydg/drYbIjh+mmvLfKtuKr75OpCu/ZYKJ2i8UjSmNlpARYeYGLaXfuNUAM3hMN8NPZPDYiBQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@types/geojson": "7946.0.4",
-        "vega-event-selector": "^3.0.1",
-        "vega-expression": "^5.2.1",
-        "vega-util": "^1.17.4"
+        "@types/geojson": "7946.0.16",
+        "vega-event-selector": "^4.0.0",
+        "vega-expression": "^6.2.0",
+        "vega-util": "^2.1.0"
       }
     },
     "node_modules/vega-util": {
-      "version": "1.17.4",
-      "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-1.17.4.tgz",
-      "integrity": "sha512-+y3ZW7dEqM8Ck+KRsd+jkMfxfE7MrQxUyIpNjkfhIpGEreym+aTn7XUw1DKXqclr8mqTQvbilPo16B3lnBr0wA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-2.1.2.tgz",
+      "integrity": "sha512-Mdvv33BUlx4no5gz2VHdue4bJ6ejWmInuieID3JGnAXwewHKrPWE/Xr2vVWA+xS9Om1eHvj/0wVsiBGJ61v2uQ==",
       "license": "BSD-3-Clause"
     },
     "node_modules/vega-view": {
-      "version": "5.16.1",
-      "resolved": "https://registry.npmjs.org/vega-view/-/vega-view-5.16.1.tgz",
-      "integrity": "sha512-YyG4i2JDkRCacHd9xNAwyov2cELxwzPGY224PA2o0gEhkoOjPkVElTmo9QHJvKeVxMoyad6wvoq+Jj+TB6zhLw==",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/vega-view/-/vega-view-6.1.2.tgz",
+      "integrity": "sha512-BG/Kqd1csdK4uKdJ4hv72msgQX3Ry5SzCV1ngbytkn6QwuQPpFWzya/f0OSWyMQP9S79avdHXqdLCxjSeiDQRw==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "d3-array": "^3.2.2",
+        "d3-array": "^3.2.4",
         "d3-timer": "^3.0.1",
-        "vega-dataflow": "^5.7.8",
-        "vega-format": "^1.1.4",
-        "vega-functions": "^5.18.1",
-        "vega-runtime": "^6.2.2",
-        "vega-scenegraph": "^4.13.2",
-        "vega-util": "^1.17.4"
+        "vega-dataflow": "^6.1.2",
+        "vega-format": "^2.1.2",
+        "vega-functions": "^6.1.3",
+        "vega-runtime": "^7.1.2",
+        "vega-scenegraph": "^5.2.1",
+        "vega-util": "^2.1.0"
       }
     },
     "node_modules/vega-view-transforms": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/vega-view-transforms/-/vega-view-transforms-4.6.2.tgz",
-      "integrity": "sha512-udnYutgX7T7E0crqKWSs4hcxTdUmZHR2F4rKj0+3nN9+CfYMWbGgUkCkP2pMu7j2OH0ETX2uDn5xL8+YJWeXSg==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/vega-view-transforms/-/vega-view-transforms-5.2.1.tgz",
+      "integrity": "sha512-TiguoCJ6BB7TEV+s3nNMoCoH4+q5A6XQsDMEzbVuRaSWmfIJxvWUlbZQqn4CUt65VMDr63Fy21Xpb0ntlaU5LQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "vega-dataflow": "^5.7.8",
-        "vega-scenegraph": "^4.13.2",
-        "vega-util": "^1.17.4"
+        "vega-dataflow": "^6.1.2",
+        "vega-scenegraph": "^5.2.1",
+        "vega-util": "^2.1.0"
       }
     },
     "node_modules/vega-voronoi": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/vega-voronoi/-/vega-voronoi-4.2.5.tgz",
-      "integrity": "sha512-u0TLSQboiLyoM6V9S0E6cc77EfWati+ApZ6zE+NhH3h/zZRzYZmElnDn46hUof2o9jNyh09xFXTXykVHmt7IGg==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/vega-voronoi/-/vega-voronoi-5.1.2.tgz",
+      "integrity": "sha512-8BgKb6aF/42L/PrFi3Idqag7FtbzNqDVhvPD4SfswSzGYlRDcxcn1eQQsa//q72qIZk4i5rsHeAiH2QbIjPSBg==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "d3-delaunay": "^6.0.2",
-        "vega-dataflow": "^5.7.8",
-        "vega-util": "^1.17.4"
+        "d3-delaunay": "^6.0.4",
+        "vega-dataflow": "^6.1.2",
+        "vega-util": "^2.1.0"
       }
     },
     "node_modules/vega-wordcloud": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/vega-wordcloud/-/vega-wordcloud-4.1.7.tgz",
-      "integrity": "sha512-xdMykDXdWEp3/7Hil7Yx8uNVmjvqxwGibHJLSfiubNNO9OErrH3ZUgcxWv5hLe9wdK+KSGP94SSqTOAaqH7r/A==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/vega-wordcloud/-/vega-wordcloud-5.1.2.tgz",
+      "integrity": "sha512-ZSw6fupf4qx4hBzL9q/oVUKPVbVePjJ/FSgfxxgRcKvE1VoYq3HWfx9qg+CQMvgDS+oGDsn2WoQJuNLYx9T3AQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "vega-canvas": "^1.2.7",
-        "vega-dataflow": "^5.7.8",
-        "vega-scale": "^7.4.3",
-        "vega-statistics": "^1.9.0",
-        "vega-util": "^1.17.4"
+        "vega-canvas": "^2.0.0",
+        "vega-dataflow": "^6.1.2",
+        "vega-scale": "^8.1.2",
+        "vega-statistics": "^2.0.0",
+        "vega-util": "^2.1.0"
       }
     },
     "node_modules/vite": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
-      "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
+      "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3798,20 +3780,20 @@
       }
     },
     "node_modules/vitest": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
-      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.7.tgz",
+      "integrity": "sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/chai": "^5.2.2",
-        "@vitest/expect": "3.2.4",
-        "@vitest/mocker": "3.2.4",
-        "@vitest/pretty-format": "^3.2.4",
-        "@vitest/runner": "3.2.4",
-        "@vitest/snapshot": "3.2.4",
-        "@vitest/spy": "3.2.4",
-        "@vitest/utils": "3.2.4",
+        "@vitest/expect": "3.2.7",
+        "@vitest/mocker": "3.2.7",
+        "@vitest/pretty-format": "^3.2.7",
+        "@vitest/runner": "3.2.7",
+        "@vitest/snapshot": "3.2.7",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
         "chai": "^5.2.0",
         "debug": "^4.4.1",
         "expect-type": "^1.2.1",
@@ -3841,8 +3823,8 @@
         "@edge-runtime/vm": "*",
         "@types/debug": "^4.1.12",
         "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
-        "@vitest/browser": "3.2.4",
-        "@vitest/ui": "3.2.4",
+        "@vitest/browser": "3.2.7",
+        "@vitest/ui": "3.2.7",
         "happy-dom": "*",
         "jsdom": "*"
       },
@@ -3868,22 +3850,6 @@
         "jsdom": {
           "optional": true
         }
-      }
-    },
-    "node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "license": "MIT",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {
@@ -3930,17 +3896,17 @@
       }
     },
     "node_modules/wrap-ansi": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
       "license": "MIT",
       "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
@@ -3956,30 +3922,29 @@
       }
     },
     "node_modules/yargs": {
-      "version": "17.7.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
+      "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
       "license": "MIT",
       "dependencies": {
-        "cliui": "^8.0.1",
+        "cliui": "^9.0.1",
         "escalade": "^3.1.1",
         "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.3",
+        "string-width": "^7.2.0",
         "y18n": "^5.0.5",
-        "yargs-parser": "^21.1.1"
+        "yargs-parser": "^22.0.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": "^20.19.0 || ^22.12.0 || >=23"
       }
     },
     "node_modules/yargs-parser": {
-      "version": "21.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
       "license": "ISC",
       "engines": {
-        "node": ">=12"
+        "node": "^20.19.0 || ^22.12.0 || >=23"
       }
     },
     "node_modules/yocto-queue": {

--- a/trackio/frontend/package.json
+++ b/trackio/frontend/package.json
@@ -16,15 +16,15 @@
     "eslint": "^10.1.0",
     "eslint-plugin-svelte": "^3.16.0",
     "globals": "^17.4.0",
-    "svelte": "^5.0.0",
+    "svelte": "^5.56.8",
     "svelte-eslint-parser": "^1.6.0",
-    "vite": "^6.0.0",
-    "vitest": "^3.2.4"
+    "vite": "^6.4.3",
+    "vitest": "^3.2.7"
   },
   "dependencies": {
     "hyparquet": "^1.7.0",
-    "vega": "^5.30.0",
-    "vega-embed": "^6.26.0",
-    "vega-lite": "^5.21.0"
+    "vega": "^6.3.1",
+    "vega-embed": "^7.1.0",
+    "vega-lite": "^6.4.3"
   }
 }

--- a/trackio/frontend/src/App.svelte
+++ b/trackio/frontend/src/App.svelte
@@ -5,6 +5,7 @@
   import AlertPanel from "./components/AlertPanel.svelte";
   import Metrics from "./pages/Metrics.svelte";
   import Traces from "./pages/Traces.svelte";
+  import VerifiersTraces from "./pages/VerifiersTraces.svelte";
   import SystemMetrics from "./pages/SystemMetrics.svelte";
   import Media from "./pages/Media.svelte";
   import Reports from "./pages/Reports.svelte";
@@ -115,6 +116,7 @@
   const OPTIONAL_EMPTY_TABS = new Set([
     "system",
     "traces",
+    "verifiers-traces",
     "media",
     "reports",
     "files",
@@ -124,6 +126,7 @@
     "metrics",
     "system",
     "traces",
+    "verifiers-traces",
     "media",
     "reports",
     "runs",
@@ -251,6 +254,7 @@
       metrics: false,
       system: false,
       traces: false,
+      "verifiers-traces": false,
       media: false,
       reports: false,
       runs: false,
@@ -540,6 +544,7 @@
   let showSidebar = $derived(
     currentPage === "metrics" ||
       currentPage === "traces" ||
+      currentPage === "verifiers-traces" ||
       currentPage === "system" ||
       currentPage === "media" ||
       currentPage === "reports" ||
@@ -628,6 +633,11 @@
         />
       {:else if currentPage === "traces"}
         <Traces
+          project={selectedProject}
+          selectedRuns={selectedRunRecords}
+        />
+      {:else if currentPage === "verifiers-traces"}
+        <VerifiersTraces
           project={selectedProject}
           selectedRuns={selectedRunRecords}
         />

--- a/trackio/frontend/src/components/BarPlot.svelte
+++ b/trackio/frontend/src/components/BarPlot.svelte
@@ -2,6 +2,10 @@
   import { onMount, tick } from "svelte";
   import embed from "vega-embed";
   import { buildColorSpecKey } from "../lib/dataProcessing.js";
+  import {
+    buildAxisLabelExpression,
+    VEGA_LITE_SCHEMA,
+  } from "../lib/vegaSpec.js";
 
   let {
     data = [],
@@ -90,7 +94,7 @@
     const yTitle = y.includes("/") ? y.split("/").pop() : y;
 
     return {
-      $schema: "https://vega.github.io/schema/vega-lite/v5.json",
+      $schema: VEGA_LITE_SCHEMA,
       width: "container",
       height: fullscreen ? "container" : 250,
       autosize: { type: "fit", contains: "padding" },
@@ -108,7 +112,7 @@
           axis: {
             labelAngle: keys.length > 4 ? -45 : 0,
             labelLimit: 120,
-            labelExpr: `${JSON.stringify(labelByKey)}[datum.value] || datum.value`,
+            labelExpr: buildAxisLabelExpression(labelByKey),
           },
           title: null,
         },

--- a/trackio/frontend/src/components/LinePlot.svelte
+++ b/trackio/frontend/src/components/LinePlot.svelte
@@ -4,6 +4,7 @@
   import * as vega from "vega";
   import { buildColorSpecKey } from "../lib/dataProcessing.js";
   import { visibleLegendEntries } from "../lib/legend.js";
+  import { VEGA_LITE_SCHEMA } from "../lib/vegaSpec.js";
 
   let {
     data = [],
@@ -263,7 +264,7 @@
     }
 
     return {
-      $schema: "https://vega.github.io/schema/vega-lite/v5.json",
+      $schema: VEGA_LITE_SCHEMA,
       width: "container",
       height: fullscreen ? "container" : 250,
       autosize: { type: "fit", contains: "padding" },

--- a/trackio/frontend/src/components/Navbar.svelte
+++ b/trackio/frontend/src/components/Navbar.svelte
@@ -11,6 +11,7 @@
     { id: "metrics", label: "Metrics" },
     { id: "system", label: "System Metrics" },
     { id: "traces", label: "Traces" },
+    { id: "verifiers-traces", label: "Verifiers" },
     { id: "media", label: "Media & Tables" },
     { id: "reports", label: "Alerts & Reports" },
     { id: "runs", label: "Runs" },

--- a/trackio/frontend/src/lib/api.js
+++ b/trackio/frontend/src/lib/api.js
@@ -117,9 +117,9 @@ export async function getTraces(project, run, options = {}) {
   return await callApi("/get_traces", params);
 }
 
-export async function getTraceSteps(project, run) {
-  const params = { project, ...normalizeRun(run) };
-  if (await isStaticMode()) return staticApi.getTraceSteps(project, run);
+export async function getTraceSteps(project, run, options = {}) {
+  const params = { project, ...normalizeRun(run), ...options };
+  if (await isStaticMode()) return staticApi.getTraceSteps(project, run, options);
   return await callApi("/get_trace_steps", params);
 }
 

--- a/trackio/frontend/src/lib/router.js
+++ b/trackio/frontend/src/lib/router.js
@@ -23,6 +23,8 @@ export function getPageFromPath() {
       return "system";
     case "traces":
       return "traces";
+    case "verifiers":
+      return "verifiers-traces";
     case "media":
       return "media";
     case "reports":
@@ -47,6 +49,7 @@ export function navigateTo(page) {
   const pathMap = {
     metrics: "/",
     traces: "/traces",
+    "verifiers-traces": "/verifiers",
     system: "/system",
     media: "/media",
     reports: "/reports",

--- a/trackio/frontend/src/lib/router.test.js
+++ b/trackio/frontend/src/lib/router.test.js
@@ -35,6 +35,9 @@ describe("getPageFromPath without a base prefix", () => {
     expect(getPageFromPath()).toBe("metrics");
     setLocation("/traces");
     expect(getPageFromPath()).toBe("traces");
+
+    setLocation("/verifiers");
+    expect(getPageFromPath()).toBe("verifiers-traces");
     setLocation("/system");
     expect(getPageFromPath()).toBe("system");
   });
@@ -62,6 +65,9 @@ describe("navigateTo", () => {
     setLocation("/");
     navigateTo("traces");
     expect(globalThis.window.location.pathname).toBe("/traces");
+
+    navigateTo("verifiers-traces");
+    expect(globalThis.window.location.pathname).toBe("/verifiers");
   });
 
   test("with a base prefix pushes a prefixed path", () => {

--- a/trackio/frontend/src/lib/staticApi.js
+++ b/trackio/frontend/src/lib/staticApi.js
@@ -267,11 +267,13 @@ function parseTraceJsonField(value, fallback) {
   }
 }
 
-export async function getTraceSteps(_project, run) {
+export async function getTraceSteps(_project, run, options = {}) {
   const raw = await getTracesData();
   const counts = new Map();
   for (const row of raw) {
     if (!matchesRun(row, run)) continue;
+    const traceType = row.trace_type || "trackio";
+    if (options.trace_type && traceType !== options.trace_type) continue;
     const step = row.step;
     counts.set(step, (counts.get(step) || 0) + 1);
   }
@@ -547,7 +549,8 @@ export async function getTabAvailability() {
     media,
     reports,
     system: (systemRaw || []).length > 0,
-    traces: (tracesRaw || []).length > 0,
+    traces: (tracesRaw || []).some((row) => (row.trace_type || "trackio") === "trackio"),
+    "verifiers-traces": (tracesRaw || []).some((row) => row.trace_type === "verifiers"),
     files: (files || []).length > 0,
     artifacts: (artifactVersions || []).length > 0,
   };

--- a/trackio/frontend/src/lib/staticApi.js
+++ b/trackio/frontend/src/lib/staticApi.js
@@ -296,6 +296,10 @@ export async function getTraces(_project, run, options = {}) {
       timestamp: row.timestamp,
       messages: parseTraceJsonField(row.messages, []),
       metadata: parseTraceJsonField(row.metadata, {}),
+      trace_type: row.trace_type || "trackio",
+      external_id: row.external_id || null,
+      schema_version: row.schema_version ?? null,
+      payload: parseTraceJsonField(row.payload, null),
     };
     trace._search_text = (row.search_text || `${trace.id} ${trace.key} ${flattenTraceSearchText(trace)}`).toLowerCase();
     return trace;
@@ -304,6 +308,9 @@ export async function getTraces(_project, run, options = {}) {
   let filtered = traces;
   if (options.step != null) {
     filtered = filtered.filter((trace) => trace.step === options.step);
+  }
+  if (options.trace_type) {
+    filtered = filtered.filter((trace) => trace.trace_type === options.trace_type);
   }
   if (options.search && options.search.trim()) {
     const needle = options.search.trim().toLowerCase();

--- a/trackio/frontend/src/lib/vegaSpec.js
+++ b/trackio/frontend/src/lib/vegaSpec.js
@@ -1,0 +1,12 @@
+export const VEGA_LITE_SCHEMA =
+  "https://vega.github.io/schema/vega-lite/v6.json";
+
+export function buildAxisLabelExpression(labelByKey) {
+  const labelLookup = JSON.stringify(labelByKey)
+    .replaceAll("<", "\\u003c")
+    .replaceAll(">", "\\u003e")
+    .replaceAll("&", "\\u0026")
+    .replaceAll("\u2028", "\\u2028")
+    .replaceAll("\u2029", "\\u2029");
+  return `${labelLookup}[datum.value] || datum.value`;
+}

--- a/trackio/frontend/src/lib/vegaSpec.test.js
+++ b/trackio/frontend/src/lib/vegaSpec.test.js
@@ -1,0 +1,56 @@
+import { parse, View } from "vega";
+import { compile } from "vega-lite";
+import { describe, expect, test } from "vitest";
+import {
+  buildAxisLabelExpression,
+  VEGA_LITE_SCHEMA,
+} from "./vegaSpec.js";
+
+describe("Vega chart safety", () => {
+  test("keeps hostile run labels inside an escaped expression string", () => {
+    const expression = buildAxisLabelExpression({
+      'run"]; setdata("metrics", []); //': "</script><img src=x onerror=alert(1)>",
+      separators: "line\u2028paragraph\u2029end",
+    });
+
+    expect(expression).not.toContain("<");
+    expect(expression).not.toContain(">");
+    expect(expression).not.toContain("&");
+    expect(expression).not.toContain("\u2028");
+    expect(expression).not.toContain("\u2029");
+    expect(expression).toContain("\\u003c/script\\u003e");
+  });
+
+  test("Vega 6 compiles and evaluates representative Trackio chart values", async () => {
+    const hostileKey = 'run"]; setdata("metrics", []); //';
+    const hostileLabel = "</script><img src=x onerror=alert(1)>";
+    const spec = {
+      $schema: VEGA_LITE_SCHEMA,
+      data: {
+        values: [{ key: hostileKey, label: hostileLabel, value: 0.5 }],
+      },
+      mark: { type: "bar" },
+      encoding: {
+        x: {
+          field: "key",
+          type: "nominal",
+          axis: {
+            labelExpr: buildAxisLabelExpression({
+              [hostileKey]: hostileLabel,
+            }),
+          },
+        },
+        y: { field: "value", type: "quantitative" },
+        tooltip: [
+          { field: "label", type: "nominal" },
+          { field: "value", type: "quantitative" },
+        ],
+      },
+    };
+
+    const { spec: compiled } = compile(spec);
+    const view = new View(parse(compiled), { renderer: "none" });
+    await expect(view.runAsync()).resolves.toBe(view);
+    view.finalize();
+  });
+});

--- a/trackio/frontend/src/pages/SystemMetrics.svelte
+++ b/trackio/frontend/src/pages/SystemMetrics.svelte
@@ -512,9 +512,9 @@
       <pre><code>{'import trackio\n\n# CPU/system metrics auto-enable when psutil is installed:\nrun = trackio.init(project="my-project")\n\n# Or explicitly enable/disable them:\nrun = trackio.init(project="my-project", auto_log_cpu=True)\n\n# Manually log at any time:\ntrackio.log_cpu()\ntrackio.log_gpu()'}</code></pre>
       <p><strong>Setup:</strong></p>
       <ul>
-        <li><strong>CPU/system metrics:</strong> <code>pip install trackio[cpu]</code> (requires <code>psutil</code>)</li>
-        <li><strong>NVIDIA GPU:</strong> <code>pip install trackio[gpu]</code> (requires <code>nvidia-ml-py</code>)</li>
-        <li><strong>Apple Silicon:</strong> <code>pip install trackio[apple-gpu]</code> (requires <code>psutil</code>)</li>
+        <li><strong>CPU/system metrics:</strong> <code>pip install carbonteq-trackio[cpu]</code> (requires <code>psutil</code>)</li>
+        <li><strong>NVIDIA GPU:</strong> <code>pip install carbonteq-trackio[gpu]</code> (requires <code>nvidia-ml-py</code>)</li>
+        <li><strong>Apple Silicon:</strong> <code>pip install carbonteq-trackio[apple-gpu]</code> (requires <code>psutil</code>)</li>
       </ul>
     </div>
   {:else}

--- a/trackio/frontend/src/pages/Traces.svelte
+++ b/trackio/frontend/src/pages/Traces.svelte
@@ -80,7 +80,9 @@
     }
     try {
       const results = await Promise.all(
-        selectedRuns.map((run) => getTraceSteps(project, run)),
+        selectedRuns.map((run) =>
+          getTraceSteps(project, run, { trace_type: "trackio" }),
+        ),
       );
       if (requestId !== summaryRequestId) return;
       const merged = new Map();
@@ -127,6 +129,7 @@
             step: stepNum,
             limit: perRunLimit,
             offset: perRunOffset,
+            trace_type: "trackio",
           });
           return runTraces.map((trace) => normalizeTrace(trace, run.name));
         }),

--- a/trackio/frontend/src/pages/VerifiersTraces.svelte
+++ b/trackio/frontend/src/pages/VerifiersTraces.svelte
@@ -378,7 +378,7 @@
                 <h3>{activeBranchIndex === selectedBranches.length - 1 ? "Final trajectory" : `Branch ${activeBranchIndex + 1}`}</h3>
                 {#if selectedBranches.length > 1}
                   <div class="branch-tabs" aria-label="Rollout branches">
-                    {#each selectedBranches as branch, index}
+                    {#each selectedBranches as _, index}
                       <button
                         class:active={index === activeBranchIndex}
                         onclick={() => (activeBranchIndex = index)}

--- a/trackio/frontend/src/pages/VerifiersTraces.svelte
+++ b/trackio/frontend/src/pages/VerifiersTraces.svelte
@@ -1,0 +1,458 @@
+<script>
+  import LoadingTrackio from "../components/LoadingTrackio.svelte";
+  import { getTraces, getTraceSteps } from "../lib/api.js";
+  import { openRunDetail } from "../lib/router.js";
+
+  let { project = null, selectedRuns = [] } = $props();
+
+  const PAGE_SIZE = 25;
+  let loading = $state(false);
+  let search = $state("");
+  let page = $state(0);
+  let traces = $state([]);
+  let selectedId = $state(null);
+  let activeBranchIndex = $state(0);
+  let totalCount = $state(0);
+  let loadId = 0;
+
+  function runsKey(runs) {
+    return runs.map((run) => `${run.id || ""}:${run.name || ""}`).join("|");
+  }
+
+  function textContent(content) {
+    if (typeof content === "string") return content;
+    if (!Array.isArray(content)) return "";
+    return content
+      .map((part) => part?.text || part?.content || "")
+      .filter(Boolean)
+      .join("\n");
+  }
+
+  function totalReward(payload, metadata) {
+    if (typeof metadata?.reward === "number") return metadata.reward;
+    return Object.values(payload?.rewards || {}).reduce(
+      (sum, value) => sum + (typeof value === "number" ? value : 0),
+      0,
+    );
+  }
+
+  function traceStatus(payload, metadata) {
+    if ((payload?.errors || []).length) return "error";
+    if (metadata?.is_truncated) return "truncated";
+    if (payload?.is_completed || metadata?.is_completed) return "complete";
+    return "incomplete";
+  }
+
+  function normalizeTrace(trace, runLabel) {
+    const payload = trace.payload || {};
+    const messages = Array.isArray(trace.messages) ? trace.messages : [];
+    const user = messages.find((message) => message?.role === "user");
+    return {
+      ...trace,
+      payload,
+      run: trace.run || runLabel,
+      prompt: textContent(user?.content) || "(no prompt)",
+      model: trace.metadata?.model || payload.agent?.model || "—",
+      task: trace.metadata?.task_type || payload.task?.type || "—",
+      reward: totalReward(payload, trace.metadata),
+      status: traceStatus(payload, trace.metadata),
+    };
+  }
+
+  async function load() {
+    const requestId = ++loadId;
+    if (!project || selectedRuns.length === 0) {
+      traces = [];
+      selectedId = null;
+      totalCount = 0;
+      return;
+    }
+    loading = true;
+    try {
+      const counts = await Promise.all(
+        selectedRuns.map((run) =>
+          getTraceSteps(project, run, { trace_type: "verifiers" }),
+        ),
+      );
+      const offset = page * PAGE_SIZE;
+      const singleRun = selectedRuns.length === 1;
+      const batches = await Promise.all(
+        selectedRuns.map(async (run) => {
+          const rows = await getTraces(project, run, {
+            trace_type: "verifiers",
+            search: search.trim(),
+            sort: "request_time_desc",
+            limit: singleRun ? PAGE_SIZE : offset + PAGE_SIZE,
+            offset: singleRun ? offset : 0,
+          });
+          return rows.map((trace) => normalizeTrace(trace, run.name));
+        }),
+      );
+      if (requestId !== loadId) return;
+      totalCount = counts.reduce((sum, result) => sum + (result?.total || 0), 0);
+      let merged = batches
+        .flat()
+        .sort((a, b) => String(b.timestamp || "").localeCompare(String(a.timestamp || "")));
+      if (!singleRun) merged = merged.slice(offset, offset + PAGE_SIZE);
+      traces = merged;
+      if (!traces.some((trace) => trace.id === selectedId)) {
+        selectedId = traces[0]?.id || null;
+      }
+    } catch (error) {
+      if (requestId === loadId) {
+        console.error("Failed to load Verifiers traces:", error);
+        traces = [];
+      }
+    } finally {
+      if (requestId === loadId) loading = false;
+    }
+  }
+
+  let lastScope = "";
+  let lastSearch = "";
+  $effect(() => {
+    const scope = `${project || ""}:${runsKey(selectedRuns)}`;
+    const query = search.trim();
+    if (scope !== lastScope || query !== lastSearch) {
+      page = 0;
+      lastScope = scope;
+      lastSearch = query;
+    }
+    const timeout = setTimeout(load, 150);
+    return () => clearTimeout(timeout);
+  });
+
+  let selected = $derived(traces.find((trace) => trace.id === selectedId) || null);
+  let totalPages = $derived(Math.max(1, Math.ceil(totalCount / PAGE_SIZE)));
+
+  function traceBranches(payload) {
+    const nodes = Array.isArray(payload?.nodes) ? payload.nodes : [];
+    if (!nodes.length) return [];
+    const parents = new Set(
+      nodes.map((node) => node?.parent).filter((parent) => Number.isInteger(parent)),
+    );
+    return nodes
+      .map((_, index) => index)
+      .filter((index) => !parents.has(index))
+      .map((leaf) => {
+        const path = [];
+        const seen = new Set();
+        let index = leaf;
+        while (Number.isInteger(index) && nodes[index] && !seen.has(index)) {
+          seen.add(index);
+          path.unshift(index);
+          index = nodes[index]?.parent;
+        }
+        return {
+          leaf,
+          indices: path,
+          messages: path.map((nodeIndex) => nodes[nodeIndex]?.message).filter(Boolean),
+        };
+      });
+  }
+
+  let selectedBranches = $derived(selected ? traceBranches(selected.payload) : []);
+  let activeBranch = $derived(selectedBranches[activeBranchIndex] || null);
+  let displayedMessages = $derived(
+    activeBranch?.messages?.length ? activeBranch.messages : (selected?.messages || []),
+  );
+
+  let previousSelectedId = null;
+  $effect(() => {
+    if (selectedId !== previousSelectedId) {
+      activeBranchIndex = Math.max(0, selectedBranches.length - 1);
+      previousSelectedId = selectedId;
+    }
+  });
+
+  function branchCount(payload) {
+    const nodes = payload?.nodes || [];
+    const parents = new Set(
+      nodes.map((node) => node?.parent).filter((parent) => Number.isInteger(parent)),
+    );
+    return nodes.filter((_, index) => !parents.has(index)).length;
+  }
+
+  function duration(span) {
+    if (typeof span?.duration === "number") return span.duration;
+    if (typeof span?.start === "number" && typeof span?.end === "number") {
+      return span.end - span.start;
+    }
+    return null;
+  }
+
+  function formatDuration(span) {
+    const seconds = duration(span);
+    if (seconds == null) return "—";
+    if (seconds < 1) return `${Math.round(seconds * 1000)} ms`;
+    return `${seconds.toFixed(2)} s`;
+  }
+
+  function formatNumber(value) {
+    return typeof value === "number" ? value.toLocaleString() : "—";
+  }
+
+  function entries(value) {
+    return Object.entries(value || {});
+  }
+
+  function phases(payload) {
+    const timing = payload?.timing || {};
+    return ["boot", "setup", "generation", "finalize", "scoring"].map((name) => ({
+      name,
+      value: timing[name],
+    }));
+  }
+
+  function stopRowClick(event) {
+    event.stopPropagation();
+  }
+</script>
+
+<div class="verifiers-page">
+  {#if !project || selectedRuns.length === 0}
+    <div class="empty-state">
+      <h2>Open Verifiers rollouts</h2>
+      <p>Select one or more experiment runs in the sidebar.</p>
+    </div>
+  {:else}
+    <header class="page-header">
+      <div>
+        <h1>Verifiers rollouts</h1>
+        <p>Inspect task trajectories, scoring, model calls, and environment timing.</p>
+      </div>
+      <div class="header-count">{totalCount} rollout{totalCount === 1 ? "" : "s"}</div>
+    </header>
+
+    <div class="toolbar">
+      <input bind:value={search} placeholder="Search prompts, model, task, or metadata" />
+    </div>
+
+    {#if loading && traces.length === 0}
+      <LoadingTrackio />
+    {:else if traces.length === 0}
+      <div class="empty-state"><h2>No Verifiers rollouts found</h2></div>
+    {:else}
+      <div class="workspace" class:dim={loading}>
+        <aside class="rollout-list">
+          {#each traces as trace (trace.id)}
+            <button
+              class="rollout-card"
+              class:active={trace.id === selectedId}
+              onclick={() => (selectedId = trace.id)}
+            >
+              <div class="card-topline">
+                <span class="status" data-status={trace.status}>{trace.status}</span>
+                <span class="reward">reward {trace.reward.toFixed(3)}</span>
+              </div>
+              <div class="task">{trace.task}</div>
+              <div class="prompt">{trace.prompt}</div>
+              <div class="card-meta">
+                <span>{trace.model}</span>
+                <span>step {trace.step ?? "—"}</span>
+              </div>
+            </button>
+          {/each}
+        </aside>
+
+        {#if selected}
+          <main class="rollout-detail">
+            <div class="detail-heading">
+              <div>
+                <div class="eyebrow">{selected.task}</div>
+                <h2>{selected.external_id || selected.id}</h2>
+              </div>
+              <button
+                class="experiment-link"
+                onclick={(event) => {
+                  stopRowClick(event);
+                  openRunDetail(selected.run, selected.run_id);
+                }}
+              >Open experiment ↗</button>
+            </div>
+
+            <section class="summary-grid">
+              <div><span>Status</span><strong>{selected.status}</strong></div>
+              <div><span>Total reward</span><strong>{selected.reward.toFixed(3)}</strong></div>
+              <div><span>Stop condition</span><strong>{selected.payload.stop_condition || "—"}</strong></div>
+              <div><span>Branches</span><strong>{branchCount(selected.payload)}</strong></div>
+              <div><span>Model calls</span><strong>{selected.payload.calls?.length || 0}</strong></div>
+              <div><span>Model</span><strong>{selected.model}</strong></div>
+            </section>
+
+            <section>
+              <div class="section-heading">
+                <h3>{activeBranchIndex === selectedBranches.length - 1 ? "Final trajectory" : `Branch ${activeBranchIndex + 1}`}</h3>
+                {#if selectedBranches.length > 1}
+                  <div class="branch-tabs" aria-label="Rollout branches">
+                    {#each selectedBranches as branch, index}
+                      <button
+                        class:active={index === activeBranchIndex}
+                        onclick={() => (activeBranchIndex = index)}
+                      >{index === selectedBranches.length - 1 ? "Final" : `Branch ${index + 1}`}</button>
+                    {/each}
+                  </div>
+                {/if}
+              </div>
+              <div class="trajectory">
+                {#each displayedMessages as message}
+                  <article class="message" data-role={message.role || "unknown"}>
+                    <div class="message-role">{message.role || "message"}</div>
+                    {#if textContent(message.content)}
+                      <pre>{textContent(message.content)}</pre>
+                    {/if}
+                    {#if message.tool_calls?.length}
+                      <div class="tool-calls">
+                        {#each message.tool_calls as call}
+                          <div class="tool-call">
+                            <strong>{call.function?.name || call.name || "tool"}</strong>
+                            <code>{call.function?.arguments || call.arguments || ""}</code>
+                          </div>
+                        {/each}
+                      </div>
+                    {/if}
+                  </article>
+                {/each}
+              </div>
+            </section>
+
+            {#if selected.payload.tools?.length}
+              <section>
+                <h3>Available tools</h3>
+                <div class="tool-inventory">
+                  {#each selected.payload.tools as tool}
+                    <article>
+                      <strong>{tool.function?.name || tool.name || "tool"}</strong>
+                      {#if tool.function?.description || tool.description}
+                        <p>{tool.function?.description || tool.description}</p>
+                      {/if}
+                    </article>
+                  {/each}
+                </div>
+              </section>
+            {/if}
+
+            <section class="two-column">
+              <div>
+                <h3>Rewards</h3>
+                <div class="kv-list">
+                  {#each entries(selected.payload.rewards) as [name, value]}
+                    <div><span>{name}</span><strong>{value}</strong></div>
+                  {:else}<p class="muted">No reward components.</p>{/each}
+                </div>
+              </div>
+              <div>
+                <h3>Environment metrics</h3>
+                <div class="kv-list">
+                  {#each entries(selected.payload.metrics) as [name, value]}
+                    <div><span>{name}</span><strong>{value}</strong></div>
+                  {:else}<p class="muted">No environment metrics.</p>{/each}
+                </div>
+              </div>
+            </section>
+
+            <section>
+              <h3>Model calls</h3>
+              <div class="calls">
+                {#each selected.payload.calls || [] as call, index}
+                  <article class="call-card">
+                    <div class="call-heading">
+                      <strong>Call {index + 1}</strong>
+                      <span>{call.finish_reason || (call.error ? "error" : "—")}</span>
+                    </div>
+                    <div class="call-grid">
+                      <div><span>Endpoint</span><strong>{call.endpoint || "—"}</strong></div>
+                      <div><span>Duration</span><strong>{formatDuration(call.time)}</strong></div>
+                      <div><span>Input tokens</span><strong>{formatNumber(call.usage?.prompt_tokens)}</strong></div>
+                      <div><span>Output tokens</span><strong>{formatNumber(call.usage?.completion_tokens)}</strong></div>
+                    </div>
+                    {#if call.error}<div class="error-panel">{call.error.message || call.error}</div>{/if}
+                  </article>
+                {:else}<p class="muted">No model calls recorded.</p>{/each}
+              </div>
+            </section>
+
+            <section>
+              <h3>Rollout timing</h3>
+              <div class="phase-grid">
+                {#each phases(selected.payload) as phase}
+                  <div><span>{phase.name}</span><strong>{formatDuration(phase.value)}</strong></div>
+                {/each}
+              </div>
+            </section>
+
+            {#if selected.payload.errors?.length}
+              <section>
+                <h3>Errors</h3>
+                {#each selected.payload.errors as error}
+                  <div class="error-panel"><strong>{error.type || "Error"}</strong><p>{error.message || ""}</p></div>
+                {/each}
+              </section>
+            {/if}
+          </main>
+        {/if}
+      </div>
+
+      <div class="pagination">
+        <button disabled={page === 0 || loading} onclick={() => (page -= 1)}>← Previous</button>
+        <span>Page {page + 1} of {totalPages}</span>
+        <button disabled={page >= totalPages - 1 || loading} onclick={() => (page += 1)}>Next →</button>
+      </div>
+    {/if}
+  {/if}
+</div>
+
+<style>
+  .verifiers-page { padding: 24px; overflow-y: auto; flex: 1; background: var(--background-fill-secondary, #f7f8fa); color: var(--body-text-color, #18202a); }
+  .page-header, .detail-heading, .card-topline, .card-meta, .call-heading, .pagination, .section-heading { display: flex; align-items: center; justify-content: space-between; gap: 12px; }
+  .page-header h1 { margin: 0; font-size: 24px; }
+  .page-header p, .muted { color: var(--body-text-color-subdued, #667085); }
+  .header-count { font-weight: 600; }
+  .toolbar { margin: 18px 0; }
+  .toolbar input { width: 100%; padding: 11px 14px; border: 1px solid var(--border-color-primary, #d9dee7); border-radius: 8px; background: var(--background-fill-primary, white); color: inherit; }
+  .workspace { display: grid; grid-template-columns: minmax(280px, 360px) minmax(0, 1fr); min-height: 620px; border: 1px solid var(--border-color-primary, #d9dee7); border-radius: 10px; overflow: hidden; background: var(--background-fill-primary, white); transition: opacity .15s; }
+  .workspace.dim { opacity: .65; }
+  .rollout-list { border-right: 1px solid var(--border-color-primary, #d9dee7); overflow-y: auto; max-height: 78vh; background: var(--background-fill-secondary, #f8fafc); }
+  .rollout-card { width: 100%; padding: 14px; border: 0; border-bottom: 1px solid var(--border-color-primary, #e6eaf0); background: transparent; color: inherit; text-align: left; cursor: pointer; }
+  .rollout-card:hover, .rollout-card.active { background: var(--background-fill-primary, white); }
+  .rollout-card.active { box-shadow: inset 3px 0 0 var(--color-accent, #6d5efc); }
+  .status { padding: 3px 8px; border-radius: 999px; font-size: 11px; font-weight: 700; text-transform: uppercase; background: #eef2f6; }
+  .status[data-status="complete"] { background: #dcfce7; color: #166534; }
+  .status[data-status="error"] { background: #fee2e2; color: #991b1b; }
+  .status[data-status="truncated"] { background: #fef3c7; color: #92400e; }
+  .reward { font-variant-numeric: tabular-nums; font-size: 12px; }
+  .task { margin-top: 10px; font-weight: 650; }
+  .prompt { margin: 6px 0 10px; color: var(--body-text-color-subdued, #667085); line-height: 1.4; display: -webkit-box; -webkit-line-clamp: 3; -webkit-box-orient: vertical; overflow: hidden; }
+  .card-meta { font-size: 11px; color: var(--body-text-color-subdued, #667085); }
+  .rollout-detail { padding: 22px; overflow-y: auto; max-height: 78vh; }
+  .eyebrow { color: var(--body-text-color-subdued, #667085); font-size: 12px; font-weight: 700; text-transform: uppercase; letter-spacing: .06em; }
+  .detail-heading h2 { margin: 4px 0 0; font-size: 16px; font-family: ui-monospace, monospace; word-break: break-all; }
+  .experiment-link, .pagination button { border: 1px solid var(--border-color-primary, #d9dee7); border-radius: 7px; padding: 8px 12px; background: var(--background-fill-primary, white); color: inherit; cursor: pointer; }
+  section { margin-top: 24px; }
+  section h3 { margin: 0 0 10px; font-size: 15px; }
+  .section-heading h3 { margin: 0; }
+  .branch-tabs { display: flex; flex-wrap: wrap; justify-content: flex-end; gap: 6px; }
+  .branch-tabs button { border: 1px solid var(--border-color-primary, #d9dee7); border-radius: 999px; padding: 5px 10px; background: transparent; color: inherit; cursor: pointer; font-size: 12px; }
+  .branch-tabs button.active { border-color: var(--color-accent, #6d5efc); background: color-mix(in srgb, var(--color-accent, #6d5efc) 12%, transparent); }
+  .summary-grid, .phase-grid, .call-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(130px, 1fr)); gap: 10px; }
+  .summary-grid > div, .phase-grid > div, .call-grid > div { border: 1px solid var(--border-color-primary, #e2e6ec); border-radius: 7px; padding: 10px; display: flex; flex-direction: column; gap: 5px; }
+  .summary-grid span, .phase-grid span, .call-grid span { color: var(--body-text-color-subdued, #667085); font-size: 11px; text-transform: uppercase; }
+  .trajectory, .calls { display: flex; flex-direction: column; gap: 10px; }
+  .message, .call-card { border: 1px solid var(--border-color-primary, #e2e6ec); border-radius: 8px; padding: 12px; }
+  .message-role { color: var(--body-text-color-subdued, #667085); font-size: 11px; font-weight: 700; text-transform: uppercase; margin-bottom: 7px; }
+  .message pre { margin: 0; white-space: pre-wrap; word-break: break-word; font: inherit; line-height: 1.5; }
+  .tool-calls { margin-top: 10px; display: grid; gap: 8px; }
+  .tool-call { padding: 9px; border-radius: 6px; background: var(--background-fill-secondary, #f6f8fa); display: flex; flex-direction: column; gap: 5px; }
+  .tool-call code { white-space: pre-wrap; word-break: break-word; }
+  .tool-inventory { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 10px; }
+  .tool-inventory article { border: 1px solid var(--border-color-primary, #e2e6ec); border-radius: 8px; padding: 12px; }
+  .tool-inventory p { margin: 6px 0 0; color: var(--body-text-color-subdued, #667085); line-height: 1.4; }
+  .two-column { display: grid; grid-template-columns: 1fr 1fr; gap: 18px; }
+  .kv-list > div { display: flex; justify-content: space-between; padding: 8px 0; border-bottom: 1px solid var(--border-color-primary, #edf0f3); }
+  .call-heading { margin-bottom: 10px; }
+  .error-panel { margin-top: 10px; padding: 10px; border: 1px solid #fecaca; border-radius: 7px; background: #fff1f2; color: #991b1b; white-space: pre-wrap; }
+  .pagination { justify-content: center; margin-top: 16px; }
+  .pagination button:disabled { opacity: .45; cursor: not-allowed; }
+  .empty-state { padding: 48px 24px; }
+  @media (max-width: 980px) { .workspace { grid-template-columns: 1fr; } .rollout-list { border-right: 0; border-bottom: 1px solid var(--border-color-primary, #d9dee7); max-height: 320px; } .rollout-detail { max-height: none; } .two-column { grid-template-columns: 1fr; } }
+</style>

--- a/trackio/frontend/src/pages/VerifiersTraces.svelte
+++ b/trackio/frontend/src/pages/VerifiersTraces.svelte
@@ -1,6 +1,6 @@
 <script>
   import LoadingTrackio from "../components/LoadingTrackio.svelte";
-  import { getTraces, getTraceSteps } from "../lib/api.js";
+  import { getLogs, getTraces, getTraceSteps } from "../lib/api.js";
   import { openRunDetail } from "../lib/router.js";
 
   let { project = null, selectedRuns = [] } = $props();
@@ -10,6 +10,7 @@
   let search = $state("");
   let page = $state(0);
   let traces = $state([]);
+  let evalResults = $state({});
   let selectedId = $state(null);
   let activeBranchIndex = $state(0);
   let totalCount = $state(0);
@@ -17,6 +18,20 @@
 
   function runsKey(runs) {
     return runs.map((run) => `${run.id || ""}:${run.name || ""}`).join("|");
+  }
+
+  function runKey(run) {
+    return run?.id || run?.name || String(run || "");
+  }
+
+  function summarizeEvalLogs(logs) {
+    const result = {};
+    for (const row of logs || []) {
+      for (const [key, value] of Object.entries(row)) {
+        if (key.startsWith("eval/") && typeof value === "number") result[key] = value;
+      }
+    }
+    return result;
   }
 
   function textContent(content) {
@@ -63,17 +78,28 @@
     const requestId = ++loadId;
     if (!project || selectedRuns.length === 0) {
       traces = [];
+      evalResults = {};
       selectedId = null;
       totalCount = 0;
       return;
     }
     loading = true;
     try {
-      const counts = await Promise.all(
+      const [counts, runLogs] = await Promise.all([
+        Promise.all(
         selectedRuns.map((run) =>
           getTraceSteps(project, run, { trace_type: "verifiers" }),
         ),
-      );
+        ),
+        Promise.all(
+          selectedRuns.map(async (run) => ({
+            key: runKey(run),
+            metrics: summarizeEvalLogs(
+              await getLogs(project, run, { scalar_only: true }),
+            ),
+          })),
+        ),
+      ]);
       const offset = page * PAGE_SIZE;
       const singleRun = selectedRuns.length === 1;
       const batches = await Promise.all(
@@ -89,6 +115,9 @@
         }),
       );
       if (requestId !== loadId) return;
+      evalResults = Object.fromEntries(
+        runLogs.map(({ key, metrics }) => [key, metrics]),
+      );
       totalCount = counts.reduce((sum, result) => sum + (result?.total || 0), 0);
       let merged = batches
         .flat()
@@ -123,6 +152,12 @@
   });
 
   let selected = $derived(traces.find((trace) => trace.id === selectedId) || null);
+  let selectedEvalResult = $derived(
+    selected
+      ? (evalResults[selected.run_id] || evalResults[selected.run] || {})
+      : {},
+  );
+  let hasEvalResult = $derived(Object.keys(selectedEvalResult).length > 0);
   let totalPages = $derived(Math.max(1, Math.ceil(totalCount / PAGE_SIZE)));
 
   function traceBranches(payload) {
@@ -190,6 +225,24 @@
 
   function formatNumber(value) {
     return typeof value === "number" ? value.toLocaleString() : "—";
+  }
+
+  function formatDecimal(value, digits = 3) {
+    return typeof value === "number" ? value.toFixed(digits) : "—";
+  }
+
+  function formatPercent(value) {
+    return typeof value === "number" ? `${(value * 100).toFixed(1)}%` : "—";
+  }
+
+  function formatCost(value) {
+    return typeof value === "number" ? `$${value.toFixed(4)}` : "—";
+  }
+
+  function prefixedMetrics(result, prefix) {
+    return Object.entries(result)
+      .filter(([key]) => key.startsWith(prefix))
+      .map(([key, value]) => [key.slice(prefix.length), value]);
   }
 
   function entries(value) {
@@ -279,6 +332,46 @@
               <div><span>Model calls</span><strong>{selected.payload.calls?.length || 0}</strong></div>
               <div><span>Model</span><strong>{selected.model}</strong></div>
             </section>
+
+            {#if hasEvalResult}
+              <section class="eval-result">
+                <div class="section-heading">
+                  <div>
+                    <div class="eyebrow">Producing run</div>
+                    <h3>Evaluation result</h3>
+                  </div>
+                  <span class="result-scope">aggregate across {formatNumber(selectedEvalResult["eval/rollouts"])} rollouts</span>
+                </div>
+                <div class="result-grid">
+                  <div><span>Mean reward</span><strong>{formatDecimal(selectedEvalResult["eval/mean_reward"])}</strong></div>
+                  <div><span>Completed</span><strong>{formatNumber(selectedEvalResult["eval/completed"])} / {formatNumber(selectedEvalResult["eval/rollouts"])}</strong></div>
+                  <div><span>Error rate</span><strong>{formatPercent(selectedEvalResult["eval/error_rate"])}</strong></div>
+                  <div><span>Truncated</span><strong>{formatPercent(selectedEvalResult["eval/truncated_rollout_rate"])}</strong></div>
+                  <div><span>Call p95</span><strong>{formatDecimal(selectedEvalResult["eval/model_call_latency_p95_seconds"], 2)} s</strong></div>
+                  <div><span>Total tokens</span><strong>{formatNumber((selectedEvalResult["eval/input_tokens"] || 0) + (selectedEvalResult["eval/output_tokens"] || 0))}</strong></div>
+                  <div><span>Provider cost</span><strong>{formatCost(selectedEvalResult["eval/provider_cost"])}</strong></div>
+                  <div><span>Trace sync</span><strong>{selectedEvalResult["eval/trace_sync_complete"] === 1 ? "complete" : "partial"}</strong></div>
+                </div>
+                <div class="two-column result-components">
+                  <div>
+                    <h4>Average verifier rewards</h4>
+                    <div class="kv-list">
+                      {#each prefixedMetrics(selectedEvalResult, "eval/reward/") as [name, value]}
+                        <div><span>{name}</span><strong>{formatDecimal(value)}</strong></div>
+                      {:else}<p class="muted">No aggregate reward components.</p>{/each}
+                    </div>
+                  </div>
+                  <div>
+                    <h4>Average environment metrics</h4>
+                    <div class="kv-list">
+                      {#each prefixedMetrics(selectedEvalResult, "eval/environment_metric/") as [name, value]}
+                        <div><span>{name}</span><strong>{formatDecimal(value)}</strong></div>
+                      {:else}<p class="muted">No aggregate environment metrics.</p>{/each}
+                    </div>
+                  </div>
+                </div>
+              </section>
+            {/if}
 
             <section>
               <div class="section-heading">
@@ -434,9 +527,15 @@
   .branch-tabs { display: flex; flex-wrap: wrap; justify-content: flex-end; gap: 6px; }
   .branch-tabs button { border: 1px solid var(--border-color-primary, #d9dee7); border-radius: 999px; padding: 5px 10px; background: transparent; color: inherit; cursor: pointer; font-size: 12px; }
   .branch-tabs button.active { border-color: var(--color-accent, #6d5efc); background: color-mix(in srgb, var(--color-accent, #6d5efc) 12%, transparent); }
-  .summary-grid, .phase-grid, .call-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(130px, 1fr)); gap: 10px; }
-  .summary-grid > div, .phase-grid > div, .call-grid > div { border: 1px solid var(--border-color-primary, #e2e6ec); border-radius: 7px; padding: 10px; display: flex; flex-direction: column; gap: 5px; }
-  .summary-grid span, .phase-grid span, .call-grid span { color: var(--body-text-color-subdued, #667085); font-size: 11px; text-transform: uppercase; }
+  .summary-grid, .phase-grid, .call-grid, .result-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(130px, 1fr)); gap: 10px; }
+  .summary-grid > div, .phase-grid > div, .call-grid > div, .result-grid > div { border: 1px solid var(--border-color-primary, #e2e6ec); border-radius: 7px; padding: 10px; display: flex; flex-direction: column; gap: 5px; }
+  .summary-grid span, .phase-grid span, .call-grid span, .result-grid span { color: var(--body-text-color-subdued, #667085); font-size: 11px; text-transform: uppercase; }
+  .eval-result { padding: 16px; border: 1px solid color-mix(in srgb, var(--color-accent, #6d5efc) 35%, var(--border-color-primary, #e2e6ec)); border-radius: 10px; background: color-mix(in srgb, var(--color-accent, #6d5efc) 4%, var(--background-fill-primary, white)); }
+  .eval-result .section-heading { margin-bottom: 12px; }
+  .eval-result h3 { margin: 3px 0 0; }
+  .result-scope { color: var(--body-text-color-subdued, #667085); font-size: 12px; }
+  .result-components { margin-top: 14px; }
+  .result-components h4 { margin: 0 0 6px; font-size: 13px; }
   .trajectory, .calls { display: flex; flex-direction: column; gap: 10px; }
   .message, .call-card { border: 1px solid var(--border-color-primary, #e2e6ec); border-radius: 8px; padding: 12px; }
   .message-role { color: var(--body-text-color-subdued, #667085); font-size: 11px; font-weight: 700; text-transform: uppercase; margin-bottom: 7px; }

--- a/trackio/imports.py
+++ b/trackio/imports.py
@@ -198,7 +198,9 @@ def import_tf_events(
         from tbparse import SummaryReader
     except ImportError:
         raise ImportError(
-            "The `tbparse` package is not installed but is required for `import_tf_events`. Please install trackio with the `tensorboard` extra: `pip install trackio[tensorboard]`."
+            "The `tbparse` package is not installed but is required for `import_tf_events`. "
+            "Please install the CarbonTeq Trackio distribution with the `tensorboard` extra: "
+            "`pip install carbonteq-trackio[tensorboard]`."
         )
 
     if SQLiteStorage.get_runs(project):

--- a/trackio/lifecycle.py
+++ b/trackio/lifecycle.py
@@ -1,0 +1,24 @@
+"""Normalize the lifecycle values a run records as metrics.
+
+A run's status and timings are logged as ordinary metric rows rather than as
+run-level columns. Reading them per run costs a request each, so both storage
+providers answer for a whole project at once and share this shaping so the two
+cannot drift apart.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+LIFECYCLE_KEYS = (
+    "run/status",
+    "run/started_at",
+    "run/finished_at",
+    "run/error_type",
+    "run/error_message",
+)
+
+
+def lifecycle_row(values: dict[str, Any]) -> dict[str, Any]:
+    """Keep the lifecycle fields of one metric row, dropping everything else."""
+    return {key: values[key] for key in LIFECYCLE_KEYS if key in values}

--- a/trackio/pending_uploads.py
+++ b/trackio/pending_uploads.py
@@ -70,6 +70,7 @@ def replay_pending_uploads(
     project: str,
     *,
     predict: Callable[..., Any],
+    artifact_blob_uploader: Callable[[str, str, Path], bool] | None = None,
     hf_token: str | None,
     warn_missing: Callable[[int, str], None],
     verbose: bool = False,
@@ -93,14 +94,30 @@ def replay_pending_uploads(
         )
         SQLiteStorage.clear_pending_uploads(project, media["ids"])
     for proj, group in grouped["artifact_blobs"].items():
+        legacy_entries: list[dict] = []
+        legacy_ids: list[int] = []
+        if artifact_blob_uploader is not None:
+            for entry, upload_id in zip(group["entries"], group["ids"]):
+                uploaded_file = entry["uploaded_file"]
+                path = Path(uploaded_file["path"])
+                if artifact_blob_uploader(proj, entry["digest"], path):
+                    SQLiteStorage.clear_pending_uploads(project, [upload_id])
+                else:
+                    legacy_entries.append(entry)
+                    legacy_ids.append(upload_id)
+        else:
+            legacy_entries = group["entries"]
+            legacy_ids = group["ids"]
+        if not legacy_entries:
+            continue
         if verbose:
             print(
-                f"  Syncing {len(group['entries'])} artifact blobs for project '{proj}'..."
+                f"  Syncing {len(legacy_entries)} artifact blobs for project '{proj}'..."
             )
         predict(
             api_name="/bulk_upload_artifact_blob",
             project=proj,
-            uploads=group["entries"],
+            uploads=legacy_entries,
             hf_token=hf_token,
         )
-        SQLiteStorage.clear_pending_uploads(project, group["ids"])
+        SQLiteStorage.clear_pending_uploads(project, legacy_ids)

--- a/trackio/remote_client.py
+++ b/trackio/remote_client.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import inspect
 from pathlib import Path
 from typing import Any
@@ -10,6 +11,7 @@ import huggingface_hub
 from gradio_client import Client as GradioClient
 from huggingface_hub.utils import build_hf_headers
 
+from trackio.resumable_uploads import COMPATIBILITY_MAX_BYTES
 from trackio.utils import parse_trackio_server_url
 
 HTTP_API_VERSION = 1
@@ -108,6 +110,7 @@ class _TrackioHTTPClient:
         if isinstance(extra, dict):
             h.update({str(k): str(v) for k, v in extra.items()})
         self.headers = h
+        self._artifact_upload_capabilities: dict[str, Any] | None = None
 
     def _upload_file(self, file_data: dict[str, Any]) -> dict[str, Any]:
         path = Path(file_data["path"])
@@ -163,6 +166,88 @@ class _TrackioHTTPClient:
             raise RuntimeError(body["error"])
         return body.get("data")
 
+    def _resumable_capabilities(self) -> dict[str, Any] | None:
+        if self._artifact_upload_capabilities is not None:
+            return self._artifact_upload_capabilities
+        response = httpx.get(
+            urljoin(self.src, "api/artifact-upload/capabilities"),
+            headers=self.headers,
+            **self.httpx_kwargs,
+        )
+        if response.status_code == 404:
+            return None
+        response.raise_for_status()
+        capabilities = response.json()
+        if capabilities.get("resumable") is not True:
+            return None
+        self._artifact_upload_capabilities = capabilities
+        return capabilities
+
+    def upload_artifact_blob(self, project: str, digest: str, path: Path) -> bool:
+        """Upload one blob through the resumable API.
+
+        Returns ``False`` only when a legacy server can safely handle the small
+        file through the compatibility path.
+        """
+
+        size_bytes = path.stat().st_size
+        capabilities = self._resumable_capabilities()
+        if capabilities is None:
+            if size_bytes > COMPATIBILITY_MAX_BYTES:
+                raise RuntimeError(
+                    "The Trackio server does not support resumable artifact uploads; "
+                    f"refusing to send {size_bytes} bytes through the legacy whole-file endpoint."
+                )
+            return False
+
+        idempotency_key = hashlib.sha256(
+            f"{project}\0{digest}".encode("utf-8")
+        ).hexdigest()
+        init_response = httpx.post(
+            urljoin(self.src, f"api/artifact-upload/{project}"),
+            headers=self.headers,
+            json={
+                "digest": digest,
+                "size_bytes": size_bytes,
+                "idempotency_key": idempotency_key,
+            },
+            **self.httpx_kwargs,
+        )
+        init_response.raise_for_status()
+        session = init_response.json()
+        upload_id = session["upload_id"]
+        chunk_size = int(session["chunk_size_bytes"])
+        acknowledged = {int(index) for index in session["acknowledged_chunks"]}
+        with path.open("rb") as handle:
+            for index in range(int(session["chunk_count"])):
+                chunk = handle.read(chunk_size)
+                if index in acknowledged:
+                    continue
+                chunk_digest = hashlib.sha256(chunk).hexdigest()
+                response = httpx.put(
+                    urljoin(
+                        self.src,
+                        f"api/artifact-upload/{project}/{upload_id}/chunks/{index}",
+                    ),
+                    headers={
+                        **self.headers,
+                        "x-trackio-chunk-sha256": chunk_digest,
+                    },
+                    content=chunk,
+                    **self.httpx_kwargs,
+                )
+                response.raise_for_status()
+        complete_response = httpx.post(
+            urljoin(self.src, f"api/artifact-upload/{project}/{upload_id}"),
+            headers=self.headers,
+            **self.httpx_kwargs,
+        )
+        complete_response.raise_for_status()
+        completed = complete_response.json()
+        if completed.get("digest") != digest or completed.get("size_bytes") != size_bytes:
+            raise RuntimeError("Trackio completed an artifact upload with the wrong identity.")
+        return True
+
 
 class _TrackioGradioCompatClient:
     def __init__(
@@ -207,6 +292,14 @@ class _TrackioGradioCompatClient:
                     "Redeploy with `trackio sync`."
                 ) from e
             raise
+
+    def upload_artifact_blob(self, project: str, digest: str, path: Path) -> bool:
+        if path.stat().st_size > COMPATIBILITY_MAX_BYTES:
+            raise RuntimeError(
+                "The Trackio server does not support resumable artifact uploads; "
+                f"refusing to send {path.stat().st_size} bytes through the legacy whole-file endpoint."
+            )
+        return False
 
 
 def _raise_if_space_is_building(space_id: str) -> None:
@@ -296,3 +389,6 @@ class RemoteClient:
 
     def predict(self, *args, api_name: str, **kwargs) -> Any:
         return self._client.predict(*args, api_name=api_name, **kwargs)
+
+    def upload_artifact_blob(self, project: str, digest: str, path: Path) -> bool:
+        return self._client.upload_artifact_blob(project, digest, path)

--- a/trackio/resumable_uploads.py
+++ b/trackio/resumable_uploads.py
@@ -1,0 +1,349 @@
+"""Durable, bounded-memory upload sessions for artifact blobs."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import shutil
+import tempfile
+from collections.abc import AsyncIterable, Iterator
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+from trackio import cas, utils
+
+DEFAULT_CHUNK_SIZE = 8 * 1024 * 1024
+COMPATIBILITY_MAX_BYTES = 32 * 1024 * 1024
+DEFAULT_SESSION_TTL = timedelta(hours=24)
+UPLOAD_ID_RE = re.compile(r"^[0-9a-f]{64}$")
+IDEMPOTENCY_KEY_RE = re.compile(r"^[A-Za-z0-9_-]{16,128}$")
+
+
+class UploadSessionError(ValueError):
+    """An invalid or conflicting resumable upload operation."""
+
+
+def _uploads_root(project: str) -> Path:
+    return utils.project_artifacts_dir(project) / "uploads"
+
+
+def _session_dir(project: str, upload_id: str) -> Path:
+    if not UPLOAD_ID_RE.fullmatch(upload_id):
+        raise UploadSessionError("Invalid upload id.")
+    return _uploads_root(project) / upload_id
+
+
+def _metadata_path(project: str, upload_id: str) -> Path:
+    return _session_dir(project, upload_id) / "session.json"
+
+
+def _part_path(project: str, upload_id: str, index: int) -> Path:
+    return _session_dir(project, upload_id) / "parts" / f"{index:08d}.part"
+
+
+def _now() -> datetime:
+    return datetime.now(UTC)
+
+
+def _write_json_atomic(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile(
+        mode="w",
+        encoding="utf-8",
+        dir=path.parent,
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+        delete=False,
+    ) as handle:
+        json.dump(payload, handle, sort_keys=True)
+        handle.write("\n")
+        handle.flush()
+        os.fsync(handle.fileno())
+        temporary = Path(handle.name)
+    os.replace(temporary, path)
+
+
+def _read_session(project: str, upload_id: str) -> dict[str, Any]:
+    path = _metadata_path(project, upload_id)
+    if not path.is_file():
+        raise FileNotFoundError("Upload session does not exist.")
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise UploadSessionError("Upload session metadata is invalid.") from error
+    if payload.get("project") != utils.canonical_project_name(project):
+        raise UploadSessionError("Upload session project does not match.")
+    return payload
+
+
+def _upload_id(project: str, idempotency_key: str) -> str:
+    if not IDEMPOTENCY_KEY_RE.fullmatch(idempotency_key):
+        raise UploadSessionError(
+            "Idempotency key must be 16-128 URL-safe alphanumeric characters."
+        )
+    identity = f"{utils.canonical_project_name(project)}\0{idempotency_key}".encode()
+    return hashlib.sha256(identity).hexdigest()
+
+
+def _expected_chunks(size_bytes: int, chunk_size_bytes: int) -> int:
+    if size_bytes == 0:
+        return 0
+    return (size_bytes + chunk_size_bytes - 1) // chunk_size_bytes
+
+
+def _expected_chunk_size(session: dict[str, Any], index: int) -> int:
+    count = int(session["chunk_count"])
+    if index < 0 or index >= count:
+        raise UploadSessionError(f"Chunk index {index} is outside 0..{count - 1}.")
+    chunk_size = int(session["chunk_size_bytes"])
+    if index < count - 1:
+        return chunk_size
+    return int(session["size_bytes"]) - (index * chunk_size)
+
+
+def _public_session(session: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "upload_id": session["upload_id"],
+        "digest": session["digest"],
+        "size_bytes": session["size_bytes"],
+        "chunk_size_bytes": session["chunk_size_bytes"],
+        "chunk_count": session["chunk_count"],
+        "acknowledged_chunks": sorted(int(index) for index in session["chunks"]),
+        "state": session["state"],
+        "expires_at": session["expires_at"],
+    }
+
+
+def create_or_resume_session(
+    *,
+    project: str,
+    digest: str,
+    size_bytes: int,
+    idempotency_key: str,
+    chunk_size_bytes: int = DEFAULT_CHUNK_SIZE,
+) -> dict[str, Any]:
+    """Create an idempotent upload session or return its current state."""
+
+    project = utils.canonical_project_name(project)
+    digest = str(cas.validate_digest(digest))
+    if not isinstance(size_bytes, int) or size_bytes < 0:
+        raise UploadSessionError("Upload size must be a non-negative integer.")
+    if chunk_size_bytes <= 0:
+        raise UploadSessionError("Chunk size must be positive.")
+    upload_id = _upload_id(project, idempotency_key)
+    metadata = _metadata_path(project, upload_id)
+    if metadata.is_file():
+        session = _read_session(project, upload_id)
+        if session["digest"] != digest or session["size_bytes"] != size_bytes:
+            raise UploadSessionError(
+                "Idempotency key is already bound to a different artifact blob."
+            )
+        return _public_session(session)
+
+    now = _now()
+    session = {
+        "schema_version": 1,
+        "upload_id": upload_id,
+        "project": project,
+        "digest": digest,
+        "size_bytes": size_bytes,
+        "chunk_size_bytes": chunk_size_bytes,
+        "chunk_count": _expected_chunks(size_bytes, chunk_size_bytes),
+        "chunks": {},
+        "state": "uploading",
+        "created_at": now.isoformat(),
+        "updated_at": now.isoformat(),
+        "expires_at": (now + DEFAULT_SESSION_TTL).isoformat(),
+    }
+    _write_json_atomic(metadata, session)
+    return _public_session(session)
+
+
+def get_session(project: str, upload_id: str) -> dict[str, Any]:
+    return _public_session(_read_session(project, upload_id))
+
+
+async def store_chunk(
+    *,
+    project: str,
+    upload_id: str,
+    index: int,
+    claimed_digest: str,
+    chunks: AsyncIterable[bytes],
+) -> dict[str, Any]:
+    """Stream one chunk to durable staging and acknowledge it idempotently."""
+
+    claimed_digest = str(cas.validate_digest(claimed_digest))
+    session = _read_session(project, upload_id)
+    if session["state"] == "completed":
+        raise UploadSessionError("Upload session is already completed.")
+    expected_size = _expected_chunk_size(session, index)
+    existing = session["chunks"].get(str(index))
+    if existing is not None:
+        if existing["digest"] != claimed_digest:
+            raise UploadSessionError("Chunk index is already bound to a different digest.")
+        return {"index": index, **existing, "already_present": True}
+
+    destination = _part_path(project, upload_id, index)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    temporary = destination.parent / cas.partial_blob_name(destination.name)
+    sha = hashlib.sha256()
+    received = 0
+    try:
+        with temporary.open("wb") as handle:
+            async for chunk in chunks:
+                if not chunk:
+                    continue
+                received += len(chunk)
+                if received > expected_size:
+                    raise UploadSessionError(
+                        f"Chunk {index} exceeds expected size {expected_size}."
+                    )
+                sha.update(chunk)
+                handle.write(chunk)
+            handle.flush()
+            os.fsync(handle.fileno())
+        if received != expected_size:
+            raise UploadSessionError(
+                f"Chunk {index} has size {received}; expected {expected_size}."
+            )
+        actual = sha.hexdigest()
+        if actual != claimed_digest:
+            raise UploadSessionError(
+                f"Chunk digest mismatch: claimed {claimed_digest}, computed {actual}."
+            )
+        os.replace(temporary, destination)
+    except Exception:
+        temporary.unlink(missing_ok=True)
+        raise
+
+    session = _read_session(project, upload_id)
+    existing = session["chunks"].get(str(index))
+    if existing is None:
+        session["chunks"][str(index)] = {"digest": claimed_digest, "size_bytes": received}
+        now = _now()
+        session["updated_at"] = now.isoformat()
+        session["expires_at"] = (now + DEFAULT_SESSION_TTL).isoformat()
+        _write_json_atomic(_metadata_path(project, upload_id), session)
+        already_present = False
+    else:
+        already_present = True
+    return {
+        "index": index,
+        "digest": claimed_digest,
+        "size_bytes": received,
+        "already_present": already_present,
+    }
+
+
+def _part_chunks(project: str, upload_id: str, count: int) -> Iterator[bytes]:
+    for index in range(count):
+        path = _part_path(project, upload_id, index)
+        with path.open("rb") as handle:
+            while chunk := handle.read(cas.HASH_CHUNK_SIZE):
+                yield chunk
+
+
+def complete_session(project: str, upload_id: str) -> dict[str, Any]:
+    """Verify and atomically expose a fully acknowledged artifact blob."""
+
+    session = _read_session(project, upload_id)
+    target = cas.blob_path(project, session["digest"])
+    if session["state"] == "completed":
+        return {
+            "digest": session["digest"],
+            "size_bytes": session["size_bytes"],
+            "already_present": True,
+        }
+    expected = set(range(int(session["chunk_count"])))
+    acknowledged = {int(index) for index in session["chunks"]}
+    missing = sorted(expected - acknowledged)
+    if missing:
+        raise UploadSessionError(f"Upload session is missing chunks: {missing[:20]}.")
+
+    already_present = target.is_file()
+    cas.stage_blob_from_chunks(
+        _part_chunks(project, upload_id, int(session["chunk_count"])),
+        claimed_digest=session["digest"],
+        target_path=target,
+    )
+    if target.stat().st_size != session["size_bytes"]:
+        raise UploadSessionError("Completed artifact blob size does not match session.")
+
+    session["state"] = "completed"
+    session["completed_at"] = _now().isoformat()
+    session["updated_at"] = session["completed_at"]
+    _write_json_atomic(_metadata_path(project, upload_id), session)
+    shutil.rmtree(_session_dir(project, upload_id) / "parts", ignore_errors=True)
+    return {
+        "digest": session["digest"],
+        "size_bytes": session["size_bytes"],
+        "already_present": already_present,
+    }
+
+
+def abort_session(project: str, upload_id: str) -> bool:
+    session = _read_session(project, upload_id)
+    if session["state"] == "completed":
+        raise UploadSessionError("Completed upload sessions cannot be aborted.")
+    shutil.rmtree(_session_dir(project, upload_id))
+    return True
+
+
+def expire_sessions(
+    *,
+    project: str,
+    older_than: datetime,
+    dry_run: bool = True,
+) -> dict[str, Any]:
+    """Report or remove incomplete sessions older than a timezone-aware cutoff."""
+
+    if older_than.tzinfo is None:
+        raise UploadSessionError("Expiry cutoff must be timezone-aware.")
+    root = _uploads_root(project)
+    expired: list[dict[str, Any]] = []
+    if root.is_dir():
+        for metadata in root.glob("*/session.json"):
+            try:
+                session = json.loads(metadata.read_text(encoding="utf-8"))
+                updated = datetime.fromisoformat(session["updated_at"])
+            except (OSError, KeyError, ValueError, json.JSONDecodeError):
+                continue
+            if session.get("state") == "completed" or updated >= older_than:
+                continue
+            session_dir = metadata.parent
+            bytes_used = sum(
+                path.stat().st_size for path in session_dir.rglob("*") if path.is_file()
+            )
+            expired.append(
+                {
+                    "upload_id": session["upload_id"],
+                    "updated_at": session["updated_at"],
+                    "bytes": bytes_used,
+                }
+            )
+            if not dry_run:
+                shutil.rmtree(session_dir)
+    return {
+        "project": utils.canonical_project_name(project),
+        "dry_run": dry_run,
+        "sessions": expired,
+        "session_count": len(expired),
+        "reclaimable_bytes": sum(item["bytes"] for item in expired),
+    }
+
+
+__all__ = [
+    "COMPATIBILITY_MAX_BYTES",
+    "DEFAULT_CHUNK_SIZE",
+    "UploadSessionError",
+    "abort_session",
+    "complete_session",
+    "create_or_resume_session",
+    "expire_sessions",
+    "get_session",
+    "store_chunk",
+]

--- a/trackio/run.py
+++ b/trackio/run.py
@@ -789,6 +789,11 @@ class Run:
             buffered,
             self.project,
             predict=self._client.predict,
+            artifact_blob_uploader=(
+                self._client.upload_artifact_blob
+                if callable(getattr(type(self._client), "upload_artifact_blob", None))
+                else None
+            ),
             hf_token=self._hf_token_for_remote(),
             warn_missing=self._warn_missing_uploads,
         )

--- a/trackio/server.py
+++ b/trackio/server.py
@@ -967,6 +967,11 @@ def get_run_configs(project: str) -> dict[str, Any]:
     return Storage.get_all_run_configs(project)
 
 
+def get_run_lifecycles(project: str) -> dict[str, Any]:
+    """Every run's latest lifecycle values, so a listing needs one request."""
+    return Storage.get_run_lifecycles(project)
+
+
 def get_metrics_for_run(
     project: str, run: str | None = None, run_id: str | None = None
 ) -> list[str]:
@@ -1335,6 +1340,7 @@ def _api_registry() -> dict[str, Any]:
         "get_logs": get_logs,
         "get_run_history": get_run_history,
         "get_logs_batch": get_logs_batch,
+        "get_run_lifecycles": get_run_lifecycles,
         "get_traces": get_traces,
         "get_trace_steps": get_trace_steps,
         "query_project": query_project,

--- a/trackio/server.py
+++ b/trackio/server.py
@@ -1130,6 +1130,7 @@ def get_traces(
     limit: int | None = None,
     offset: int | None = 0,
     step: int | None = None,
+    trace_type: str | None = None,
 ) -> list[dict[str, Any]]:
     try:
         normalized_offset = max(0, int(offset)) if offset is not None else 0
@@ -1161,6 +1162,7 @@ def get_traces(
         offset=normalized_offset,
         run_id=run_id,
         step=normalized_step,
+        trace_type=trace_type,
     )
 
 

--- a/trackio/server.py
+++ b/trackio/server.py
@@ -25,7 +25,6 @@ from starlette.routing import Route
 import trackio.cas as cas
 import trackio.references as references
 import trackio.utils as utils
-from trackio import database as sqlite3
 from trackio.asgi_app import (
     cleanup_uploaded_temp_file,
     consume_uploaded_temp_file,
@@ -33,7 +32,11 @@ from trackio.asgi_app import (
 )
 from trackio.exceptions import TrackioAPIError
 from trackio.media import get_project_media_path
-from trackio.sqlite_storage import SQLiteStorage
+from trackio.storage import (
+    Storage,
+    StorageOperationalError,
+    is_retryable_storage_error,
+)
 from trackio.typehints import (
     AlertEntry,
     ArtifactBlobUploadEntry,
@@ -177,16 +180,15 @@ def _flush_loop() -> None:
         kind, payload = _write_queue[0]
         try:
             if kind == "bulk_log":
-                SQLiteStorage.bulk_log(**payload)
+                Storage.bulk_log(**payload)
             elif kind == "bulk_log_system":
-                SQLiteStorage.bulk_log_system(**payload)
+                Storage.bulk_log_system(**payload)
             elif kind == "bulk_alert":
-                SQLiteStorage.bulk_alert(**payload)
+                Storage.bulk_alert(**payload)
             _write_queue.popleft()
             retries = 0
-        except sqlite3.OperationalError as e:
-            msg = str(e).lower()
-            if "disk i/o error" in msg or "readonly" in msg:
+        except StorageOperationalError as e:
+            if is_retryable_storage_error(e):
                 retries += 1
                 logger.warning(
                     "write queue: flush failed (%s), retry %d/%d",
@@ -572,7 +574,7 @@ def upload_db_to_space(
     assert_can_write_metrics(request, hf_token)
     uploaded_path = consume_uploaded_temp_file(request, uploaded_db)
     try:
-        db_project_path = SQLiteStorage.get_project_db_path(project)
+        db_project_path = Storage.get_project_db_path(project)
         os.makedirs(os.path.dirname(db_project_path), exist_ok=True)
         shutil.copy(uploaded_path, db_project_path)
     finally:
@@ -629,7 +631,7 @@ def check_artifact_blobs(
     assert_can_write_metrics(request, hf_token)
     project = _validate_project_name(project)
     validated = [_validate_sha256_digest(d) for d in digests]
-    present = SQLiteStorage.list_artifact_blobs_present(project, validated)
+    present = Storage.list_artifact_blobs_present(project, validated)
     return {"present": [d for d in validated if d in present]}
 
 
@@ -708,7 +710,7 @@ def artifact_log(
         cas.assert_manifest_paths_compatible(paths)
     except ValueError as err:
         raise TrackioAPIError(str(err)) from err
-    present = SQLiteStorage.list_artifact_blobs_present(project, file_digests)
+    present = Storage.list_artifact_blobs_present(project, file_digests)
     missing = [d for d in file_digests if d not in present]
     if missing:
         preview = missing[:5]
@@ -717,7 +719,7 @@ def artifact_log(
             f"Manifest references blobs not on server: {preview}{suffix}"
         )
 
-    return SQLiteStorage.commit_artifact_version(
+    return Storage.commit_artifact_version(
         project=project,
         name=name,
         type=type,
@@ -736,17 +738,17 @@ def get_artifact_manifest(
     spec: str | None,
 ) -> dict | None:
     project = _validate_project_name(project)
-    return SQLiteStorage.get_artifact_manifest(project, name, spec)
+    return Storage.get_artifact_manifest(project, name, spec)
 
 
 def get_artifacts(project: str) -> list[dict]:
     project = _validate_project_name(project)
-    return SQLiteStorage.get_artifacts(project)
+    return Storage.get_artifacts(project)
 
 
 def list_artifacts(project: str) -> list[dict]:
     project = _validate_project_name(project)
-    return SQLiteStorage.list_artifacts(project)
+    return Storage.list_artifacts(project)
 
 
 def get_run_artifacts(
@@ -755,17 +757,17 @@ def get_run_artifacts(
     run_id: str | None = None,
 ) -> dict[str, list[dict]]:
     project = _validate_project_name(project)
-    return SQLiteStorage.get_run_artifacts(project, run_name=run, run_id=run_id)
+    return Storage.get_run_artifacts(project, run_name=run, run_id=run_id)
 
 
 def get_run_artifact_counts(project: str) -> list[dict]:
     project = _validate_project_name(project)
-    return SQLiteStorage.get_run_artifact_counts(project)
+    return Storage.get_run_artifact_counts(project)
 
 
 def get_artifact_consumers(project: str, version_id: int) -> list[dict]:
     project = _validate_project_name(project)
-    return SQLiteStorage.get_artifact_consumers(project, version_id)
+    return Storage.get_artifact_consumers(project, version_id)
 
 
 def log_artifact_use(
@@ -778,7 +780,7 @@ def log_artifact_use(
 ) -> None:
     assert_can_write_metrics(request, hf_token)
     project = _validate_project_name(project)
-    SQLiteStorage.insert_run_artifact_link(
+    Storage.insert_run_artifact_link(
         project=project,
         run_name=run_name,
         run_id=run_id,
@@ -797,9 +799,7 @@ def log(
     run_id: str | None = None,
 ) -> None:
     assert_can_write_metrics(request, hf_token)
-    SQLiteStorage.log(
-        project=project, run=run, run_id=run_id, metrics=metrics, step=step
-    )
+    Storage.log(project=project, run=run, run_id=run_id, metrics=metrics, step=step)
 
 
 def bulk_log(
@@ -837,8 +837,10 @@ def bulk_log(
             log_ids=data["log_ids"] if has_log_ids else None,
         )
         try:
-            SQLiteStorage.bulk_log(**payload)
-        except sqlite3.OperationalError:
+            Storage.bulk_log(**payload)
+        except StorageOperationalError as error:
+            if not is_retryable_storage_error(error):
+                raise
             _enqueue_write("bulk_log", payload)
 
 
@@ -869,8 +871,10 @@ def bulk_log_system(
             log_ids=data["log_ids"] if has_log_ids else None,
         )
         try:
-            SQLiteStorage.bulk_log_system(**payload)
-        except sqlite3.OperationalError:
+            Storage.bulk_log_system(**payload)
+        except StorageOperationalError as error:
+            if not is_retryable_storage_error(error):
+                raise
             _enqueue_write("bulk_log_system", payload)
 
 
@@ -914,8 +918,10 @@ def bulk_alert(
             alert_ids=data["alert_ids"] if has_alert_ids else None,
         )
         try:
-            SQLiteStorage.bulk_alert(**payload)
-        except sqlite3.OperationalError:
+            Storage.bulk_alert(**payload)
+        except StorageOperationalError as error:
+            if not is_retryable_storage_error(error):
+                raise
             _enqueue_write("bulk_alert", payload)
 
 
@@ -926,7 +932,7 @@ def get_alerts(
     level: str | None = None,
     since: str | None = None,
 ) -> list[dict[str, Any]]:
-    return SQLiteStorage.get_alerts(
+    return Storage.get_alerts(
         project, run_name=run, run_id=run_id, level=level, since=since
     )
 
@@ -941,7 +947,7 @@ def get_metric_values(
     window: int | None = None,
     run_id: str | None = None,
 ) -> list[dict[str, Any]]:
-    return SQLiteStorage.get_metric_values(
+    return Storage.get_metric_values(
         project,
         run,
         metric_name,
@@ -954,17 +960,17 @@ def get_metric_values(
 
 
 def get_runs_for_project(project: str) -> list[dict[str, Any]]:
-    return SQLiteStorage.get_run_records(project)
+    return Storage.get_run_records(project)
 
 
 def get_run_configs(project: str) -> dict[str, Any]:
-    return SQLiteStorage.get_all_run_configs(project)
+    return Storage.get_all_run_configs(project)
 
 
 def get_metrics_for_run(
     project: str, run: str | None = None, run_id: str | None = None
 ) -> list[str]:
-    return SQLiteStorage.get_all_metrics_for_run(project, run, run_id=run_id)
+    return Storage.get_all_metrics_for_run(project, run, run_id=run_id)
 
 
 def filter_metrics_by_regex(metrics: list[str], filter_pattern: str) -> list[str]:
@@ -980,15 +986,15 @@ def filter_metrics_by_regex(metrics: list[str], filter_pattern: str) -> list[str
 
 
 def get_all_projects() -> list[str]:
-    return SQLiteStorage.get_projects()
+    return Storage.get_projects()
 
 
 def get_project_summary(project: str) -> dict[str, Any]:
-    runs = SQLiteStorage.get_run_records(project)
+    runs = Storage.get_run_records(project)
     if not runs:
         return {"project": project, "num_runs": 0, "runs": [], "last_activity": None}
 
-    last_steps = SQLiteStorage.get_max_steps_for_runs(project)
+    last_steps = Storage.get_max_steps_for_runs(project)
 
     return {
         "project": project,
@@ -1005,7 +1011,7 @@ def get_run_summary(
         record = next(
             (
                 record
-                for record in SQLiteStorage.get_run_records(project)
+                for record in Storage.get_run_records(project)
                 if record["id"] == run_id
             ),
             None,
@@ -1013,7 +1019,7 @@ def get_run_summary(
         if record is not None:
             run = record["name"]
 
-    num_logs = SQLiteStorage.get_log_count(project, run, run_id=run_id)
+    num_logs = Storage.get_log_count(project, run, run_id=run_id)
     if num_logs == 0:
         return {
             "project": project,
@@ -1025,9 +1031,9 @@ def get_run_summary(
             "last_step": None,
         }
 
-    metrics = SQLiteStorage.get_all_metrics_for_run(project, run, run_id=run_id)
-    config = SQLiteStorage.get_run_config(project, run, run_id=run_id)
-    last_step = SQLiteStorage.get_last_step(project, run, run_id=run_id)
+    metrics = Storage.get_all_metrics_for_run(project, run, run_id=run_id)
+    config = Storage.get_run_config(project, run, run_id=run_id)
+    last_step = Storage.get_last_step(project, run, run_id=run_id)
 
     return {
         "project": project,
@@ -1043,13 +1049,13 @@ def get_run_summary(
 def get_system_metrics_for_run(
     project: str, run: str | None = None, run_id: str | None = None
 ) -> list[str]:
-    return SQLiteStorage.get_all_system_metrics_for_run(project, run, run_id=run_id)
+    return Storage.get_all_system_metrics_for_run(project, run, run_id=run_id)
 
 
 def get_system_logs(
     project: str, run: str | None = None, run_id: str | None = None
 ) -> list[dict[str, Any]]:
-    return SQLiteStorage.get_system_logs(project, run, run_id=run_id, max_points=3000)
+    return Storage.get_system_logs(project, run, run_id=run_id, max_points=3000)
 
 
 def get_system_logs_batch(
@@ -1059,7 +1065,7 @@ def get_system_logs_batch(
 ) -> list[dict[str, Any]]:
     runs_clean = _normalize_logs_batch_runs(runs)
     mp = _normalize_logs_batch_max_points(max_points)
-    return SQLiteStorage.get_system_logs_batch(project, runs_clean, max_points=mp)
+    return Storage.get_system_logs_batch(project, runs_clean, max_points=mp)
 
 
 def get_snapshot(
@@ -1071,7 +1077,7 @@ def get_snapshot(
     at_time: str | None = None,
     window: int | None = None,
 ) -> dict[str, Any]:
-    return SQLiteStorage.get_snapshot(
+    return Storage.get_snapshot(
         project,
         run,
         run_id=run_id,
@@ -1088,7 +1094,7 @@ def get_logs(
     run_id: str | None = None,
     scalar_only: bool = False,
 ) -> list[dict[str, Any]]:
-    return SQLiteStorage.get_logs(
+    return Storage.get_logs(
         project,
         run,
         max_points=3000,
@@ -1105,7 +1111,7 @@ def get_run_history(
 ) -> list[dict[str, Any]]:
     """Return unsampled run history for provider-neutral API consumers."""
 
-    return SQLiteStorage.get_logs(
+    return Storage.get_logs(
         project,
         run,
         max_points=None,
@@ -1122,7 +1128,7 @@ def get_logs_batch(
 ) -> list[dict[str, Any]]:
     runs_clean = _normalize_logs_batch_runs(runs)
     mp = _normalize_logs_batch_max_points(max_points)
-    return SQLiteStorage.get_logs_batch(
+    return Storage.get_logs_batch(
         project,
         runs_clean,
         max_points=mp,
@@ -1170,7 +1176,7 @@ def get_traces(
         except (TypeError, ValueError):
             normalized_step = None
     normalized_sort = sort if sort in _ALLOWED_TRACE_SORTS else None
-    return SQLiteStorage.get_traces(
+    return Storage.get_traces(
         project,
         run,
         search=search,
@@ -1189,13 +1195,11 @@ def get_trace_steps(
     run_id: str | None = None,
     trace_type: str | None = None,
 ) -> dict[str, Any]:
-    return SQLiteStorage.get_trace_steps(
-        project, run, run_id=run_id, trace_type=trace_type
-    )
+    return Storage.get_trace_steps(project, run, run_id=run_id, trace_type=trace_type)
 
 
 def query_project(project: str, query: str) -> dict[str, Any]:
-    return SQLiteStorage.query_project(project, query)
+    return Storage.query_project(project, query)
 
 
 def get_settings() -> dict[str, Any]:
@@ -1244,7 +1248,7 @@ def _project_has_files(project: str) -> bool:
 
 
 def get_tab_availability(project: str) -> dict[str, bool]:
-    flags = SQLiteStorage.get_tab_availability_flags(project)
+    flags = Storage.get_tab_availability_flags(project)
     return {
         "metrics": flags["metrics"],
         "system": flags["system"],
@@ -1264,7 +1268,7 @@ def delete_run(
     run_id: str | None = None,
 ) -> bool:
     assert_can_mutate_runs(request)
-    return SQLiteStorage.delete_run(project, run, run_id=run_id)
+    return Storage.delete_run(project, run, run_id=run_id)
 
 
 def rename_run(
@@ -1275,7 +1279,7 @@ def rename_run(
     run_id: str | None = None,
 ) -> bool:
     assert_can_mutate_runs(request)
-    SQLiteStorage.rename_run(project, old_name, new_name, run_id=run_id)
+    Storage.rename_run(project, old_name, new_name, run_id=run_id)
     return True
 
 
@@ -1286,9 +1290,9 @@ def force_sync() -> bool:
         logger.warning("inbox fragment import during force_sync failed: %s", e)
     if os.environ.get("TRACKIO_BUCKET_ID"):
         return True
-    SQLiteStorage._dataset_import_attempted = True
-    SQLiteStorage.export_to_parquet()
-    scheduler = SQLiteStorage.get_scheduler()
+    Storage._dataset_import_attempted = True
+    Storage.export_to_parquet()
+    scheduler = Storage.get_scheduler()
     scheduler.trigger().result()
     return True
 

--- a/trackio/server.py
+++ b/trackio/server.py
@@ -1097,6 +1097,23 @@ def get_logs(
     )
 
 
+def get_run_history(
+    project: str,
+    run: str | None = None,
+    run_id: str | None = None,
+    scalar_only: bool = False,
+) -> list[dict[str, Any]]:
+    """Return unsampled run history for provider-neutral API consumers."""
+
+    return SQLiteStorage.get_logs(
+        project,
+        run,
+        max_points=None,
+        run_id=run_id,
+        scalar_only=_normalize_bool_param(scalar_only, "scalar_only"),
+    )
+
+
 def get_logs_batch(
     project: str,
     runs: list[dict[str, Any]],
@@ -1312,6 +1329,7 @@ def _api_registry() -> dict[str, Any]:
         "get_system_logs_batch": get_system_logs_batch,
         "get_snapshot": get_snapshot,
         "get_logs": get_logs,
+        "get_run_history": get_run_history,
         "get_logs_batch": get_logs_batch,
         "get_traces": get_traces,
         "get_trace_steps": get_trace_steps,

--- a/trackio/server.py
+++ b/trackio/server.py
@@ -6,7 +6,6 @@ import os
 import re
 import secrets
 import shutil
-import sqlite3
 import threading
 import time
 import warnings
@@ -26,6 +25,7 @@ from starlette.routing import Route
 import trackio.cas as cas
 import trackio.references as references
 import trackio.utils as utils
+from trackio import database as sqlite3
 from trackio.asgi_app import (
     cleanup_uploaded_temp_file,
     consume_uploaded_temp_file,
@@ -1170,8 +1170,11 @@ def get_trace_steps(
     project: str,
     run: str | None = None,
     run_id: str | None = None,
+    trace_type: str | None = None,
 ) -> dict[str, Any]:
-    return SQLiteStorage.get_trace_steps(project, run, run_id=run_id)
+    return SQLiteStorage.get_trace_steps(
+        project, run, run_id=run_id, trace_type=trace_type
+    )
 
 
 def query_project(project: str, query: str) -> dict[str, Any]:
@@ -1229,6 +1232,7 @@ def get_tab_availability(project: str) -> dict[str, bool]:
         "metrics": flags["metrics"],
         "system": flags["system"],
         "traces": flags["traces"],
+        "verifiers-traces": flags["verifiers_traces"],
         "media": flags["media"],
         "reports": flags["reports"] or flags["alerts"],
         "files": _project_has_files(project),

--- a/trackio/sqlite_storage.py
+++ b/trackio/sqlite_storage.py
@@ -25,6 +25,7 @@ except ImportError:
 import huggingface_hub as hf
 import orjson
 
+from trackio.lifecycle import lifecycle_row
 from trackio import cas, references
 from trackio import database as sqlite3
 from trackio.commit_scheduler import CommitScheduler
@@ -4000,6 +4001,48 @@ class SQLiteStorage:
                         source_conn.commit()
 
                         return True
+
+    @staticmethod
+    def get_run_lifecycles(project: str) -> dict[str, dict]:
+        """Return the latest lifecycle row for every run in `project`.
+
+    Lifecycle values are logged as ordinary metric rows, so describing a run
+    otherwise costs a request per run and a listing costs one per run in the
+    project. This answers for every run at once, which is what makes listing a
+    project cost the same whether it holds one run or a thousand.
+    """
+        db_path = SQLiteStorage.get_project_db_path(project)
+        if not db_path.exists():
+            return {}
+        lifecycles: dict[str, dict] = {}
+        try:
+            with SQLiteStorage._get_connection(db_path) as conn:
+                identity = (
+                    "run_id" if SQLiteStorage._supports_run_ids(conn) else "run_name"
+                )
+                cursor = conn.cursor()
+                cursor.execute(
+                    f"""
+                    SELECT {identity} AS run_key, metrics FROM metrics
+                    WHERE metrics LIKE ?
+                    ORDER BY timestamp
+                    """,
+                    ("%run/status%",),
+                )
+                for row in cursor.fetchall():
+                    try:
+                        values = orjson.loads(row["metrics"])
+                    except (TypeError, ValueError, orjson.JSONDecodeError):
+                        continue
+                    if not isinstance(values, dict) or "run/status" not in values:
+                        continue
+                    # Ordered oldest first, so the last row seen for a run wins.
+                    lifecycles[str(row["run_key"])] = lifecycle_row(values)
+        except sqlite3.OperationalError as error:
+            if "no such table: metrics" in str(error):
+                return {}
+            raise
+        return lifecycles
 
     @staticmethod
     def get_all_run_configs(project: str) -> dict[str, dict]:

--- a/trackio/sqlite_storage.py
+++ b/trackio/sqlite_storage.py
@@ -524,7 +524,11 @@ class SQLiteStorage:
                         metadata TEXT NOT NULL,
                         search_text TEXT NOT NULL,
                         log_id TEXT,
-                        space_id TEXT
+                        space_id TEXT,
+                        trace_type TEXT NOT NULL DEFAULT 'trackio',
+                        external_id TEXT,
+                        schema_version INTEGER,
+                        payload TEXT
                     )
                     """
                 )
@@ -696,6 +700,21 @@ class SQLiteStorage:
                     CREATE INDEX IF NOT EXISTS idx_traces_search
                     ON traces(search_text)
                     """
+                )
+                for col in (
+                    "trace_type TEXT NOT NULL DEFAULT 'trackio'",
+                    "external_id TEXT",
+                    "schema_version INTEGER",
+                    "payload TEXT",
+                ):
+                    try:
+                        cursor.execute(f"ALTER TABLE traces ADD COLUMN {col}")
+                    except sqlite3.OperationalError:
+                        pass
+                cursor.execute(
+                    """CREATE UNIQUE INDEX IF NOT EXISTS idx_traces_external_id
+                    ON traces(run_id, trace_type, external_id)
+                    WHERE external_id IS NOT NULL"""
                 )
                 alerts_cols = SQLiteStorage._table_columns(conn, "alerts")
                 alerts_run_key = "run_id" if "run_id" in alerts_cols else "run_name"
@@ -953,7 +972,7 @@ class SQLiteStorage:
         normalized: list[dict[str, object]] = []
         for row in rows:
             new_row = dict(row)
-            for col in ("messages", "metadata"):
+            for col in ("messages", "metadata", "payload"):
                 value = new_row.get(col)
                 if value is None:
                     continue
@@ -1431,6 +1450,11 @@ class SQLiteStorage:
                 continue
 
             rows = SQLiteStorage._read_parquet_rows(parquet_path)
+            for row in rows:
+                row.setdefault("trace_type", "trackio")
+                row.setdefault("external_id", None)
+                row.setdefault("schema_version", None)
+                row.setdefault("payload", None)
             SQLiteStorage.init_db(project_name)
             SQLiteStorage._replace_table_rows(
                 db_path,
@@ -1449,6 +1473,10 @@ class SQLiteStorage:
                     "search_text",
                     "log_id",
                     "space_id",
+                    "trace_type",
+                    "external_id",
+                    "schema_version",
+                    "payload",
                 ],
             )
 
@@ -2385,7 +2413,10 @@ class SQLiteStorage:
 
     @staticmethod
     def _is_trace_payload(value: Any) -> bool:
-        return isinstance(value, dict) and value.get("_type") == "trackio.trace"
+        return isinstance(value, dict) and value.get("_type") in {
+            "trackio.trace",
+            "trackio.verifiers_trace",
+        }
 
     @staticmethod
     def _split_trace_metrics(
@@ -2423,9 +2454,18 @@ class SQLiteStorage:
                     clean_metrics[key] = non_trace_items
 
             for trace_index, trace in traces_for_key:
-                trace_id_parts = [run_id or run, log_id or uuid.uuid4().hex, key]
-                if trace_index is not None:
-                    trace_id_parts.append(str(trace_index))
+                trace_type = (
+                    "verifiers"
+                    if trace.get("_type") == "trackio.verifiers_trace"
+                    else "trackio"
+                )
+                external_id = trace.get("external_id")
+                if trace_type == "verifiers" and external_id:
+                    trace_id_parts = [run_id or run, trace_type, external_id]
+                else:
+                    trace_id_parts = [run_id or run, log_id or uuid.uuid4().hex, key]
+                    if trace_index is not None:
+                        trace_id_parts.append(str(trace_index))
                 trace_record = {
                     "id": ":".join(str(part) for part in trace_id_parts),
                     "run_id": run_id,
@@ -2438,6 +2478,10 @@ class SQLiteStorage:
                     "metadata": trace.get("metadata", {}),
                     "log_id": log_id,
                     "space_id": space_id,
+                    "trace_type": trace_type,
+                    "external_id": external_id,
+                    "schema_version": trace.get("schema_version"),
+                    "payload": trace.get("payload"),
                 }
                 trace_record["search_text"] = (
                     f"{trace_record['id']} {key} "
@@ -2454,8 +2498,8 @@ class SQLiteStorage:
         cursor.executemany(
             """
             INSERT OR IGNORE INTO traces
-            (id, run_id, timestamp, run_name, step, key, trace_index, messages, metadata, search_text, log_id, space_id)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            (id, run_id, timestamp, run_name, step, key, trace_index, messages, metadata, search_text, log_id, space_id, trace_type, external_id, schema_version, payload)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             [
                 (
@@ -2471,6 +2515,12 @@ class SQLiteStorage:
                     row["search_text"],
                     row["log_id"],
                     row["space_id"],
+                    row["trace_type"],
+                    row["external_id"],
+                    row["schema_version"],
+                    orjson.dumps(serialize_values(row["payload"]))
+                    if row["payload"] is not None
+                    else None,
                 )
                 for row in trace_rows
             ],
@@ -2515,8 +2565,7 @@ class SQLiteStorage:
                 candidates = value if isinstance(value, list) else [value]
                 for index, candidate in enumerate(candidates):
                     if (
-                        not isinstance(candidate, dict)
-                        or candidate.get("_type") != "trackio.trace"
+                        not SQLiteStorage._is_trace_payload(candidate)
                     ):
                         continue
 
@@ -2535,6 +2584,14 @@ class SQLiteStorage:
                         "timestamp": timestamp,
                         "messages": candidate.get("messages", []),
                         "metadata": candidate.get("metadata", {}),
+                        "trace_type": (
+                            "verifiers"
+                            if candidate.get("_type") == "trackio.verifiers_trace"
+                            else "trackio"
+                        ),
+                        "external_id": candidate.get("external_id"),
+                        "schema_version": candidate.get("schema_version"),
+                        "payload": candidate.get("payload"),
                     }
                     trace_record["_search_text"] = (
                         f"{trace_record['id']} {key} "
@@ -2571,6 +2628,7 @@ class SQLiteStorage:
         offset: int = 0,
         run_id: str | None = None,
         step: int | None = None,
+        trace_type: str | None = None,
     ) -> list[dict[str, Any]]:
         try:
             offset = max(0, int(offset or 0))
@@ -2606,6 +2664,9 @@ class SQLiteStorage:
                 if step is not None:
                     where.append("step = ?")
                     params.append(step)
+                if trace_type:
+                    where.append("trace_type = ?")
+                    params.append(trace_type)
                 if search:
                     needle = search.strip().lower()
                     if needle:
@@ -2613,7 +2674,9 @@ class SQLiteStorage:
                         params.append(f"%{needle}%")
 
                 query = f"""
-                    SELECT id, key, trace_index, run_name, run_id, step, timestamp, messages, metadata
+                    SELECT id, key, trace_index, run_name, run_id, step, timestamp,
+                           messages, metadata, trace_type, external_id,
+                           schema_version, payload
                     FROM traces
                     WHERE {" AND ".join(where)}
                     ORDER BY {order_by}
@@ -2646,6 +2709,12 @@ class SQLiteStorage:
                 "timestamp": row["timestamp"],
                 "messages": deserialize_values(orjson.loads(row["messages"])),
                 "metadata": deserialize_values(orjson.loads(row["metadata"])),
+                "trace_type": row["trace_type"],
+                "external_id": row["external_id"],
+                "schema_version": row["schema_version"],
+                "payload": deserialize_values(orjson.loads(row["payload"]))
+                if row["payload"] is not None
+                else None,
             }
             for row in rows
         ]

--- a/trackio/sqlite_storage.py
+++ b/trackio/sqlite_storage.py
@@ -78,6 +78,23 @@ def _env_pragma_int(name: str) -> int | None:
         return None
 
 
+def _read_only() -> bool:
+    return os.environ.get("TRACKIO_READ_ONLY", "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
+
+def _configure_read_only_pragmas(conn: sqlite3.Connection) -> None:
+    conn.execute("PRAGMA query_only = ON")
+    conn.execute("PRAGMA temp_store = MEMORY")
+    conn.execute("PRAGMA cache_size = -20000")
+    mmap_size = _env_pragma_int("TRACKIO_SQLITE_MMAP_SIZE")
+    conn.execute(f"PRAGMA mmap_size = {0 if mmap_size is None else mmap_size}")
+
+
 def _configure_sqlite_pragmas(conn: sqlite3.Connection) -> None:
     override = os.environ.get("TRACKIO_SQLITE_JOURNAL_MODE", "").strip().lower()
     if override in _JOURNAL_MODE_WHITELIST:
@@ -393,6 +410,17 @@ class SQLiteStorage:
         configure_pragmas: bool = True,
         row_factory=sqlite3.Row,
     ) -> Iterator[sqlite3.Connection]:
+        if _read_only():
+            conn = sqlite3.readonly_sqlite_connect(str(db_path.resolve()))
+            try:
+                _configure_read_only_pragmas(conn)
+                if row_factory is not None:
+                    conn.row_factory = row_factory
+                with conn:
+                    yield conn
+            finally:
+                conn.close()
+            return
         if on_spaces():
             # On Spaces, all callers share a single persistent connection
             # that is pragma-configured at creation time. The `configure_pragmas`
@@ -468,6 +496,13 @@ class SQLiteStorage:
         Initialize the SQLite database with required tables.
         Returns the database path.
         """
+        if _read_only():
+            db_path = SQLiteStorage.get_project_db_path(project)
+            if not db_path.is_file():
+                raise FileNotFoundError(
+                    f"Trackio project database does not exist: {db_path}"
+                )
+            return db_path
         SQLiteStorage._ensure_hub_loaded()
         db_path = SQLiteStorage.get_project_db_path(project)
         db_path.parent.mkdir(parents=True, exist_ok=True)
@@ -2865,6 +2900,8 @@ class SQLiteStorage:
 
     @staticmethod
     def _ensure_hub_loaded():
+        if _read_only():
+            return
         if not SQLiteStorage._dataset_import_attempted:
             SQLiteStorage.load_from_dataset()
 

--- a/trackio/sqlite_storage.py
+++ b/trackio/sqlite_storage.py
@@ -797,7 +797,7 @@ class SQLiteStorage:
             import pyarrow.parquet as pq
         except ImportError as e:
             raise ImportError(
-                "Parquet import/export requires `trackio[spaces]`."
+                "Parquet import/export requires `carbonteq-trackio[spaces]`."
             ) from e
         return pa, pq
 

--- a/trackio/sqlite_storage.py
+++ b/trackio/sqlite_storage.py
@@ -3,7 +3,6 @@ import hashlib
 import json as json_mod
 import os
 import shutil
-import sqlite3
 import time
 import uuid
 from collections.abc import Iterator
@@ -27,6 +26,7 @@ import huggingface_hub as hf
 import orjson
 
 from trackio import cas, references
+from trackio import database as sqlite3
 from trackio.commit_scheduler import CommitScheduler
 from trackio.dummy_commit_scheduler import DummyCommitScheduler
 from trackio.typehints import (
@@ -2193,6 +2193,7 @@ class SQLiteStorage:
             "metrics": False,
             "system": False,
             "traces": False,
+            "verifiers_traces": False,
             "media": False,
             "reports": False,
             "alerts": False,
@@ -2239,7 +2240,12 @@ class SQLiteStorage:
                 ('*"_type":"trackio.markdown"*',),
             )
             flags["system"] = _exists(conn, "SELECT 1 FROM system_metrics LIMIT 1")
-            flags["traces"] = _exists(conn, "SELECT 1 FROM traces LIMIT 1")
+            flags["traces"] = _exists(
+                conn, "SELECT 1 FROM traces WHERE trace_type = 'trackio' LIMIT 1"
+            )
+            flags["verifiers_traces"] = _exists(
+                conn, "SELECT 1 FROM traces WHERE trace_type = 'verifiers' LIMIT 1"
+            )
             flags["alerts"] = _exists(conn, "SELECT 1 FROM alerts LIMIT 1")
             flags["artifacts"] = _exists(
                 conn, "SELECT 1 FROM artifact_versions LIMIT 1"
@@ -2564,9 +2570,7 @@ class SQLiteStorage:
 
                 candidates = value if isinstance(value, list) else [value]
                 for index, candidate in enumerate(candidates):
-                    if (
-                        not SQLiteStorage._is_trace_payload(candidate)
-                    ):
+                    if not SQLiteStorage._is_trace_payload(candidate):
                         continue
 
                     trace_index = index if isinstance(value, list) else None
@@ -2724,6 +2728,7 @@ class SQLiteStorage:
         project: str,
         run: str | None = None,
         run_id: str | None = None,
+        trace_type: str | None = None,
     ) -> dict[str, Any]:
         """Return per-step trace counts and total for a run.
 
@@ -2742,15 +2747,20 @@ class SQLiteStorage:
                 if run_identity is None:
                     return {"total": 0, "steps": []}
                 cursor = conn.cursor()
+                where = [f"{run_identity[0]} = ?"]
+                params: list[Any] = [run_identity[1]]
+                if trace_type:
+                    where.append("trace_type = ?")
+                    params.append(trace_type)
                 cursor.execute(
                     f"""
                     SELECT step, COUNT(*) AS c
                     FROM traces
-                    WHERE {run_identity[0]} = ?
+                    WHERE {" AND ".join(where)}
                     GROUP BY step
                     ORDER BY step ASC
                     """,
-                    (run_identity[1],),
+                    params,
                 )
                 rows = cursor.fetchall()
         except sqlite3.OperationalError as e:
@@ -2900,17 +2910,17 @@ class SQLiteStorage:
     ) -> int:
         del arg2, db_name, source
         if action_code in {
-            sqlite3.SQLITE_SELECT,
-            sqlite3.SQLITE_READ,
-            sqlite3.SQLITE_FUNCTION,
+            sqlite3.sqlite_authorizer.SQLITE_SELECT,
+            sqlite3.sqlite_authorizer.SQLITE_READ,
+            sqlite3.sqlite_authorizer.SQLITE_FUNCTION,
         }:
-            return sqlite3.SQLITE_OK
-        pragma_code = getattr(sqlite3, "SQLITE_PRAGMA", None)
+            return sqlite3.sqlite_authorizer.SQLITE_OK
+        pragma_code = getattr(sqlite3.sqlite_authorizer, "SQLITE_PRAGMA", None)
         if action_code == pragma_code:
             pragma_name = (arg1 or "").lower()
             if pragma_name in _READ_ONLY_PRAGMAS:
-                return sqlite3.SQLITE_OK
-        return sqlite3.SQLITE_DENY
+                return sqlite3.sqlite_authorizer.SQLITE_OK
+        return sqlite3.sqlite_authorizer.SQLITE_DENY
 
     @staticmethod
     def _normalize_query_value(value: Any) -> Any:
@@ -2928,7 +2938,7 @@ class SQLiteStorage:
             raise FileNotFoundError(f"Project '{project}' not found.")
 
         normalized_query = SQLiteStorage._validate_read_only_query(query)
-        with SQLiteStorage._get_connection(db_path) as conn:
+        with sqlite3.readonly_sqlite_connect(str(db_path)) as conn:
             conn.set_authorizer(SQLiteStorage._query_authorizer)
             try:
                 cursor = conn.cursor()
@@ -2948,7 +2958,7 @@ class SQLiteStorage:
                     }
                     for row in fetched
                 ]
-            except sqlite3.DatabaseError as e:
+            except (sqlite3.DatabaseError, sqlite3.ReadonlyDatabaseError) as e:
                 raise ValueError(str(e)) from e
             finally:
                 conn.set_authorizer(None)
@@ -4537,12 +4547,15 @@ class SQLiteStorage:
             (artifact_id, manifest_digest),
         ).fetchone()
         if existing is not None:
+            existing_id = int(existing["id"])
+            existing_version = int(existing["version"])
             if metadata:
                 cursor.execute(
                     "UPDATE artifact_versions SET metadata = ? WHERE id = ?",
-                    (metadata_json, int(existing["id"])),
+                    (metadata_json, existing_id),
                 )
-            return int(existing["id"]), int(existing["version"]), False
+            cursor.close()
+            return existing_id, existing_version, False
         row = cursor.execute(
             "SELECT MAX(version) AS m FROM artifact_versions WHERE artifact_id = ?",
             (artifact_id,),
@@ -4565,7 +4578,9 @@ class SQLiteStorage:
                 now,
             ),
         )
-        return int(cursor.lastrowid), next_version, True
+        version_id = int(cursor.lastrowid)
+        cursor.close()
+        return version_id, next_version, True
 
     @staticmethod
     def insert_artifact_version(
@@ -4606,11 +4621,17 @@ class SQLiteStorage:
             raise ValueError(
                 f"Alias '{alias}' is reserved for version pointers (vN); choose another."
             )
+        # Replace the pointer inside the surrounding transaction. pyturso can
+        # retain the old target for an UPDATE/UPSERT issued immediately after a
+        # content-dedup lookup; delete+insert has consistent semantics on both
+        # supported engines and keeps the composite uniqueness invariant.
         conn.execute(
-            """INSERT INTO artifact_aliases (artifact_id, alias, artifact_version_id)
-            VALUES (?, ?, ?)
-            ON CONFLICT(artifact_id, alias) DO UPDATE SET
-                artifact_version_id = excluded.artifact_version_id""",
+            "DELETE FROM artifact_aliases WHERE artifact_id = ? AND alias = ?",
+            (artifact_id, alias),
+        )
+        conn.execute(
+            """INSERT INTO artifact_aliases
+            (artifact_id, alias, artifact_version_id) VALUES (?, ?, ?)""",
             (artifact_id, alias, version_id),
         )
 
@@ -4623,12 +4644,14 @@ class SQLiteStorage:
         version_int: int,
     ) -> None:
         """Reassign `alias` only when it does not move backward."""
-        current = conn.execute(
+        cursor = conn.execute(
             """SELECT av.version FROM artifact_aliases aa
             JOIN artifact_versions av ON av.id = aa.artifact_version_id
             WHERE aa.artifact_id = ? AND aa.alias = ?""",
             (artifact_id, alias),
-        ).fetchone()
+        )
+        current = cursor.fetchone()
+        cursor.close()
         if current is not None and int(current["version"]) > version_int:
             return
         SQLiteStorage._reassign_alias_cursor(conn, artifact_id, alias, version_id)

--- a/trackio/storage.py
+++ b/trackio/storage.py
@@ -1,0 +1,67 @@
+"""Select Trackio's logical persistence provider.
+
+SQLite and Turso share the historical ``SQLiteStorage`` implementation. Apache
+Doris is not SQLite-compatible and therefore implements the same logical
+server operations in a separate provider.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import pymysql
+
+from trackio import database as sqlite_database
+from trackio.doris_storage import DorisStorage
+from trackio.sqlite_storage import SQLiteStorage
+
+SUPPORTED_ENGINES = ("turso", "sqlite", "doris")
+_sqlite_operational_errors = sqlite_database.OperationalError
+if not isinstance(_sqlite_operational_errors, tuple):
+    _sqlite_operational_errors = (_sqlite_operational_errors,)
+StorageOperationalError = (
+    *_sqlite_operational_errors,
+    pymysql.err.OperationalError,
+    pymysql.err.InterfaceError,
+)
+
+
+def is_retryable_storage_error(error: BaseException) -> bool:
+    if isinstance(error, pymysql.err.InterfaceError):
+        return True
+    if isinstance(error, pymysql.err.OperationalError):
+        code = error.args[0] if error.args else None
+        return code in {1047, 1205, 2003, 2006, 2013}
+    message = str(error).lower()
+    return any(
+        marker in message
+        for marker in (
+            "database is locked",
+            "disk i/o error",
+            "readonly",
+            "temporarily unavailable",
+        )
+    )
+
+
+def selected_engine() -> str:
+    engine = os.environ.get("TRACKIO_DATABASE_ENGINE", "turso").strip().lower()
+    if engine not in SUPPORTED_ENGINES:
+        choices = ", ".join(repr(choice) for choice in SUPPORTED_ENGINES)
+        raise RuntimeError(f"TRACKIO_DATABASE_ENGINE must be one of {choices}")
+    return engine
+
+
+def get_storage(engine: str | None = None) -> type[Any]:
+    resolved = (engine or selected_engine()).strip().lower()
+    if resolved not in SUPPORTED_ENGINES:
+        choices = ", ".join(repr(choice) for choice in SUPPORTED_ENGINES)
+        raise RuntimeError(f"TRACKIO_DATABASE_ENGINE must be one of {choices}")
+    if resolved == "doris":
+        return DorisStorage
+
+    return SQLiteStorage
+
+
+Storage = get_storage()

--- a/trackio/trace.py
+++ b/trackio/trace.py
@@ -48,3 +48,123 @@ class Trace:
             "messages": self._serialize_nested_value(self.messages, project, run, step),
             "metadata": self._serialize_nested_value(self.metadata, project, run, step),
         }
+
+
+class VerifiersTrace(Trace):
+    """A queryable projection plus the complete native Verifiers trace record.
+
+    Trackio intentionally does not import Verifiers. ``record`` may be a JSON
+    mapping, a Verifiers ``Trace`` (``to_record``), or another Pydantic-like
+    object exposing ``model_dump``.
+    """
+
+    TYPE = "trackio.verifiers_trace"
+
+    def __init__(
+        self,
+        record: Any,
+        messages: list[dict[str, Any]] | None = None,
+        metadata: dict | None = None,
+    ):
+        native = self._record_mapping(record)
+        trace_id = native.get("id")
+        schema_version = native.get("version")
+        if not isinstance(trace_id, str) or not trace_id:
+            raise TypeError("Verifiers trace record requires a non-empty string `id`.")
+        if not isinstance(schema_version, int) or isinstance(schema_version, bool):
+            raise TypeError("Verifiers trace record requires an integer `version`.")
+
+        display_messages = messages if messages is not None else self._final_branch(native)
+        auto_metadata = self._metadata(native)
+        super().__init__(display_messages, {**auto_metadata, **dict(metadata or {})})
+        self.record = native
+        self.trace_id = trace_id
+        self.schema_version = schema_version
+
+    @staticmethod
+    def _record_mapping(record: Any) -> dict[str, Any]:
+        if hasattr(record, "to_record"):
+            record = record.to_record()
+        elif hasattr(record, "model_dump"):
+            record = record.model_dump(mode="json", exclude_none=True)
+        if not isinstance(record, dict):
+            raise TypeError("`record` must be a mapping or a Verifiers trace object.")
+        return dict(record)
+
+    @staticmethod
+    def _final_branch(record: dict[str, Any]) -> list[dict[str, Any]]:
+        nodes = record.get("nodes", [])
+        if not isinstance(nodes, list) or not nodes:
+            return []
+        parents = {
+            node.get("parent")
+            for node in nodes
+            if isinstance(node, dict) and isinstance(node.get("parent"), int)
+        }
+        leaves = [index for index in range(len(nodes)) if index not in parents]
+        current = leaves[-1] if leaves else len(nodes) - 1
+        path: list[int] = []
+        seen: set[int] = set()
+        while 0 <= current < len(nodes) and current not in seen:
+            seen.add(current)
+            path.append(current)
+            node = nodes[current]
+            parent = node.get("parent") if isinstance(node, dict) else None
+            if not isinstance(parent, int):
+                break
+            current = parent
+        messages = []
+        for index in reversed(path):
+            node = nodes[index]
+            message = node.get("message") if isinstance(node, dict) else None
+            if isinstance(message, dict):
+                messages.append(dict(message))
+        return messages
+
+    @staticmethod
+    def _metadata(record: dict[str, Any]) -> dict[str, Any]:
+        agent = record.get("agent") or {}
+        task = record.get("task") or {}
+        task_data = (task.get("data") or {}) if isinstance(task, dict) else {}
+        rewards = record.get("rewards") or {}
+        errors = record.get("errors") or []
+        last_error = errors[-1] if isinstance(errors, list) and errors else None
+        last_call = next(
+            (
+                call
+                for call in reversed(record.get("calls") or [])
+                if isinstance(call, dict) and not call.get("error")
+            ),
+            None,
+        )
+        truncating_stops = {
+            "max_turns",
+            "max_input_tokens",
+            "max_output_tokens",
+            "max_total_tokens",
+            "context_length",
+            "harness_timeout",
+        }
+        return {
+            "trace_id": record["id"],
+            "trace_schema_version": record["version"],
+            "model": agent.get("model") if isinstance(agent, dict) else None,
+            "task_type": task.get("type") if isinstance(task, dict) else None,
+            "task_index": task_data.get("idx") if isinstance(task_data, dict) else None,
+            "reward": sum(rewards.values()) if isinstance(rewards, dict) else 0.0,
+            "stop_condition": record.get("stop_condition"),
+            "is_completed": bool(record.get("is_completed")),
+            "is_truncated": record.get("stop_condition") in truncating_stops
+            or bool(last_call and last_call.get("finish_reason") == "length"),
+            "error_type": last_error.get("type") if isinstance(last_error, dict) else None,
+        }
+
+    def _to_dict(self, project: str, run: str, step: int = 0) -> dict[str, Any]:
+        return {
+            "_type": self.TYPE,
+            "external_id": self.trace_id,
+            "schema_version": self.schema_version,
+            "messages": self._serialize_nested_value(self.messages, project, run, step),
+            "metadata": self._serialize_nested_value(self.metadata, project, run, step),
+            "payload": self._serialize_nested_value(self.record, project, run, step),
+        }

--- a/uv.lock
+++ b/uv.lock
@@ -117,6 +117,81 @@ wheels = [
 ]
 
 [[package]]
+name = "carbonteq-trackio"
+version = "0.31.5.post1"
+source = { editable = "." }
+dependencies = [
+    { name = "brotli" },
+    { name = "gradio-client" },
+    { name = "huggingface-hub" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "orjson" },
+    { name = "pillow" },
+    { name = "python-multipart" },
+    { name = "pyturso" },
+    { name = "starlette" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "uvicorn", extra = ["standard"] },
+]
+
+[package.optional-dependencies]
+apple-gpu = [
+    { name = "psutil" },
+]
+cpu = [
+    { name = "psutil" },
+]
+dev = [
+    { name = "playwright" },
+    { name = "pytest" },
+    { name = "pytest-playwright" },
+    { name = "ruff" },
+]
+gpu = [
+    { name = "nvidia-ml-py" },
+    { name = "psutil" },
+]
+mcp = [
+    { name = "mcp" },
+]
+spaces = [
+    { name = "pyarrow" },
+]
+tensorboard = [
+    { name = "tbparse" },
+    { name = "tensorboardx" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "brotli", specifier = ">=1.0.0,<2.0.0" },
+    { name = "gradio-client", specifier = ">=2.0.0,<3.0.0" },
+    { name = "huggingface-hub", specifier = ">=1.10.0,<2" },
+    { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.0.0,<2.0.0" },
+    { name = "numpy", specifier = "<3.0.0" },
+    { name = "nvidia-ml-py", marker = "extra == 'gpu'", specifier = ">=12.0.0" },
+    { name = "orjson", specifier = ">=3.0,<4.0.0" },
+    { name = "pillow", specifier = "<13.0.0" },
+    { name = "playwright", marker = "extra == 'dev'", specifier = "==1.60.0" },
+    { name = "psutil", marker = "extra == 'apple-gpu'", specifier = ">=5.9.0" },
+    { name = "psutil", marker = "extra == 'cpu'", specifier = ">=5.9.0" },
+    { name = "psutil", marker = "extra == 'gpu'", specifier = ">=5.9.0" },
+    { name = "pyarrow", marker = "extra == 'spaces'", specifier = ">=21.0" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0,<9.0.0" },
+    { name = "pytest-playwright", marker = "extra == 'dev'", specifier = ">=0.7.0,<1.0.0" },
+    { name = "python-multipart", specifier = ">=0.0.9,<1.0.0" },
+    { name = "pyturso", specifier = ">=0.7.0,<1.0.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = "==0.9.3" },
+    { name = "starlette", specifier = "<2.0.0" },
+    { name = "tbparse", marker = "extra == 'tensorboard'", specifier = "==0.0.9" },
+    { name = "tensorboardx", marker = "extra == 'tensorboard'", specifier = ">=2.0.0,<3.0.0" },
+    { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0.0" },
+    { name = "uvicorn", extras = ["standard"], specifier = ">=0.30.0,<1.0.0" },
+]
+provides-extras = ["dev", "tensorboard", "gpu", "apple-gpu", "cpu", "spaces", "mcp"]
+
+[[package]]
 name = "certifi"
 version = "2026.2.25"
 source = { registry = "https://pypi.org/simple" }
@@ -2200,80 +2275,6 @@ sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd
 wheels = [
     { url = "https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl", hash = "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf", size = 78374, upload-time = "2026-02-03T17:35:50.982Z" },
 ]
-
-[[package]]
-name = "trackio"
-source = { editable = "." }
-dependencies = [
-    { name = "brotli" },
-    { name = "gradio-client" },
-    { name = "huggingface-hub" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "orjson" },
-    { name = "pillow" },
-    { name = "python-multipart" },
-    { name = "pyturso" },
-    { name = "starlette" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
-    { name = "uvicorn", extra = ["standard"] },
-]
-
-[package.optional-dependencies]
-apple-gpu = [
-    { name = "psutil" },
-]
-cpu = [
-    { name = "psutil" },
-]
-dev = [
-    { name = "playwright" },
-    { name = "pytest" },
-    { name = "pytest-playwright" },
-    { name = "ruff" },
-]
-gpu = [
-    { name = "nvidia-ml-py" },
-    { name = "psutil" },
-]
-mcp = [
-    { name = "mcp" },
-]
-spaces = [
-    { name = "pyarrow" },
-]
-tensorboard = [
-    { name = "tbparse" },
-    { name = "tensorboardx" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "brotli", specifier = ">=1.0.0,<2.0.0" },
-    { name = "gradio-client", specifier = ">=2.0.0,<3.0.0" },
-    { name = "huggingface-hub", specifier = ">=1.10.0,<2" },
-    { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.0.0,<2.0.0" },
-    { name = "numpy", specifier = "<3.0.0" },
-    { name = "nvidia-ml-py", marker = "extra == 'gpu'", specifier = ">=12.0.0" },
-    { name = "orjson", specifier = ">=3.0,<4.0.0" },
-    { name = "pillow", specifier = "<13.0.0" },
-    { name = "playwright", marker = "extra == 'dev'", specifier = "==1.60.0" },
-    { name = "psutil", marker = "extra == 'apple-gpu'", specifier = ">=5.9.0" },
-    { name = "psutil", marker = "extra == 'cpu'", specifier = ">=5.9.0" },
-    { name = "psutil", marker = "extra == 'gpu'", specifier = ">=5.9.0" },
-    { name = "pyarrow", marker = "extra == 'spaces'", specifier = ">=21.0" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0,<9.0.0" },
-    { name = "pytest-playwright", marker = "extra == 'dev'", specifier = ">=0.7.0,<1.0.0" },
-    { name = "python-multipart", specifier = ">=0.0.9,<1.0.0" },
-    { name = "pyturso", specifier = ">=0.7.0,<1.0.0" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = "==0.9.3" },
-    { name = "starlette", specifier = "<2.0.0" },
-    { name = "tbparse", marker = "extra == 'tensorboard'", specifier = "==0.0.9" },
-    { name = "tensorboardx", marker = "extra == 'tensorboard'", specifier = ">=2.0.0,<3.0.0" },
-    { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0.0" },
-    { name = "uvicorn", extras = ["standard"], specifier = ">=0.30.0,<1.0.0" },
-]
-provides-extras = ["apple-gpu", "cpu", "dev", "gpu", "mcp", "spaces", "tensorboard"]
 
 [[package]]
 name = "typer"

--- a/uv.lock
+++ b/uv.lock
@@ -1716,6 +1716,21 @@ wheels = [
 ]
 
 [[package]]
+name = "pyturso"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5f/9d/c75ce150bf6a8afb4146fc95a52176de3e1fcb661bed547ccb4949a4edd4/pyturso-0.7.0.tar.gz", hash = "sha256:bf599d3416980c6989bd430f108c2515cb9e61e80acdc4abedbf83e93b8dcef8", size = 2847665, upload-time = "2026-07-14T09:18:44.504Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/44/f7b258a20e75ec4b037c934b6efdf74f16d2109328b73a9adc40b21e9cba/pyturso-0.7.0-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:ccaeb088663c90ea90d33beab29986d5591ed05637dd49cae97ebb946bdf6b9b", size = 8752762, upload-time = "2026-07-14T09:18:34.348Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/ca/ebe06f759494984a0db261f287b0d8d9bd7c533f118f3df636d605e04605/pyturso-0.7.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:d6207c7629448a2b1fc51bc554668ec39a04ccf02b410cbb8dd0a2a23614874e", size = 7757877, upload-time = "2026-07-14T09:18:37.077Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/65/d65256b9952b85676475e7f1b785d9bf837c9273a984e7e2837846b88677/pyturso-0.7.0-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8649b23b7329a8f92f76efb014e0ca03180b9b8a16705667fa5f3836cfdf02a4", size = 25969316, upload-time = "2026-07-14T09:18:39.483Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/f2/fdb8d7692b6c8468b8ef8151a79c68822214b42e569e678fc6fc57c2abd1/pyturso-0.7.0-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0d79040fa12992b7f4449f95a3d7ea248d8cffeebec52fd838fa263179f1f84c", size = 26483677, upload-time = "2026-07-14T09:18:42.242Z" },
+]
+
+[[package]]
 name = "pytz"
 version = "2026.1.post1"
 source = { registry = "https://pypi.org/simple" }
@@ -2198,6 +2213,7 @@ dependencies = [
     { name = "orjson" },
     { name = "pillow" },
     { name = "python-multipart" },
+    { name = "pyturso" },
     { name = "starlette" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
     { name = "uvicorn", extra = ["standard"] },
@@ -2249,6 +2265,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0,<9.0.0" },
     { name = "pytest-playwright", marker = "extra == 'dev'", specifier = ">=0.7.0,<1.0.0" },
     { name = "python-multipart", specifier = ">=0.0.9,<1.0.0" },
+    { name = "pyturso", specifier = ">=0.7.0,<1.0.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = "==0.9.3" },
     { name = "starlette", specifier = "<2.0.0" },
     { name = "tbparse", marker = "extra == 'tensorboard'", specifier = "==0.0.9" },

--- a/uv.lock
+++ b/uv.lock
@@ -118,7 +118,7 @@ wheels = [
 
 [[package]]
 name = "carbonteq-trackio"
-version = "0.31.5.post2"
+version = "0.31.5.post3"
 source = { editable = "." }
 dependencies = [
     { name = "brotli" },
@@ -128,6 +128,7 @@ dependencies = [
     { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "orjson" },
     { name = "pillow" },
+    { name = "pymysql" },
     { name = "python-multipart" },
     { name = "pyturso" },
     { name = "starlette" },
@@ -178,6 +179,7 @@ requires-dist = [
     { name = "psutil", marker = "extra == 'cpu'", specifier = ">=5.9.0" },
     { name = "psutil", marker = "extra == 'gpu'", specifier = ">=5.9.0" },
     { name = "pyarrow", marker = "extra == 'spaces'", specifier = ">=21.0" },
+    { name = "pymysql", specifier = ">=1.1.0,<2.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0,<9.0.0" },
     { name = "pytest-playwright", marker = "extra == 'dev'", specifier = ">=0.7.0,<1.0.0" },
     { name = "python-multipart", specifier = ">=0.0.9,<1.0.0" },
@@ -1700,6 +1702,15 @@ wheels = [
 [package.optional-dependencies]
 crypto = [
     { name = "cryptography" },
+]
+
+[[package]]
+name = "pymysql"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/bc/1c6a92f385940f727daeecf3bacaf186e03875dff57197801046c583bcf0/pymysql-1.2.0.tar.gz", hash = "sha256:6c7b17ca686988104d7426c27895b455cdeea3e9d3ceb1270f0c3704fead8c33", size = 49021, upload-time = "2026-05-19T08:26:22.302Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c4/bd/2534e130295c8cfd4f0a2e31623baab7502278f1e97bcfe61db75656a77f/pymysql-1.2.0-py3-none-any.whl", hash = "sha256:62169ce6d5510f08e140c5e7990ee884a9764024e4a9a27b2cc11f1099322ae0", size = 45716, upload-time = "2026-05-19T08:26:20.974Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -59,6 +59,64 @@ wheels = [
 ]
 
 [[package]]
+name = "brotli"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f7/16/c92ca344d646e71a43b8bb353f0a6490d7f6e06210f8554c8f874e454285/brotli-1.2.0.tar.gz", hash = "sha256:e310f77e41941c13340a95976fe66a8a95b01e783d430eeaf7a2f87e0a57dd0a", size = 7388632, upload-time = "2025-11-05T18:39:42.86Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/10/a090475284fc4a71aed40a96f32e44a7fe5bda39687353dd977720b211b6/brotli-1.2.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:3b90b767916ac44e93a8e28ce6adf8d551e43affb512f2377c732d486ac6514e", size = 863089, upload-time = "2025-11-05T18:38:01.181Z" },
+    { url = "https://files.pythonhosted.org/packages/03/41/17416630e46c07ac21e378c3464815dd2e120b441e641bc516ac32cc51d2/brotli-1.2.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:6be67c19e0b0c56365c6a76e393b932fb0e78b3b56b711d180dd7013cb1fd984", size = 445442, upload-time = "2025-11-05T18:38:02.434Z" },
+    { url = "https://files.pythonhosted.org/packages/24/31/90cc06584deb5d4fcafc0985e37741fc6b9717926a78674bbb3ce018957e/brotli-1.2.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0bbd5b5ccd157ae7913750476d48099aaf507a79841c0d04a9db4415b14842de", size = 1532658, upload-time = "2025-11-05T18:38:03.588Z" },
+    { url = "https://files.pythonhosted.org/packages/62/17/33bf0c83bcbc96756dfd712201d87342732fad70bb3472c27e833a44a4f9/brotli-1.2.0-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:3f3c908bcc404c90c77d5a073e55271a0a498f4e0756e48127c35d91cf155947", size = 1631241, upload-time = "2025-11-05T18:38:04.582Z" },
+    { url = "https://files.pythonhosted.org/packages/48/10/f47854a1917b62efe29bc98ac18e5d4f71df03f629184575b862ef2e743b/brotli-1.2.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1b557b29782a643420e08d75aea889462a4a8796e9a6cf5621ab05a3f7da8ef2", size = 1424307, upload-time = "2025-11-05T18:38:05.587Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/b7/f88eb461719259c17483484ea8456925ee057897f8e64487d76e24e5e38d/brotli-1.2.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:81da1b229b1889f25adadc929aeb9dbc4e922bd18561b65b08dd9343cfccca84", size = 1488208, upload-time = "2025-11-05T18:38:06.613Z" },
+    { url = "https://files.pythonhosted.org/packages/26/59/41bbcb983a0c48b0b8004203e74706c6b6e99a04f3c7ca6f4f41f364db50/brotli-1.2.0-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:ff09cd8c5eec3b9d02d2408db41be150d8891c5566addce57513bf546e3d6c6d", size = 1597574, upload-time = "2025-11-05T18:38:07.838Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/e6/8c89c3bdabbe802febb4c5c6ca224a395e97913b5df0dff11b54f23c1788/brotli-1.2.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:a1778532b978d2536e79c05dac2d8cd857f6c55cd0c95ace5b03740824e0e2f1", size = 1492109, upload-time = "2025-11-05T18:38:08.816Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/9a/4b19d4310b2dbd545c0c33f176b0528fa68c3cd0754e34b2f2bcf56548ae/brotli-1.2.0-cp310-cp310-win32.whl", hash = "sha256:b232029d100d393ae3c603c8ffd7e3fe6f798c5e28ddca5feabb8e8fdb732997", size = 334461, upload-time = "2025-11-05T18:38:10.729Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/39/70981d9f47705e3c2b95c0847dfa3e7a37aa3b7c6030aedc4873081ed005/brotli-1.2.0-cp310-cp310-win_amd64.whl", hash = "sha256:ef87b8ab2704da227e83a246356a2b179ef826f550f794b2c52cddb4efbd0196", size = 369035, upload-time = "2025-11-05T18:38:11.827Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/ef/f285668811a9e1ddb47a18cb0b437d5fc2760d537a2fe8a57875ad6f8448/brotli-1.2.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:15b33fe93cedc4caaff8a0bd1eb7e3dab1c61bb22a0bf5bdfdfd97cd7da79744", size = 863110, upload-time = "2025-11-05T18:38:12.978Z" },
+    { url = "https://files.pythonhosted.org/packages/50/62/a3b77593587010c789a9d6eaa527c79e0848b7b860402cc64bc0bc28a86c/brotli-1.2.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:898be2be399c221d2671d29eed26b6b2713a02c2119168ed914e7d00ceadb56f", size = 445438, upload-time = "2025-11-05T18:38:14.208Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/e1/7fadd47f40ce5549dc44493877db40292277db373da5053aff181656e16e/brotli-1.2.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:350c8348f0e76fff0a0fd6c26755d2653863279d086d3aa2c290a6a7251135dd", size = 1534420, upload-time = "2025-11-05T18:38:15.111Z" },
+    { url = "https://files.pythonhosted.org/packages/12/8b/1ed2f64054a5a008a4ccd2f271dbba7a5fb1a3067a99f5ceadedd4c1d5a7/brotli-1.2.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2e1ad3fda65ae0d93fec742a128d72e145c9c7a99ee2fcd667785d99eb25a7fe", size = 1632619, upload-time = "2025-11-05T18:38:16.094Z" },
+    { url = "https://files.pythonhosted.org/packages/89/5a/7071a621eb2d052d64efd5da2ef55ecdac7c3b0c6e4f9d519e9c66d987ef/brotli-1.2.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:40d918bce2b427a0c4ba189df7a006ac0c7277c180aee4617d99e9ccaaf59e6a", size = 1426014, upload-time = "2025-11-05T18:38:17.177Z" },
+    { url = "https://files.pythonhosted.org/packages/26/6d/0971a8ea435af5156acaaccec1a505f981c9c80227633851f2810abd252a/brotli-1.2.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:2a7f1d03727130fc875448b65b127a9ec5d06d19d0148e7554384229706f9d1b", size = 1489661, upload-time = "2025-11-05T18:38:18.41Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/75/c1baca8b4ec6c96a03ef8230fab2a785e35297632f402ebb1e78a1e39116/brotli-1.2.0-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:9c79f57faa25d97900bfb119480806d783fba83cd09ee0b33c17623935b05fa3", size = 1599150, upload-time = "2025-11-05T18:38:19.792Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/1a/23fcfee1c324fd48a63d7ebf4bac3a4115bdb1b00e600f80f727d850b1ae/brotli-1.2.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:844a8ceb8483fefafc412f85c14f2aae2fb69567bf2a0de53cdb88b73e7c43ae", size = 1493505, upload-time = "2025-11-05T18:38:20.913Z" },
+    { url = "https://files.pythonhosted.org/packages/36/e5/12904bbd36afeef53d45a84881a4810ae8810ad7e328a971ebbfd760a0b3/brotli-1.2.0-cp311-cp311-win32.whl", hash = "sha256:aa47441fa3026543513139cb8926a92a8e305ee9c71a6209ef7a97d91640ea03", size = 334451, upload-time = "2025-11-05T18:38:21.94Z" },
+    { url = "https://files.pythonhosted.org/packages/02/8b/ecb5761b989629a4758c394b9301607a5880de61ee2ee5fe104b87149ebc/brotli-1.2.0-cp311-cp311-win_amd64.whl", hash = "sha256:022426c9e99fd65d9475dce5c195526f04bb8be8907607e27e747893f6ee3e24", size = 369035, upload-time = "2025-11-05T18:38:22.941Z" },
+    { url = "https://files.pythonhosted.org/packages/11/ee/b0a11ab2315c69bb9b45a2aaed022499c9c24a205c3a49c3513b541a7967/brotli-1.2.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:35d382625778834a7f3061b15423919aa03e4f5da34ac8e02c074e4b75ab4f84", size = 861543, upload-time = "2025-11-05T18:38:24.183Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/2f/29c1459513cd35828e25531ebfcbf3e92a5e49f560b1777a9af7203eb46e/brotli-1.2.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7a61c06b334bd99bc5ae84f1eeb36bfe01400264b3c352f968c6e30a10f9d08b", size = 444288, upload-time = "2025-11-05T18:38:25.139Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/6f/feba03130d5fceadfa3a1bb102cb14650798c848b1df2a808356f939bb16/brotli-1.2.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:acec55bb7c90f1dfc476126f9711a8e81c9af7fb617409a9ee2953115343f08d", size = 1528071, upload-time = "2025-11-05T18:38:26.081Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/38/f3abb554eee089bd15471057ba85f47e53a44a462cfce265d9bf7088eb09/brotli-1.2.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:260d3692396e1895c5034f204f0db022c056f9e2ac841593a4cf9426e2a3faca", size = 1626913, upload-time = "2025-11-05T18:38:27.284Z" },
+    { url = "https://files.pythonhosted.org/packages/03/a7/03aa61fbc3c5cbf99b44d158665f9b0dd3d8059be16c460208d9e385c837/brotli-1.2.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:072e7624b1fc4d601036ab3f4f27942ef772887e876beff0301d261210bca97f", size = 1419762, upload-time = "2025-11-05T18:38:28.295Z" },
+    { url = "https://files.pythonhosted.org/packages/21/1b/0374a89ee27d152a5069c356c96b93afd1b94eae83f1e004b57eb6ce2f10/brotli-1.2.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:adedc4a67e15327dfdd04884873c6d5a01d3e3b6f61406f99b1ed4865a2f6d28", size = 1484494, upload-time = "2025-11-05T18:38:29.29Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/57/69d4fe84a67aef4f524dcd075c6eee868d7850e85bf01d778a857d8dbe0a/brotli-1.2.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:7a47ce5c2288702e09dc22a44d0ee6152f2c7eda97b3c8482d826a1f3cfc7da7", size = 1593302, upload-time = "2025-11-05T18:38:30.639Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/3b/39e13ce78a8e9a621c5df3aeb5fd181fcc8caba8c48a194cd629771f6828/brotli-1.2.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:af43b8711a8264bb4e7d6d9a6d004c3a2019c04c01127a868709ec29962b6036", size = 1487913, upload-time = "2025-11-05T18:38:31.618Z" },
+    { url = "https://files.pythonhosted.org/packages/62/28/4d00cb9bd76a6357a66fcd54b4b6d70288385584063f4b07884c1e7286ac/brotli-1.2.0-cp312-cp312-win32.whl", hash = "sha256:e99befa0b48f3cd293dafeacdd0d191804d105d279e0b387a32054c1180f3161", size = 334362, upload-time = "2025-11-05T18:38:32.939Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/4e/bc1dcac9498859d5e353c9b153627a3752868a9d5f05ce8dedd81a2354ab/brotli-1.2.0-cp312-cp312-win_amd64.whl", hash = "sha256:b35c13ce241abdd44cb8ca70683f20c0c079728a36a996297adb5334adfc1c44", size = 369115, upload-time = "2025-11-05T18:38:33.765Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/d4/4ad5432ac98c73096159d9ce7ffeb82d151c2ac84adcc6168e476bb54674/brotli-1.2.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:9e5825ba2c9998375530504578fd4d5d1059d09621a02065d1b6bfc41a8e05ab", size = 861523, upload-time = "2025-11-05T18:38:34.67Z" },
+    { url = "https://files.pythonhosted.org/packages/91/9f/9cc5bd03ee68a85dc4bc89114f7067c056a3c14b3d95f171918c088bf88d/brotli-1.2.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0cf8c3b8ba93d496b2fae778039e2f5ecc7cff99df84df337ca31d8f2252896c", size = 444289, upload-time = "2025-11-05T18:38:35.6Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/b6/fe84227c56a865d16a6614e2c4722864b380cb14b13f3e6bef441e73a85a/brotli-1.2.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c8565e3cdc1808b1a34714b553b262c5de5fbda202285782173ec137fd13709f", size = 1528076, upload-time = "2025-11-05T18:38:36.639Z" },
+    { url = "https://files.pythonhosted.org/packages/55/de/de4ae0aaca06c790371cf6e7ee93a024f6b4bb0568727da8c3de112e726c/brotli-1.2.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:26e8d3ecb0ee458a9804f47f21b74845cc823fd1bb19f02272be70774f56e2a6", size = 1626880, upload-time = "2025-11-05T18:38:37.623Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/16/a1b22cbea436642e071adcaf8d4b350a2ad02f5e0ad0da879a1be16188a0/brotli-1.2.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:67a91c5187e1eec76a61625c77a6c8c785650f5b576ca732bd33ef58b0dff49c", size = 1419737, upload-time = "2025-11-05T18:38:38.729Z" },
+    { url = "https://files.pythonhosted.org/packages/46/63/c968a97cbb3bdbf7f974ef5a6ab467a2879b82afbc5ffb65b8acbb744f95/brotli-1.2.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4ecdb3b6dc36e6d6e14d3a1bdc6c1057c8cbf80db04031d566eb6080ce283a48", size = 1484440, upload-time = "2025-11-05T18:38:39.916Z" },
+    { url = "https://files.pythonhosted.org/packages/06/9d/102c67ea5c9fc171f423e8399e585dabea29b5bc79b05572891e70013cdd/brotli-1.2.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:3e1b35d56856f3ed326b140d3c6d9db91740f22e14b06e840fe4bb1923439a18", size = 1593313, upload-time = "2025-11-05T18:38:41.24Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/4a/9526d14fa6b87bc827ba1755a8440e214ff90de03095cacd78a64abe2b7d/brotli-1.2.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:54a50a9dad16b32136b2241ddea9e4df159b41247b2ce6aac0b3276a66a8f1e5", size = 1487945, upload-time = "2025-11-05T18:38:42.277Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/e8/3fe1ffed70cbef83c5236166acaed7bb9c766509b157854c80e2f766b38c/brotli-1.2.0-cp313-cp313-win32.whl", hash = "sha256:1b1d6a4efedd53671c793be6dd760fcf2107da3a52331ad9ea429edf0902f27a", size = 334368, upload-time = "2025-11-05T18:38:43.345Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/91/e739587be970a113b37b821eae8097aac5a48e5f0eca438c22e4c7dd8648/brotli-1.2.0-cp313-cp313-win_amd64.whl", hash = "sha256:b63daa43d82f0cdabf98dee215b375b4058cce72871fd07934f179885aad16e8", size = 369116, upload-time = "2025-11-05T18:38:44.609Z" },
+    { url = "https://files.pythonhosted.org/packages/17/e1/298c2ddf786bb7347a1cd71d63a347a79e5712a7c0cba9e3c3458ebd976f/brotli-1.2.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:6c12dad5cd04530323e723787ff762bac749a7b256a5bece32b2243dd5c27b21", size = 863080, upload-time = "2025-11-05T18:38:45.503Z" },
+    { url = "https://files.pythonhosted.org/packages/84/0c/aac98e286ba66868b2b3b50338ffbd85a35c7122e9531a73a37a29763d38/brotli-1.2.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:3219bd9e69868e57183316ee19c84e03e8f8b5a1d1f2667e1aa8c2f91cb061ac", size = 445453, upload-time = "2025-11-05T18:38:46.433Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/f1/0ca1f3f99ae300372635ab3fe2f7a79fa335fee3d874fa7f9e68575e0e62/brotli-1.2.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:963a08f3bebd8b75ac57661045402da15991468a621f014be54e50f53a58d19e", size = 1528168, upload-time = "2025-11-05T18:38:47.371Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/a6/2ebfc8f766d46df8d3e65b880a2e220732395e6d7dc312c1e1244b0f074a/brotli-1.2.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:9322b9f8656782414b37e6af884146869d46ab85158201d82bab9abbcb971dc7", size = 1627098, upload-time = "2025-11-05T18:38:48.385Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/2f/0976d5b097ff8a22163b10617f76b2557f15f0f39d6a0fe1f02b1a53e92b/brotli-1.2.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:cf9cba6f5b78a2071ec6fb1e7bd39acf35071d90a81231d67e92d637776a6a63", size = 1419861, upload-time = "2025-11-05T18:38:49.372Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/97/d76df7176a2ce7616ff94c1fb72d307c9a30d2189fe877f3dd99af00ea5a/brotli-1.2.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7547369c4392b47d30a3467fe8c3330b4f2e0f7730e45e3103d7d636678a808b", size = 1484594, upload-time = "2025-11-05T18:38:50.655Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/93/14cf0b1216f43df5609f5b272050b0abd219e0b54ea80b47cef9867b45e7/brotli-1.2.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:fc1530af5c3c275b8524f2e24841cbe2599d74462455e9bae5109e9ff42e9361", size = 1593455, upload-time = "2025-11-05T18:38:51.624Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/73/3183c9e41ca755713bdf2cc1d0810df742c09484e2e1ddd693bee53877c1/brotli-1.2.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:d2d085ded05278d1c7f65560aae97b3160aeb2ea2c0b3e26204856beccb60888", size = 1488164, upload-time = "2025-11-05T18:38:53.079Z" },
+    { url = "https://files.pythonhosted.org/packages/64/6a/0c78d8f3a582859236482fd9fa86a65a60328a00983006bcf6d83b7b2253/brotli-1.2.0-cp314-cp314-win32.whl", hash = "sha256:832c115a020e463c2f67664560449a7bea26b0c1fdd690352addad6d0a08714d", size = 339280, upload-time = "2025-11-05T18:38:54.02Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/10/56978295c14794b2c12007b07f3e41ba26acda9257457d7085b0bb3bb90c/brotli-1.2.0-cp314-cp314-win_amd64.whl", hash = "sha256:e7c0af964e0b4e3412a0ebf341ea26ec767fa0b4cf81abb5e897c9338b5ad6a3", size = 375639, upload-time = "2025-11-05T18:38:55.67Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.2.25"
 source = { registry = "https://pypi.org/simple" }
@@ -340,7 +398,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -2132,6 +2190,7 @@ wheels = [
 name = "trackio"
 source = { editable = "." }
 dependencies = [
+    { name = "brotli" },
     { name = "gradio-client" },
     { name = "huggingface-hub" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
@@ -2174,6 +2233,7 @@ tensorboard = [
 
 [package.metadata]
 requires-dist = [
+    { name = "brotli", specifier = ">=1.0.0,<2.0.0" },
     { name = "gradio-client", specifier = ">=2.0.0,<3.0.0" },
     { name = "huggingface-hub", specifier = ">=1.10.0,<2" },
     { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.0.0,<2.0.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -118,7 +118,7 @@ wheels = [
 
 [[package]]
 name = "carbonteq-trackio"
-version = "0.31.5.post1"
+version = "0.31.5.post2"
 source = { editable = "." }
 dependencies = [
     { name = "brotli" },


### PR DESCRIPTION
## Summary
- Land bulk `run_lifecycles` / `run_configs` APIs (formerly post4).
- **post5**: fix `_version.py` vs `pyproject.toml` skew. `0.31.5.post4` on `pypi.lan` is permanently wrong (metadata post4, import post3); do not use it.

## Test plan
- [x] Focused lifecycle unit tests
- [x] `tests/unit/test_distribution.py` (version sync)
- [ ] CI green
- [ ] After merge: tag `carbonteq-v0.31.5.post5`, publish to pypi.lan + attempt PyPI
- [ ] Redeploy Trackio server; update framework pin