### PR TITLE
Remove beta status from logbooks

### DIFF
--- a/.changeset/deep-chicken-drive.md
+++ b/.changeset/deep-chicken-drive.md
@@ -1,0 +1,5 @@
+---
+"trackio": minor
+---
+
+feat:Remove beta status from logbooks

--- a/docs/source/_toctree.yml
+++ b/docs/source/_toctree.yml
@@ -25,6 +25,8 @@
     title: Python API for Managing Runs
   - local: cli_commands
     title: CLI Commands
+  - local: logbooks
+    title: Logbooks
   - local: storage_schema
     title: Storage Schema and Direct Queries
   - local: api_mcp_server

--- a/docs/source/logbooks.md
+++ b/docs/source/logbooks.md
@@ -5,17 +5,73 @@ commands, results, figures, artifacts, and agent traces behind an experiment.
 A logbook is stored locally in the `.trackio/logbook` directory of a workspace
 and can be previewed locally or published as a static Hugging Face Space.
 
-## Create and preview a logbook
+> **Recommended for coding agents:** Start the logbook at the beginning of the
+> agent session. Install the Trackio skill so the agent knows to run experiment
+> commands through the logbook, then attach the active session trace. This
+> creates a complete record that a person or the next agent can continue from.
 
-From an experiment workspace, create a logbook and open its local preview:
+## Start an agent session with a logbook
+
+The easiest way to use a logbook is to create it before the agent starts making
+changes or running experiments:
 
 ```sh
 trackio logbook open --title "Learning-rate sweep"
 ```
 
-Use `--no-serve` when you only want to create or attach to the local logbook.
-Use `--no-browser` to start the preview without opening a browser, or pass
-`--port` to select a different port.
+This creates the local logbook and opens its preview. Use `--no-serve` when
+you only want to create or attach to the local logbook. Use `--no-browser` to
+start the preview without opening a browser, or pass `--port` to select a
+different port.
+
+### Give the agent the Trackio skill
+
+Install the Trackio skill for the coding agent you are using. For Codex:
+
+```sh
+trackio skills add --codex
+```
+
+The command installs the skill in the project and links it for Codex. Start a
+new Codex session after installation when necessary so it can load the skill.
+For another supported agent, replace `--codex` with its flag, such as
+`--claude`, `--cursor`, `--opencode`, or `--pi`.
+
+The skill tells the agent to run code with `trackio logbook run -- ...` rather
+than invoking an experiment command directly. That wrapper records the exact
+command, detected scripts and configuration files, output, exit code, duration,
+and supported output artifacts. For example:
+
+```sh
+trackio logbook page "Baseline"
+trackio logbook run -- python train.py --learning-rate 0.001
+```
+
+The training script should still use `trackio.init()`, `trackio.log()`, and
+`trackio.finish()` normally. With a logbook in the workspace, `trackio.init()`
+can also add a live dashboard cell for the active Trackio project.
+
+### Attach the active session trace
+
+Attach the current coding-agent transcript near the beginning of the session:
+
+```sh
+trackio logbook attach trace /absolute/path/to/current-session.jsonl --title "Agent session"
+```
+
+The agent runtime determines where its transcript is stored. Find the JSON or
+JSONL file for the active conversation using that runtime's session directory,
+then attach the file whose timestamps and metadata match the session. An active
+JSONL file can be attached before the session ends; Trackio refreshes it while
+the local preview is open. Attaching also establishes the Workspace baseline,
+so later supported model and data files can be associated with the session.
+
+Trackio scrubs common secrets from an attached trace by default. Review traces
+before publishing because they can still contain prompts, tool inputs, command
+output, paths, or personal data. Use `--no-scrub` only for an already-sanitized
+source.
+
+### Create pages as the work develops
 
 Opening a workspace that already contains a logbook attaches to it. The
 logbook is made up of pages; create or select a page with:
@@ -60,15 +116,6 @@ trackio logbook read --json
 
 Use `trackio logbook read cell <cell-id> --full` when a cell needs to be
 inspected in full. The JSON form is useful for automation and coding agents.
-
-Agent session traces can be attached explicitly:
-
-```sh
-trackio logbook attach trace session.jsonl --title "Agent run"
-```
-
-By default, secrets are scrubbed from attached traces. Use `--no-scrub` only
-when the source is known to contain no sensitive data.
 
 ## Publish a logbook
 

--- a/docs/source/logbooks.md
+++ b/docs/source/logbooks.md
@@ -1,0 +1,101 @@
+# Logbooks
+
+Trackio logbooks are shareable experiment notebooks for recording the reasoning,
+commands, results, figures, artifacts, and agent traces behind an experiment.
+A logbook is stored locally in the `.trackio/logbook` directory of a workspace
+and can be previewed locally or published as a static Hugging Face Space.
+
+## Create and preview a logbook
+
+From an experiment workspace, create a logbook and open its local preview:
+
+```sh
+trackio logbook open --title "Learning-rate sweep"
+```
+
+Use `--no-serve` when you only want to create or attach to the local logbook.
+Use `--no-browser` to start the preview without opening a browser, or pass
+`--port` to select a different port.
+
+Opening a workspace that already contains a logbook attaches to it. The
+logbook is made up of pages; create or select a page with:
+
+```sh
+trackio logbook page "Baseline"
+```
+
+## Add experiment content
+
+Add Markdown, code, figures, artifacts, or an embedded Trackio dashboard:
+
+```sh
+trackio logbook cell markdown "Baseline accuracy: 82.4%" --page "Baseline"
+trackio logbook cell code --page "Baseline" --code-text "print(metrics)" --language python
+trackio logbook cell figure --page "Baseline" --image plots/baseline.png
+trackio logbook cell artifact "my-project/model:v1" --page "Baseline" --type model
+trackio logbook cell dashboard my-project --page "Baseline"
+```
+
+To run an experiment command and capture its command, output, scripts, and
+output files in one step:
+
+```sh
+trackio logbook run --page "Sweep" -- python train.py --learning-rate 0.001
+```
+
+Output model and data files are recorded as artifact cells by default. Pass
+`--no-artifacts` to disable that capture.
+
+## Read a logbook programmatically
+
+`trackio logbook read` produces a compact, agent-friendly view. It can read a
+local workspace, a published Space ID, or a logbook URL:
+
+```sh
+trackio logbook read
+trackio logbook read pages
+trackio logbook read page "Baseline"
+trackio logbook read --json
+```
+
+Use `trackio logbook read cell <cell-id> --full` when a cell needs to be
+inspected in full. The JSON form is useful for automation and coding agents.
+
+Agent session traces can be attached explicitly:
+
+```sh
+trackio logbook attach trace session.jsonl --title "Agent run"
+```
+
+By default, secrets are scrubbed from attached traces. Use `--no-scrub` only
+when the source is known to contain no sensitive data.
+
+## Publish a logbook
+
+Publish the current logbook to a Hugging Face Space:
+
+```sh
+trackio logbook publish username/learning-rate-logbook
+```
+
+Published logbooks are static and read-only. The Space stores references to
+trace datasets and artifact buckets by default; use `--public` only when those
+referenced resources should also be public. Use `--private` to make the Space
+private.
+
+## Keep a logbook current
+
+Regenerate the derived site files after editing page sources directly:
+
+```sh
+trackio logbook sync
+```
+
+Use `trackio logbook pin <cell-id>` to surface an important cell on the
+logbook introduction, and `trackio logbook remove trace <session-id>` or
+`trackio logbook cell remove <cell-id>` to remove attached content.
+
+The Python API exposes the same building blocks through `trackio.logbook`,
+including `create_logbook`, `ensure_page`, `add_markdown_cell`,
+`add_code_cell`, `add_figure_cell`, `add_artifact_cell`, `attach_trace`, and
+`publish`.

--- a/docs/source/logbooks.md
+++ b/docs/source/logbooks.md
@@ -10,6 +10,25 @@ and can be previewed locally or published as a static Hugging Face Space.
 > commands through the logbook, then attach the active session trace. This
 > creates a complete record that a person or the next agent can continue from.
 
+Run these commands from the experiment workspace before beginning substantive
+work (replace the placeholders):
+
+```sh
+trackio logbook open --title "<experiment title>"
+trackio skills add --codex
+trackio logbook attach trace "/absolute/path/to/current-session.jsonl" --title "Codex session"
+```
+
+Give the coding agent these instructions immediately:
+
+> Work in this workspace's Trackio logbook. Before running any experiment or
+> script, create or select the relevant page with `trackio logbook page "..."`.
+> Run every experiment command with `trackio logbook run -- <command>` rather
+> than invoking it directly. Record findings with Markdown, figures, and
+> artifacts as they are produced. Keep the attached session trace in place and
+> review it for sensitive content before publishing. Use `trackio logbook read`
+> to understand the current record before continuing work from another session.
+
 ## Start an agent session with a logbook
 
 The easiest way to use a logbook is to create it before the agent starts making

--- a/docs/source/logbooks.md
+++ b/docs/source/logbooks.md
@@ -1,33 +1,22 @@
 # Logbooks
 
 Trackio logbooks are shareable experiment notebooks for recording the reasoning,
-commands, results, figures, artifacts, and agent traces behind an experiment.
+commands, results, figures, artifacts (checkpoints, datasets, etc.), and agent traces behind an experiment.
 A logbook is stored locally in the `.trackio/logbook` directory of a workspace
 and can be previewed locally or published as a static Hugging Face Space.
 
-> **Recommended for coding agents:** Start the logbook at the beginning of the
-> agent session. Install the Trackio skill so the agent knows to run experiment
-> commands through the logbook, then attach the active session trace. This
-> creates a complete record that a person or the next agent can continue from.
+**Recommended for coding agents**: The easiest way to use Logbooks with coding agents (e.g. Codex, Claude Code, Pi, OpenCode) is to just give your coding agent these instructions:
 
-Run these commands from the experiment workspace before beginning substantive
-work (replace the placeholders):
+```txt
+trackio skills add
+trackio logbook open
+trackio logbook attach trace <path to current trace>
 
-```sh
-trackio logbook open --title "<experiment title>"
-trackio skills add --codex
-trackio logbook attach trace "/absolute/path/to/current-session.jsonl" --title "Codex session"
+Work in this workspace's Trackio logbook. Before running any experiment or
+script, create or select the relevant page with `trackio logbook page "..."`. Run every experiment command with `trackio logbook run -- <command>` ratherthan invoking it directly, which will log the code and its outputs into the logbook. 
 ```
 
-Give the coding agent these instructions immediately:
-
-> Work in this workspace's Trackio logbook. Before running any experiment or
-> script, create or select the relevant page with `trackio logbook page "..."`.
-> Run every experiment command with `trackio logbook run -- <command>` rather
-> than invoking it directly. Record findings with Markdown, figures, and
-> artifacts as they are produced. Keep the attached session trace in place and
-> review it for sensitive content before publishing. Use `trackio logbook read`
-> to understand the current record before continuing work from another session.
+For more specifics and fine-grained control, keep reading!
 
 ## Start an agent session with a logbook
 
@@ -145,23 +134,5 @@ trackio logbook publish username/learning-rate-logbook
 ```
 
 Published logbooks are static and read-only. The Space stores references to
-trace datasets and artifact buckets by default; use `--public` only when those
-referenced resources should also be public. Use `--private` to make the Space
-private.
+trace datasets and artifact buckets by default; use `--public` only when those referenced resources should also be public. Use `--private` to make the Space private.
 
-## Keep a logbook current
-
-Regenerate the derived site files after editing page sources directly:
-
-```sh
-trackio logbook sync
-```
-
-Use `trackio logbook pin <cell-id>` to surface an important cell on the
-logbook introduction, and `trackio logbook remove trace <session-id>` or
-`trackio logbook cell remove <cell-id>` to remove attached content.
-
-The Python API exposes the same building blocks through `trackio.logbook`,
-including `create_logbook`, `ensure_page`, `add_markdown_cell`,
-`add_code_cell`, `add_figure_cell`, `add_artifact_cell`, `attach_trace`, and
-`publish`.

--- a/tests/unit/test_logbook.py
+++ b/tests/unit/test_logbook.py
@@ -719,19 +719,6 @@ def test_cli_cell_dashboard(proj, monkeypatch):
     assert cells[0]["project"] == "mnist"
 
 
-def test_cli_logbook_open_does_not_report_beta_status(proj, monkeypatch, capsys):
-    from trackio import cli
-
-    monkeypatch.setattr(
-        sys,
-        "argv",
-        ["trackio", "logbook", "open", "--no-serve"],
-    )
-    cli.main()
-
-    assert "experimental" not in capsys.readouterr().out.lower()
-
-
 def test_resolve_read_source_local_and_invalid(proj, tmp_path):
     resolved = logbook.resolve_read_source(str(tmp_path))
     assert resolved == proj

--- a/tests/unit/test_logbook.py
+++ b/tests/unit/test_logbook.py
@@ -719,6 +719,19 @@ def test_cli_cell_dashboard(proj, monkeypatch):
     assert cells[0]["project"] == "mnist"
 
 
+def test_cli_logbook_open_does_not_report_beta_status(proj, monkeypatch, capsys):
+    from trackio import cli
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["trackio", "logbook", "open", "--no-serve"],
+    )
+    cli.main()
+
+    assert "experimental" not in capsys.readouterr().out.lower()
+
+
 def test_resolve_read_source_local_and_invalid(proj, tmp_path):
     resolved = logbook.resolve_read_source(str(tmp_path))
     assert resolved == proj

--- a/trackio/cli.py
+++ b/trackio/cli.py
@@ -1929,7 +1929,6 @@ def _handle_logbook(args):
     action = args.logbook_action
     try:
         if action == "open":
-            print("Warning: Trackio Logbook is an experimental feature.")
             proj = lb.find_project_dir()
             if proj is not None:
                 if args.space_id:


### PR DESCRIPTION
## What changed

- Remove the experimental-feature warning from `trackio logbook open`.
- Add a regression test covering the CLI output.
- Add a Logbooks guide covering creation, pages, cells, traces, reading, publishing, privacy, and sync workflows.

## Why

Logbooks are now documented as a supported Trackio workflow, so the CLI should not present them as experimental.

## Validation

- `pytest -q tests/unit/test_logbook.py` (66 passed)
- `python -m compileall -q trackio/cli.py`
- `git diff --check`