### PR TITLE
Fix remote media upload filenames

### DIFF
--- a/.changeset/fast-eggs-bake.md
+++ b/.changeset/fast-eggs-bake.md
@@ -1,0 +1,5 @@
+---
+"trackio": patch
+---
+
+feat:Fix remote media upload filenames

--- a/tests/unit/test_local_server_api.py
+++ b/tests/unit/test_local_server_api.py
@@ -345,7 +345,13 @@ def test_local_dashboard_upload_api_accepts_only_server_uploaded_paths(temp_dir)
         app.close()
 
 
-def test_local_dashboard_run_media_upload_preserves_media_basename(temp_dir):
+@pytest.mark.parametrize(
+    "orig_name_template",
+    ["{name}", "C:\\fakepath\\{name}"],
+)
+def test_local_dashboard_run_media_upload_preserves_media_basename(
+    temp_dir, orig_name_template
+):
     project = "test_local_run_media_upload"
     run_name = "run-media"
     step = 7
@@ -385,7 +391,9 @@ def test_local_dashboard_run_media_upload_preserves_media_basename(temp_dir):
                         "relative_path": None,
                         "uploaded_file": {
                             "path": uploaded_path,
-                            "orig_name": source_path.name,
+                            "orig_name": orig_name_template.format(
+                                name=source_path.name
+                            ),
                         },
                     }
                 ],
@@ -402,6 +410,41 @@ def test_local_dashboard_run_media_upload_preserves_media_basename(temp_dir):
         source_path.unlink(missing_ok=True)
         trackio.delete_project(project, force=True)
         app.close()
+
+
+@pytest.mark.parametrize(
+    "orig_name,expected",
+    [
+        ("image.png", "image.png"),
+        ("C:\\fakepath\\image.png", "image.png"),
+        ("nested/dir/image.png", "image.png"),
+        ("..", "fallback.bin"),
+        (".", "fallback.bin"),
+        ("../..", "fallback.bin"),
+        ("dir/", "dir"),
+        ("", "fallback.bin"),
+        (None, "fallback.bin"),
+        (17, "fallback.bin"),
+    ],
+)
+def test_uploaded_file_media_basename_rejects_unsafe_names(orig_name, expected):
+    from trackio.server import _uploaded_file_media_basename
+
+    upload = {"uploaded_file": {"path": "/tmp/staged", "orig_name": orig_name}}
+
+    assert _uploaded_file_media_basename(upload, "fallback.bin") == expected
+
+
+def test_uploaded_file_media_basename_stays_within_media_dir(tmp_path):
+    from trackio.server import _uploaded_file_media_basename
+
+    media_path = tmp_path / "project" / "run" / "7"
+    media_path.mkdir(parents=True)
+
+    for orig_name in ["..", "../..", "C:\\fakepath\\..", "nested/../.."]:
+        upload = {"uploaded_file": {"path": "/tmp/staged", "orig_name": orig_name}}
+        destination = media_path / _uploaded_file_media_basename(upload, "fallback.bin")
+        assert destination.resolve().parent == media_path.resolve()
 
 
 def test_get_tab_availability_reflects_data(temp_dir):

--- a/tests/unit/test_local_server_api.py
+++ b/tests/unit/test_local_server_api.py
@@ -345,6 +345,65 @@ def test_local_dashboard_upload_api_accepts_only_server_uploaded_paths(temp_dir)
         app.close()
 
 
+def test_local_dashboard_run_media_upload_preserves_media_basename(temp_dir):
+    project = "test_local_run_media_upload"
+    run_name = "run-media"
+    step = 7
+    source_path = Path(temp_dir) / "trackio-media-basename.png"
+    source_bytes = b"uploaded media bytes"
+    source_path.write_bytes(source_bytes)
+
+    app, url, _, full_url = trackio.show(block_thread=False, open_browser=False)
+    write_token = parse_qs(urlparse(full_url).query).get("write_token", [None])[0]
+    assert write_token
+    write_headers = {"x-trackio-write-token": write_token}
+
+    try:
+        with source_path.open("rb") as handle:
+            upload_response = httpx.post(
+                f"{url.rstrip('/')}/api/upload",
+                headers=write_headers,
+                files={"files": (source_path.name, handle)},
+                timeout=5,
+            )
+        upload_response.raise_for_status()
+        uploaded_path = upload_response.json()["paths"][0]
+        target = (
+            trackio_utils.MEDIA_DIR / project / run_name / str(step) / source_path.name
+        )
+        temp_name_target = target.parent / Path(uploaded_path).name
+
+        response = httpx.post(
+            f"{url.rstrip('/')}/api/bulk_upload_media",
+            headers=write_headers,
+            json={
+                "uploads": [
+                    {
+                        "project": project,
+                        "run": run_name,
+                        "step": step,
+                        "relative_path": None,
+                        "uploaded_file": {
+                            "path": uploaded_path,
+                            "orig_name": source_path.name,
+                        },
+                    }
+                ],
+                "hf_token": None,
+            },
+            timeout=5,
+        )
+
+        assert response.status_code == 200
+        assert target.read_bytes() == source_bytes
+        assert not temp_name_target.exists()
+        assert not Path(uploaded_path).exists()
+    finally:
+        source_path.unlink(missing_ok=True)
+        trackio.delete_project(project, force=True)
+        app.close()
+
+
 def test_get_tab_availability_reflects_data(temp_dir):
     from trackio.server import get_tab_availability
     from trackio.utils import MEDIA_DIR

--- a/trackio/server.py
+++ b/trackio/server.py
@@ -13,7 +13,7 @@ import warnings
 from collections import deque
 from collections.abc import Callable
 from functools import lru_cache
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any
 from urllib.parse import urlencode
 
@@ -607,6 +607,9 @@ def _uploaded_file_media_basename(upload: UploadEntry, fallback: str) -> str:
     Run media is serialized in metrics using the basename from the local
     Trackio media file. The server must store the uploaded bytes under that
     basename so `/file` lookups match the logged `file_path`.
+
+    The name is client-supplied, so separators of either platform are stripped
+    and relative components are rejected to keep the write inside `media_path`.
     """
     uploaded_file = upload.get("uploaded_file")
     raw_name = (
@@ -615,8 +618,10 @@ def _uploaded_file_media_basename(upload: UploadEntry, fallback: str) -> str:
     if not isinstance(raw_name, str) or not raw_name:
         return fallback
 
-    name = Path(raw_name).name
-    return name or fallback
+    name = PurePosixPath(raw_name.replace("\\", "/")).name
+    if name in ("", ".", ".."):
+        return fallback
+    return name
 
 
 def bulk_upload_media(
@@ -633,7 +638,7 @@ def bulk_upload_media(
             step=upload["step"],
             relative_path=upload["relative_path"],
         )
-        if upload["run"] is not None:
+        if upload["run"]:
             media_path = media_path / _uploaded_file_media_basename(upload, src.name)
         shutil.copy(src, media_path)
 

--- a/trackio/server.py
+++ b/trackio/server.py
@@ -601,6 +601,24 @@ def _bulk_upload(
             cleanup_uploaded_temp_file(path)
 
 
+def _uploaded_file_media_basename(upload: UploadEntry, fallback: str) -> str:
+    """Return the client-side Trackio media basename for a staged upload.
+
+    Run media is serialized in metrics using the basename from the local
+    Trackio media file. The server must store the uploaded bytes under that
+    basename so `/file` lookups match the logged `file_path`.
+    """
+    uploaded_file = upload.get("uploaded_file")
+    raw_name = (
+        uploaded_file.get("orig_name") if isinstance(uploaded_file, dict) else None
+    )
+    if not isinstance(raw_name, str) or not raw_name:
+        return fallback
+
+    name = Path(raw_name).name
+    return name or fallback
+
+
 def bulk_upload_media(
     request: Request,
     uploads: list[UploadEntry],
@@ -615,6 +633,8 @@ def bulk_upload_media(
             step=upload["step"],
             relative_path=upload["relative_path"],
         )
+        if upload["run"] is not None:
+            media_path = media_path / _uploaded_file_media_basename(upload, src.name)
         shutil.copy(src, media_path)
 
     _bulk_upload(request, uploads, _write)


### PR DESCRIPTION
## Short description

This PR fixes remote Trackio dashboard media uploads for run-scoped media. Previously, uploaded media was stored on the server using the temporary upload filename, while logged metrics referenced the original Trackio media basename in `file_path`. That mismatch caused images logged to a remote dashboard to appear as broken images in the UI.

The server now preserves the client-side Trackio media basename for run media uploads, and this PR adds a regression test covering `/api/bulk_upload_media`.

## AI Disclosure

- [x] I used AI to help diagnose the remote media filename mismatch, implement the fix and regression test, self-review the change, and draft this PR description.
- [ ] I did not use AI

## Type of Change

- [x] Bug fix
- [ ] New feature (non-breaking)
- [ ] New feature (breaking change)
- [ ] Documentation update
- [x] Test improvements

## Related Issues

Closes: N/A

## Testing and linting

Ran:

```bash
.venv/bin/python -m pytest tests/unit --ignore=tests/unit/test_gpu_hardware.py
.venv/bin/python -m pytest tests/ui
env -u TEST_SPACE_ID .venv/bin/python -m pytest tests/e2e-spaces
ruff check .
ruff format --check .
cd trackio/frontend && npm test && npm run lint
```

Results:

- Unit tests: `341 passed, 5 skipped`
- UI tests: `14 passed`
- Spaces e2e tests: `20 skipped` with `TEST_SPACE_ID` unset
- Ruff lint: passed
- Ruff format check: passed
- Frontend tests: `46 passed`
- Frontend lint: passed