### PR TITLE
Fix unstable metric sampling in charts that happens in `trl>=1.7.0`

### DIFF
--- a/.changeset/proud-dragons-battle.md
+++ b/.changeset/proud-dragons-battle.md
@@ -1,0 +1,5 @@
+---
+"trackio": minor
+---
+
+feat:Fix unstable metric sampling in charts

--- a/.changeset/proud-dragons-battle.md
+++ b/.changeset/proud-dragons-battle.md
@@ -1,5 +1,5 @@
 ---
-"trackio": minor
+"trackio": patch
 ---
 
 feat:Fix unstable metric sampling in charts that happens in `trl>=1.7.0`

--- a/.changeset/proud-dragons-battle.md
+++ b/.changeset/proud-dragons-battle.md
@@ -2,4 +2,4 @@
 "trackio": minor
 ---
 
-feat:Fix unstable metric sampling in charts
+feat:Fix unstable metric sampling in charts that happens in `trl>=1.7.0`

--- a/examples/live-metric-sampling.py
+++ b/examples/live-metric-sampling.py
@@ -34,7 +34,9 @@ STEPS = int(os.environ.get("STEPS", "800"))
 STEP_DELAY = float(os.environ.get("STEP_DELAY", "0.05"))
 DENSE_METRICS = 9
 POLL_INTERVAL = float(os.environ.get("POLL_INTERVAL", "1.0"))
-PROJECT = os.environ.get("PROJECT", f"repro-653-live-{random.randint(100000, 999999)}")
+PROJECT = os.environ.get(
+    "PROJECT", f"repro-653-live-{random.randint(100000, 999999)}"
+)
 RUN_NAME = "run-1"
 OPEN_BROWSER = os.environ.get("OPEN_BROWSER", "1") != "0"
 KEEP_OPEN = os.environ.get("KEEP_OPEN", "1") != "0"
@@ -45,7 +47,11 @@ def log_step(step: int) -> None:
         trackio.log({f"dense/metric_{metric_index}": 0.0}, step=step)
 
     if step % 10 == 0:
-        loss = 2.0 + (0.75 if (step // 10) % 2 else -0.75) + 0.15 * math.sin(step / 20)
+        loss = (
+            2.0
+            + (0.75 if (step // 10) % 2 else -0.75)
+            + 0.15 * math.sin(step / 20)
+        )
         trackio.log(
             {"sparse/value": float(step), "train/loss": round(loss, 5)}, step=step
         )
@@ -88,7 +94,9 @@ def print_integrity_check() -> None:
     display_logs = SQLiteStorage.get_logs(
         PROJECT, RUN_NAME, max_points=3000, scalar_only=True
     )
-    stored_sparse_steps = [row["step"] for row in stored_logs if "sparse/value" in row]
+    stored_sparse_steps = [
+        row["step"] for row in stored_logs if "sparse/value" in row
+    ]
     displayed_sparse_steps = [
         row["step"] for row in display_logs if "sparse/value" in row
     ]
@@ -99,9 +107,7 @@ def print_integrity_check() -> None:
     print(f"  display rows:             {len(display_logs)}")
     print(f"  stored sparse/value:      {len(stored_sparse_steps)}")
     print(f"  shown sparse/value:       {len(displayed_sparse_steps)}")
-    print(
-        f"  expected cadence intact:  {displayed_sparse_steps == expected_sparse_steps}"
-    )
+    print(f"  expected cadence intact:  {displayed_sparse_steps == expected_sparse_steps}")
 
 
 def main() -> None:

--- a/examples/live-metric-sampling.py
+++ b/examples/live-metric-sampling.py
@@ -1,18 +1,25 @@
-"""Live reproduction for mixed-cadence metric sampling.
+"""Live version of the mixed-cadence reproduction from Trackio issue #653.
 
 Run from the repository root:
 
     .venv/bin/python examples/live-metric-sampling.py
 
-The dashboard opens before logging begins. On the Metrics page, watch
-``train/loss`` as the row count crosses 3,000. A broken Trackio build drops
-roughly half of its points and reshuffles them on every refresh. A fixed build
-keeps the complete 10-step cadence stable throughout the run.
+The dashboard opens before logging begins. Each training step writes nine
+``dense/metric_*`` rows, while ``sparse/value`` is written every 10 steps. This
+is the same 7,280-row layout as the issue reproduction. ``train/loss`` is added
+to the same sparse row with a deliberately jagged value so dropped points are
+easy to see in a connected line chart.
+
+On the Metrics page, watch ``train/loss`` as the row count crosses 3,000. The
+terminal also prints the displayed sparse-point count and how many selected
+points changed since the previous one-second dashboard poll. A broken build
+drops points and reports large changes; a fixed build keeps the complete
+10-step cadence and never drops an existing point.
 
 The defaults log for about 40 seconds and leave the dashboard running until
 Ctrl+C. Override them when needed, for example:
 
-    STEPS=400 STEP_DELAY=0.02 python examples/live-metric-sampling.py
+    STEPS=400 STEP_DELAY=0.02 .venv/bin/python examples/live-metric-sampling.py
 """
 
 import math
@@ -25,29 +32,55 @@ from trackio.sqlite_storage import SQLiteStorage
 
 STEPS = int(os.environ.get("STEPS", "800"))
 STEP_DELAY = float(os.environ.get("STEP_DELAY", "0.05"))
-PROFILE_METRICS = 9
-PROJECT = os.environ.get(
-    "PROJECT", f"live-metric-sampling-{random.randint(100000, 999999)}"
-)
-RUN_NAME = "mixed-cadence-run"
+DENSE_METRICS = 9
+POLL_INTERVAL = float(os.environ.get("POLL_INTERVAL", "1.0"))
+PROJECT = os.environ.get("PROJECT", f"repro-653-live-{random.randint(100000, 999999)}")
+RUN_NAME = "run-1"
 OPEN_BROWSER = os.environ.get("OPEN_BROWSER", "1") != "0"
 KEEP_OPEN = os.environ.get("KEEP_OPEN", "1") != "0"
 
 
 def log_step(step: int) -> None:
-    for metric_index in range(PROFILE_METRICS):
-        duration = (
-            0.002 + metric_index * 0.0002 + 0.0004 * math.sin(step / (8 + metric_index))
-        )
-        trackio.log({f"profiling/block_{metric_index}": round(duration, 6)}, step=step)
+    for metric_index in range(DENSE_METRICS):
+        trackio.log({f"dense/metric_{metric_index}": 0.0}, step=step)
 
     if step % 10 == 0:
-        loss = 2.5 * math.exp(-step / 300) + 0.04 * math.sin(step / 25)
-        trackio.log({"train/loss": round(loss, 5)}, step=step)
+        loss = 2.0 + (0.75 if (step // 10) % 2 else -0.75) + 0.15 * math.sin(step / 20)
+        trackio.log(
+            {"sparse/value": float(step), "train/loss": round(loss, 5)}, step=step
+        )
 
 
 def rows_through_step(step: int) -> int:
-    return (step + 1) * PROFILE_METRICS + step // 10 + 1
+    return (step + 1) * DENSE_METRICS + step // 10 + 1
+
+
+def read_sparse_steps(max_points: int | None) -> set[int]:
+    logs = SQLiteStorage.get_logs(
+        PROJECT,
+        RUN_NAME,
+        max_points=max_points,
+        scalar_only=True,
+    )
+    return {row["step"] for row in logs if "sparse/value" in row}
+
+
+def print_poll(previous_steps: set[int]) -> set[int]:
+    stored_steps = read_sparse_steps(None)
+    displayed_steps = read_sparse_steps(3000)
+    changed_steps = displayed_steps ^ previous_steps
+    dropped_steps = previous_steps - displayed_steps
+    missing_steps = stored_steps - displayed_steps
+    row_count = SQLiteStorage.get_log_count(PROJECT, RUN_NAME)
+
+    print(
+        f"poll rows={row_count:5d}  "
+        f"sparse={len(displayed_steps):2d}/{len(stored_steps):2d}  "
+        f"missing={len(missing_steps):2d}  "
+        f"changed={len(changed_steps):2d}  "
+        f"dropped={len(dropped_steps):2d}"
+    )
+    return displayed_steps
 
 
 def print_integrity_check() -> None:
@@ -55,16 +88,20 @@ def print_integrity_check() -> None:
     display_logs = SQLiteStorage.get_logs(
         PROJECT, RUN_NAME, max_points=3000, scalar_only=True
     )
-    stored_loss_steps = [row["step"] for row in stored_logs if "train/loss" in row]
-    displayed_loss_steps = [row["step"] for row in display_logs if "train/loss" in row]
-    expected_loss_steps = list(range(0, STEPS, 10))
+    stored_sparse_steps = [row["step"] for row in stored_logs if "sparse/value" in row]
+    displayed_sparse_steps = [
+        row["step"] for row in display_logs if "sparse/value" in row
+    ]
+    expected_sparse_steps = list(range(0, STEPS, 10))
 
     print("\nIntegrity check")
     print(f"  stored rows:              {len(stored_logs)}")
     print(f"  display rows:             {len(display_logs)}")
-    print(f"  stored train/loss points: {len(stored_loss_steps)}")
-    print(f"  shown train/loss points:  {len(displayed_loss_steps)}")
-    print(f"  expected cadence intact:  {displayed_loss_steps == expected_loss_steps}")
+    print(f"  stored sparse/value:      {len(stored_sparse_steps)}")
+    print(f"  shown sparse/value:       {len(displayed_sparse_steps)}")
+    print(
+        f"  expected cadence intact:  {displayed_sparse_steps == expected_sparse_steps}"
+    )
 
 
 def main() -> None:
@@ -76,8 +113,8 @@ def main() -> None:
             name=RUN_NAME,
             config={
                 "steps": STEPS,
-                "profile_metrics_per_step": PROFILE_METRICS,
-                "loss_logging_steps": 10,
+                "dense_metrics_per_step": DENSE_METRICS,
+                "sparse_logging_steps": 10,
             },
             embed=False,
             auto_log_gpu=False,
@@ -91,18 +128,22 @@ def main() -> None:
             open_browser=OPEN_BROWSER,
             block_thread=False,
         )
-        print("\nOpen the Metrics page and watch train/loss.")
+        print("\nOpen the Metrics page and watch train/loss for visible movement.")
+        print("sparse/value mirrors the exact linear metric from issue #653.")
         print("The sampling threshold is crossed after roughly 330 training steps.\n")
 
         threshold_announced = False
+        displayed_sparse_steps: set[int] = set()
+        next_poll = time.monotonic() + POLL_INTERVAL
         for step in range(1, STEPS):
             log_step(step)
             row_count = rows_through_step(step)
             if not threshold_announced and row_count > 3000:
                 print(f"Crossed 3,000 metric rows at step {step}.")
                 threshold_announced = True
-            if step % 50 == 0 or step == STEPS - 1:
-                print(f"step={step:4d}  metric_rows={row_count:5d}")
+            if time.monotonic() >= next_poll:
+                displayed_sparse_steps = print_poll(displayed_sparse_steps)
+                next_poll = time.monotonic() + POLL_INTERVAL
             time.sleep(STEP_DELAY)
 
         trackio.finish()

--- a/examples/live-metric-sampling.py
+++ b/examples/live-metric-sampling.py
@@ -34,9 +34,7 @@ STEPS = int(os.environ.get("STEPS", "800"))
 STEP_DELAY = float(os.environ.get("STEP_DELAY", "0.05"))
 DENSE_METRICS = 9
 POLL_INTERVAL = float(os.environ.get("POLL_INTERVAL", "1.0"))
-PROJECT = os.environ.get(
-    "PROJECT", f"repro-653-live-{random.randint(100000, 999999)}"
-)
+PROJECT = os.environ.get("PROJECT", f"repro-653-live-{random.randint(100000, 999999)}")
 RUN_NAME = "run-1"
 OPEN_BROWSER = os.environ.get("OPEN_BROWSER", "1") != "0"
 KEEP_OPEN = os.environ.get("KEEP_OPEN", "1") != "0"
@@ -47,11 +45,7 @@ def log_step(step: int) -> None:
         trackio.log({f"dense/metric_{metric_index}": 0.0}, step=step)
 
     if step % 10 == 0:
-        loss = (
-            2.0
-            + (0.75 if (step // 10) % 2 else -0.75)
-            + 0.15 * math.sin(step / 20)
-        )
+        loss = 2.0 + (0.75 if (step // 10) % 2 else -0.75) + 0.15 * math.sin(step / 20)
         trackio.log(
             {"sparse/value": float(step), "train/loss": round(loss, 5)}, step=step
         )
@@ -94,9 +88,7 @@ def print_integrity_check() -> None:
     display_logs = SQLiteStorage.get_logs(
         PROJECT, RUN_NAME, max_points=3000, scalar_only=True
     )
-    stored_sparse_steps = [
-        row["step"] for row in stored_logs if "sparse/value" in row
-    ]
+    stored_sparse_steps = [row["step"] for row in stored_logs if "sparse/value" in row]
     displayed_sparse_steps = [
         row["step"] for row in display_logs if "sparse/value" in row
     ]
@@ -107,7 +99,9 @@ def print_integrity_check() -> None:
     print(f"  display rows:             {len(display_logs)}")
     print(f"  stored sparse/value:      {len(stored_sparse_steps)}")
     print(f"  shown sparse/value:       {len(displayed_sparse_steps)}")
-    print(f"  expected cadence intact:  {displayed_sparse_steps == expected_sparse_steps}")
+    print(
+        f"  expected cadence intact:  {displayed_sparse_steps == expected_sparse_steps}"
+    )
 
 
 def main() -> None:

--- a/examples/live-metric-sampling.py
+++ b/examples/live-metric-sampling.py
@@ -1,0 +1,126 @@
+"""Live reproduction for mixed-cadence metric sampling.
+
+Run from the repository root:
+
+    .venv/bin/python examples/live-metric-sampling.py
+
+The dashboard opens before logging begins. On the Metrics page, watch
+``train/loss`` as the row count crosses 3,000. A broken Trackio build drops
+roughly half of its points and reshuffles them on every refresh. A fixed build
+keeps the complete 10-step cadence stable throughout the run.
+
+The defaults log for about 40 seconds and leave the dashboard running until
+Ctrl+C. Override them when needed, for example:
+
+    STEPS=400 STEP_DELAY=0.02 python examples/live-metric-sampling.py
+"""
+
+import math
+import os
+import random
+import time
+
+import trackio
+from trackio.sqlite_storage import SQLiteStorage
+
+STEPS = int(os.environ.get("STEPS", "800"))
+STEP_DELAY = float(os.environ.get("STEP_DELAY", "0.05"))
+PROFILE_METRICS = 9
+PROJECT = os.environ.get(
+    "PROJECT", f"live-metric-sampling-{random.randint(100000, 999999)}"
+)
+RUN_NAME = "mixed-cadence-run"
+OPEN_BROWSER = os.environ.get("OPEN_BROWSER", "1") != "0"
+KEEP_OPEN = os.environ.get("KEEP_OPEN", "1") != "0"
+
+
+def log_step(step: int) -> None:
+    for metric_index in range(PROFILE_METRICS):
+        duration = (
+            0.002 + metric_index * 0.0002 + 0.0004 * math.sin(step / (8 + metric_index))
+        )
+        trackio.log({f"profiling/block_{metric_index}": round(duration, 6)}, step=step)
+
+    if step % 10 == 0:
+        loss = 2.5 * math.exp(-step / 300) + 0.04 * math.sin(step / 25)
+        trackio.log({"train/loss": round(loss, 5)}, step=step)
+
+
+def rows_through_step(step: int) -> int:
+    return (step + 1) * PROFILE_METRICS + step // 10 + 1
+
+
+def print_integrity_check() -> None:
+    stored_logs = SQLiteStorage.get_logs(PROJECT, RUN_NAME)
+    display_logs = SQLiteStorage.get_logs(
+        PROJECT, RUN_NAME, max_points=3000, scalar_only=True
+    )
+    stored_loss_steps = [row["step"] for row in stored_logs if "train/loss" in row]
+    displayed_loss_steps = [row["step"] for row in display_logs if "train/loss" in row]
+    expected_loss_steps = list(range(0, STEPS, 10))
+
+    print("\nIntegrity check")
+    print(f"  stored rows:              {len(stored_logs)}")
+    print(f"  display rows:             {len(display_logs)}")
+    print(f"  stored train/loss points: {len(stored_loss_steps)}")
+    print(f"  shown train/loss points:  {len(displayed_loss_steps)}")
+    print(f"  expected cadence intact:  {displayed_loss_steps == expected_loss_steps}")
+
+
+def main() -> None:
+    dashboard = None
+    run_active = False
+    try:
+        trackio.init(
+            project=PROJECT,
+            name=RUN_NAME,
+            config={
+                "steps": STEPS,
+                "profile_metrics_per_step": PROFILE_METRICS,
+                "loss_logging_steps": 10,
+            },
+            embed=False,
+            auto_log_gpu=False,
+            auto_log_cpu=False,
+        )
+        run_active = True
+        log_step(0)
+
+        dashboard, _, _, _ = trackio.show(
+            project=PROJECT,
+            open_browser=OPEN_BROWSER,
+            block_thread=False,
+        )
+        print("\nOpen the Metrics page and watch train/loss.")
+        print("The sampling threshold is crossed after roughly 330 training steps.\n")
+
+        threshold_announced = False
+        for step in range(1, STEPS):
+            log_step(step)
+            row_count = rows_through_step(step)
+            if not threshold_announced and row_count > 3000:
+                print(f"Crossed 3,000 metric rows at step {step}.")
+                threshold_announced = True
+            if step % 50 == 0 or step == STEPS - 1:
+                print(f"step={step:4d}  metric_rows={row_count:5d}")
+            time.sleep(STEP_DELAY)
+
+        trackio.finish()
+        run_active = False
+        print_integrity_check()
+
+        if KEEP_OPEN:
+            print("\nDashboard is still running. Press Ctrl+C to stop it.")
+            while True:
+                time.sleep(1)
+    except KeyboardInterrupt:
+        print("\nStopping the live example.")
+    finally:
+        if run_active:
+            trackio.finish()
+        if dashboard is not None:
+            dashboard.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_sqlite_storage.py
+++ b/tests/unit/test_sqlite_storage.py
@@ -128,6 +128,35 @@ def test_scalar_only_rows_do_not_spend_sampling_budget(temp_dir):
     assert [row["loss"] for row in logs] == [float(index) for index in range(10)]
 
 
+def test_metric_group_budgets_scale_with_group_size():
+    budgets = SQLiteStorage._allocate_metric_group_budgets([100_000, 50, 50, 50], 3000)
+
+    assert sum(budgets) <= 3000
+    assert all(budget > 0 for budget in budgets)
+    assert budgets[0] > sum(budgets[1:])
+
+
+def test_metric_group_budgets_keep_every_group_when_budget_allows():
+    budgets = SQLiteStorage._allocate_metric_group_budgets([500_000] + [5] * 999, 3000)
+
+    assert sum(budgets) <= 3000
+    assert all(budget > 0 for budget in budgets)
+
+
+def test_dense_metric_survives_many_distinct_signatures(temp_dir):
+    metrics = [{"train/loss": float(step)} for step in range(20_000)]
+    steps = list(range(20_000))
+    metrics.extend({f"eval/sample_{index}/score": 1.0} for index in range(4000))
+    steps.extend(range(4000))
+
+    SQLiteStorage.bulk_log("proj1", "run1", metrics, steps=steps)
+
+    logs = SQLiteStorage.get_logs("proj1", "run1", max_points=3000)
+
+    assert len(logs) <= 3000
+    assert sum(1 for row in logs if "train/loss" in row) > 1000
+
+
 def test_get_projects_and_runs(temp_dir):
     SQLiteStorage.log(project="proj1", run="run1", metrics={"a": 1})
     SQLiteStorage.log(project="proj2", run="run2", metrics={"b": 2})

--- a/tests/unit/test_sqlite_storage.py
+++ b/tests/unit/test_sqlite_storage.py
@@ -57,6 +57,77 @@ def test_get_logs_scalar_only_excludes_heavy_values(temp_dir):
     ]
 
 
+def test_subsample_metric_rows_preserves_sparse_metrics(temp_dir):
+    metrics = []
+    steps = []
+    for step in range(800):
+        for metric_index in range(9):
+            metrics.append({f"dense/metric_{metric_index}": 0.0})
+            steps.append(step)
+        if step % 10 == 0:
+            metrics.append({"sparse/value": float(step)})
+            steps.append(step)
+
+    SQLiteStorage.bulk_log("proj1", "run1", metrics, steps=steps)
+
+    logs = SQLiteStorage.get_logs("proj1", "run1", max_points=3000)
+    sparse_steps = [row["step"] for row in logs if "sparse/value" in row]
+
+    assert len(logs) <= 3000
+    assert sparse_steps == list(range(0, 800, 10))
+
+
+def test_subsample_metric_rows_is_stable_as_rows_are_appended(temp_dir):
+    previous_metric_steps = None
+    for step_count in range(800, 805):
+        metrics = []
+        steps = []
+        for step in range(step_count):
+            for metric_index in range(9):
+                metrics.append({f"dense/metric_{metric_index}": 0.0})
+                steps.append(step)
+            if step % 10 == 0:
+                metrics.append({"sparse/value": float(step)})
+                steps.append(step)
+
+        project = f"proj-{step_count}"
+        SQLiteStorage.bulk_log(project, "run1", metrics, steps=steps)
+        logs = SQLiteStorage.get_logs(project, "run1", max_points=3000)
+        metric_steps = {
+            metric: {row["step"] for row in logs if metric in row}
+            for metric in [
+                *(f"dense/metric_{index}" for index in range(9)),
+                "sparse/value",
+            ]
+        }
+
+        assert len(logs) <= 3000
+        if previous_metric_steps is not None:
+            for metric, current_steps in metric_steps.items():
+                previous_steps = previous_metric_steps[metric]
+                assert previous_steps - current_steps <= {max(previous_steps)}
+        previous_metric_steps = metric_steps
+
+
+def test_scalar_only_rows_do_not_spend_sampling_budget(temp_dir):
+    metrics = [
+        {
+            "table": {
+                "_type": "trackio.table",
+                "_value": [{"value": index}],
+            }
+        }
+        for index in range(100)
+    ]
+    metrics.extend({"loss": float(index)} for index in range(10))
+    SQLiteStorage.bulk_log("proj1", "run1", metrics)
+
+    logs = SQLiteStorage.get_logs("proj1", "run1", max_points=10, scalar_only=True)
+
+    assert len(logs) == 10
+    assert [row["loss"] for row in logs] == [float(index) for index in range(10)]
+
+
 def test_get_projects_and_runs(temp_dir):
     SQLiteStorage.log(project="proj1", run="run1", metrics={"a": 1})
     SQLiteStorage.log(project="proj2", run="run2", metrics={"b": 2})

--- a/trackio/frontend/src/lib/dataProcessing.js
+++ b/trackio/frontend/src/lib/dataProcessing.js
@@ -250,7 +250,12 @@ function downsampleImpl(data, x, y, colorField, xLim, extraFields = []) {
       return;
     }
 
-    const binSize = (gXMax - gXMin) / nBins;
+    const targetBinSize = (gXMax - gXMin) / nBins;
+    const binSize = 2 ** Math.ceil(Math.log2(targetBinSize));
+    if (!Number.isFinite(binSize) || binSize <= 0) {
+      result.push(...groupData);
+      return;
+    }
     const bins = new Map();
 
     groupData.forEach((r) => {

--- a/trackio/frontend/src/lib/dataProcessing.test.js
+++ b/trackio/frontend/src/lib/dataProcessing.test.js
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "vitest";
-import { computeMetricPlotData, processRunData } from "./dataProcessing.js";
+import {
+  computeMetricPlotData,
+  downsample,
+  processRunData,
+} from "./dataProcessing.js";
 
 describe("processRunData smoothing", () => {
   test("does not fabricate values for rows that did not log the metric", () => {
@@ -72,5 +76,33 @@ describe("processRunData smoothing", () => {
     );
 
     expect(result.xColumn).toBe("step");
+  });
+
+  test("keeps downsampled bins stable as points are appended", () => {
+    let previousSteps;
+    for (let length = 500; length <= 504; length += 1) {
+      const rows = Array.from({ length }, (_, step) => ({
+        step,
+        value: step,
+        series_key: "run-1",
+      }));
+      const result = downsample(
+        rows,
+        "step",
+        "value",
+        "series_key",
+        null,
+      );
+      const steps = new Set(result.data.map((row) => row.step));
+
+      if (previousSteps) {
+        const changed = [
+          ...[...steps].filter((step) => !previousSteps.has(step)),
+          ...[...previousSteps].filter((step) => !steps.has(step)),
+        ];
+        expect(changed.length).toBeLessThanOrEqual(2);
+      }
+      previousSteps = steps;
+    }
   });
 });

--- a/trackio/sqlite_storage.py
+++ b/trackio/sqlite_storage.py
@@ -1958,7 +1958,7 @@ class SQLiteStorage:
             SELECT timestamp, metrics
             FROM system_metrics
             WHERE {run_identity[0]} = ?
-            ORDER BY timestamp
+            ORDER BY timestamp, id
             """,
             (run_identity[1],),
         )
@@ -2225,15 +2225,111 @@ class SQLiteStorage:
         return flags
 
     @staticmethod
-    def _subsample_metric_rows(rows: list[Any], max_points: int | None) -> list[Any]:
-        if max_points is None or max_points < 1:
-            return rows
+    def _is_scalar_metric_value(value: Any) -> bool:
+        return (isinstance(value, int | float) and not isinstance(value, bool)) or (
+            isinstance(value, dict) and value.get("_type") == "trackio.histogram"
+        )
+
+    @staticmethod
+    def _metric_row_signature(
+        row: Any, *, scalar_only: bool = False
+    ) -> tuple[str, ...]:
+        metrics = orjson.loads(row["metrics"])
+        if scalar_only:
+            return tuple(
+                sorted(
+                    key
+                    for key, value in metrics.items()
+                    if SQLiteStorage._is_scalar_metric_value(value)
+                )
+            )
+        return tuple(sorted(metrics))
+
+    @staticmethod
+    def _allocate_metric_group_budgets(
+        group_sizes: list[int], max_points: int
+    ) -> list[int]:
+        budgets = [0] * len(group_sizes)
+        remaining_budget = max_points
+        ordered_groups = sorted(
+            range(len(group_sizes)), key=lambda index: (group_sizes[index], index)
+        )
+
+        for position, group_index in enumerate(ordered_groups):
+            remaining_groups = len(ordered_groups) - position
+            fair_share = remaining_budget // remaining_groups
+            group_size = group_sizes[group_index]
+            if group_size <= fair_share:
+                budgets[group_index] = group_size
+                remaining_budget -= group_size
+                continue
+
+            base_budget, extra = divmod(remaining_budget, remaining_groups)
+            for offset, remaining_group_index in enumerate(ordered_groups[position:]):
+                budgets[remaining_group_index] = base_budget + (offset < extra)
+            break
+
+        return budgets
+
+    @staticmethod
+    def _stable_subsample_metric_group(
+        rows: list[tuple[int, Any]], max_points: int
+    ) -> list[tuple[int, Any]]:
+        if max_points < 1:
+            return []
         if len(rows) <= max_points:
             return rows
-        step = len(rows) / max_points
-        indices = {int(i * step) for i in range(max_points)}
-        indices.add(len(rows) - 1)
-        return [rows[i] for i in sorted(indices)]
+        if max_points == 1:
+            return [rows[-1]]
+
+        stride = 1
+        anchored_points = len(rows) - 1
+        while (anchored_points + stride - 1) // stride > max_points - 1:
+            stride *= 2
+
+        sampled = [rows[index] for index in range(0, len(rows) - 1, stride)]
+        sampled.append(rows[-1])
+        return sampled
+
+    @staticmethod
+    def _subsample_metric_rows(
+        rows: list[Any],
+        max_points: int | None,
+        *,
+        scalar_only: bool = False,
+    ) -> list[Any]:
+        if not scalar_only and (
+            max_points is None or max_points < 1 or len(rows) <= max_points
+        ):
+            return rows
+
+        grouped_rows: dict[tuple[str, ...], list[tuple[int, Any]]] = {}
+        for index, row in enumerate(rows):
+            signature = SQLiteStorage._metric_row_signature(
+                row, scalar_only=scalar_only
+            )
+            if scalar_only and not signature:
+                continue
+            grouped_rows.setdefault(signature, []).append((index, row))
+
+        filtered_rows = [
+            indexed_row for group in grouped_rows.values() for indexed_row in group
+        ]
+        if max_points is None or max_points < 1 or len(filtered_rows) <= max_points:
+            return [row for _, row in sorted(filtered_rows)]
+
+        groups = list(grouped_rows.values())
+        budgets = SQLiteStorage._allocate_metric_group_budgets(
+            [len(group) for group in groups], max_points
+        )
+        sampled_rows = [
+            indexed_row
+            for group, budget in zip(groups, budgets, strict=True)
+            for indexed_row in SQLiteStorage._stable_subsample_metric_group(
+                group, budget
+            )
+        ]
+        return [row for _, row in sorted(sampled_rows)]
 
     @staticmethod
     def _metric_rows_to_log_dicts(
@@ -2248,11 +2344,7 @@ class SQLiteStorage:
                 metrics = {
                     key: value
                     for key, value in metrics.items()
-                    if (isinstance(value, int | float) and not isinstance(value, bool))
-                    or (
-                        isinstance(value, dict)
-                        and value.get("_type") == "trackio.histogram"
-                    )
+                    if SQLiteStorage._is_scalar_metric_value(value)
                 }
             else:
                 metrics = deserialize_values(metrics)
@@ -2274,12 +2366,14 @@ class SQLiteStorage:
             SELECT timestamp, step, metrics
             FROM metrics
             WHERE {run_identity[0]} = ?
-            ORDER BY timestamp
+            ORDER BY timestamp, id
             """,
             (run_identity[1],),
         )
         rows = cursor.fetchall()
-        rows = SQLiteStorage._subsample_metric_rows(rows, max_points)
+        rows = SQLiteStorage._subsample_metric_rows(
+            rows, max_points, scalar_only=scalar_only
+        )
         return SQLiteStorage._metric_rows_to_log_dicts(rows, scalar_only=scalar_only)
 
     @staticmethod

--- a/trackio/sqlite_storage.py
+++ b/trackio/sqlite_storage.py
@@ -222,6 +222,7 @@ _LOGS_READ_CACHE: dict[tuple[Any, ...], tuple[int, list[dict[str, Any]]]] = {}
 _LOGS_READ_CACHE_LOCK = Lock()
 _LOGS_READ_CACHE_MAX_KEYS = 512
 _LOGS_READ_CACHE_MAX_ROWS_PER_ENTRY = 4000
+_METRIC_BUDGET_REFINEMENT_PASSES = 4
 
 
 def _spaces_logs_read_cache_enabled() -> bool:
@@ -2232,15 +2233,21 @@ class SQLiteStorage:
 
     @staticmethod
     def _metric_row_signature(
-        row: Any, *, scalar_only: bool = False
+        metrics: dict[str, Any], *, scalar_only: bool = False
     ) -> tuple[str, ...]:
-        metrics = orjson.loads(row["metrics"])
         if scalar_only:
             return tuple(
                 sorted(
-                    key
-                    for key, value in metrics.items()
-                    if SQLiteStorage._is_scalar_metric_value(value)
+                    [
+                        key
+                        for key, value in metrics.items()
+                        if type(value) is float
+                        or type(value) is int
+                        or (
+                            type(value) is dict
+                            and value.get("_type") == "trackio.histogram"
+                        )
+                    ]
                 )
             )
         return tuple(sorted(metrics))
@@ -2249,32 +2256,48 @@ class SQLiteStorage:
     def _allocate_metric_group_budgets(
         group_sizes: list[int], max_points: int
     ) -> list[int]:
-        budgets = [0] * len(group_sizes)
-        remaining_budget = max_points
-        ordered_groups = sorted(
-            range(len(group_sizes)), key=lambda index: (group_sizes[index], index)
-        )
+        group_count = len(group_sizes)
+        budgets = [0] * group_count
+        if group_count == 0 or max_points < 1:
+            return budgets
+        if sum(group_sizes) <= max_points:
+            return list(group_sizes)
 
-        for position, group_index in enumerate(ordered_groups):
-            remaining_groups = len(ordered_groups) - position
-            fair_share = remaining_budget // remaining_groups
-            group_size = group_sizes[group_index]
-            if group_size <= fair_share:
-                budgets[group_index] = group_size
-                remaining_budget -= group_size
-                continue
+        presence_floor = max_points // group_count
+        for index, group_size in enumerate(group_sizes):
+            budgets[index] = min(group_size, presence_floor)
 
-            base_budget, extra = divmod(remaining_budget, remaining_groups)
-            for offset, remaining_group_index in enumerate(ordered_groups[position:]):
-                budgets[remaining_group_index] = base_budget + (offset < extra)
-            break
+        for _ in range(_METRIC_BUDGET_REFINEMENT_PASSES):
+            remaining_budget = max_points - sum(budgets)
+            if remaining_budget < 1:
+                break
+            demands = [
+                group_size - budget
+                for group_size, budget in zip(group_sizes, budgets, strict=True)
+            ]
+            total_demand = sum(demands)
+            if total_demand < 1:
+                break
+
+            quotas = [remaining_budget * demand / total_demand for demand in demands]
+            additions = [int(quota) for quota in quotas]
+            leftover = remaining_budget - sum(additions)
+            if leftover > 0:
+                by_remainder = sorted(
+                    range(group_count),
+                    key=lambda index: (additions[index] - quotas[index], index),
+                )
+                for index in by_remainder[:leftover]:
+                    additions[index] += 1
+            for index in range(group_count):
+                budgets[index] = min(
+                    group_sizes[index], budgets[index] + additions[index]
+                )
 
         return budgets
 
     @staticmethod
-    def _stable_subsample_metric_group(
-        rows: list[tuple[int, Any]], max_points: int
-    ) -> list[tuple[int, Any]]:
+    def _stable_subsample_metric_group(rows: list[int], max_points: int) -> list[int]:
         if max_points < 1:
             return []
         if len(rows) <= max_points:
@@ -2298,38 +2321,40 @@ class SQLiteStorage:
         *,
         scalar_only: bool = False,
     ) -> list[Any]:
-        if not scalar_only and (
-            max_points is None or max_points < 1 or len(rows) <= max_points
-        ):
+        if max_points is None or max_points < 1 or len(rows) <= max_points:
             return rows
 
-        grouped_rows: dict[tuple[str, ...], list[tuple[int, Any]]] = {}
+        signature_by_key_order: dict[tuple[str, ...], tuple[str, ...]] = {}
+        grouped_indices: dict[tuple[str, ...], list[int]] = {}
         for index, row in enumerate(rows):
-            signature = SQLiteStorage._metric_row_signature(
-                row, scalar_only=scalar_only
-            )
+            metrics = orjson.loads(row["metrics"])
+            key_order = tuple(metrics)
+            signature = signature_by_key_order.get(key_order)
+            if signature is None:
+                signature = SQLiteStorage._metric_row_signature(
+                    metrics, scalar_only=scalar_only
+                )
+                if not scalar_only:
+                    signature_by_key_order[key_order] = signature
             if scalar_only and not signature:
                 continue
-            grouped_rows.setdefault(signature, []).append((index, row))
+            grouped_indices.setdefault(signature, []).append(index)
 
-        filtered_rows = [
-            indexed_row for group in grouped_rows.values() for indexed_row in group
-        ]
-        if max_points is None or max_points < 1 or len(filtered_rows) <= max_points:
-            return [row for _, row in sorted(filtered_rows)]
-
-        groups = list(grouped_rows.values())
-        budgets = SQLiteStorage._allocate_metric_group_budgets(
-            [len(group) for group in groups], max_points
-        )
-        sampled_rows = [
-            indexed_row
-            for group, budget in zip(groups, budgets, strict=True)
-            for indexed_row in SQLiteStorage._stable_subsample_metric_group(
-                group, budget
+        groups = list(grouped_indices.values())
+        total_rows = sum(len(group) for group in groups)
+        if total_rows <= max_points:
+            sampled_indices = [index for group in groups for index in group]
+        else:
+            budgets = SQLiteStorage._allocate_metric_group_budgets(
+                [len(group) for group in groups], max_points
             )
-        ]
-        return [row for _, row in sorted(sampled_rows)]
+            sampled_indices = [
+                index
+                for group, budget in zip(groups, budgets, strict=True)
+                for index in SQLiteStorage._stable_subsample_metric_group(group, budget)
+            ]
+        sampled_indices.sort()
+        return [rows[index] for index in sampled_indices]
 
     @staticmethod
     def _metric_rows_to_log_dicts(


### PR DESCRIPTION
Fixes #653.

- allocate the server-side metric row budget across metric-key signatures so sparse metrics are not discarded by unrelated dense logs
- use an anchored power-of-two stride for oversized groups, preserving stable selections as runs grow
- exclude non-scalar rows before applying the scalar chart budget
- make timestamp ordering deterministic and keep responses within the requested cap
- use power-of-two frontend bin widths so ordinary appends do not re-bin an entire series
- add backend and frontend regressions for sparse-metric preservation and append stability
- include a live browser example that crosses the 3,000-row threshold and prints an integrity check

Root cause: Trackio sampled heterogeneous SQLite rows uniformly before inspecting which metric keys each row contained. TRL profiling generates many single-metric rows, so sparse training metrics consumed only a small fraction of the row budget and were dropped even though their complete series was small. The floating sampling stride and frontend bins both depended on the current row/domain maximum, causing selected points to reshuffle on every poll.

Can verify by running: `examples/live-metric-sampling.py`

Before:


https://github.com/user-attachments/assets/3c985b9f-e9ad-457a-ac12-adc72d20f9ce



After:



https://github.com/user-attachments/assets/bd124c94-3b5c-4427-9f1e-3a6936b808fa

