### PR TITLE
Pin Windows CI ffmpeg to 8.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,6 +41,8 @@ jobs:
     - name: Install system dependencies (Windows)
       if: matrix.os == 'windows-latest'
       uses: AnimMouse/setup-ffmpeg@27e66fd2fe1d643b73a7c5cb105f3b4116bfb8db # v1.2.1
+      with:
+        version: "8.1"
 
     - name: Verify ffmpeg
       run: ffmpeg -version


### PR DESCRIPTION
## Problem

`AnimMouse/setup-ffmpeg` defaults to the latest ffmpeg **release**, which now resolves to **9.0**. BtbN/FFmpeg-Builds has not published a 9.0 Windows build — its `latest` release only ships `n7.1` and `n8.1`:

```
ffmpeg-n7.1-latest-win64-gpl-7.1.zip
ffmpeg-n8.1-latest-win64-gpl-8.1.zip
ffmpeg-master-latest-win64-gpl.zip
```

So the action requests `ffmpeg-n9.0-latest-win64-gpl-9.0.zip` and fails:

```
Cache not found for input keys: FFmpeg-9.0-...-Windows-X64
##[group]Downloading FFmpeg 9.0 for Windows
Invoke-WebRequest: ... releases/download/... | Not Found
##[error]Process completed with exit code 1.
```

This hits **any run that misses the ffmpeg cache**, and because the `test` matrix uses fail-fast, it also cancels `test (hf-jobs-cpu-upgrade)` before a single Python test runs. Currently reproducing on #659 and #658.

## Fix

Pin to `8.1`, the newest version BtbN actually publishes. Worth revisiting once a 9.x Windows build lands upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)