### PR TITLE
Install ffmpeg explicitly on the Linux runner

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,6 +38,12 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-uv-
 
+    - name: Install system dependencies (Linux)
+      if: matrix.os != 'windows-latest'
+      run: |
+        sudo apt-get update -qq
+        sudo apt-get install -y -qq ffmpeg
+
     - name: Install system dependencies (Windows)
       if: matrix.os == 'windows-latest'
       uses: AnimMouse/setup-ffmpeg@27e66fd2fe1d643b73a7c5cb105f3b4116bfb8db # v1.2.1


### PR DESCRIPTION
## Problem

`test.yml` only installs ffmpeg for `windows-latest`. The `hf-jobs-cpu-upgrade` (Linux) leg relied on the self-hosted runner's base image happening to ship `/usr/bin/ffmpeg`, so `Verify ffmpeg` passed by accident.

The runner base image had to move from Ubuntu 22.04 to 24.04 (GitHub deprecated runner v2.319.1, and v2.336.0's `installdependencies.sh` needs `libicu74`, which only exists on 24.04). The 24.04 Playwright image does **not** ship an apt ffmpeg:

```
v1.60.0-jammy  VERSION=22.04  /usr/bin/ffmpeg  ffmpeg version 4.4.2
v1.60.0-noble  VERSION=24.04  NO ffmpeg on PATH
```

So the Linux job now fails at:

```
/actions-runner/_work/_temp/....sh: line 1: ffmpeg: command not found
##[error]Process completed with exit code 127
```

## Fix

Install ffmpeg explicitly on Linux, mirroring what the Windows leg already does, so the job no longer depends on the image's contents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)