### PR TITLE
Skip the Spaces e2e run for fork PRs

### DIFF
--- a/.github/workflows/e2e-spaces.yml
+++ b/.github/workflows/e2e-spaces.yml
@@ -44,6 +44,7 @@ jobs:
   e2e-test:
     name: "e2e-spaces-test"
     needs: get-pr-info
+    if: needs.get-pr-info.outputs.source_repo == github.repository
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -134,3 +135,24 @@ jobs:
               target_url: '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
             })
 
+  e2e-skip-fork:
+    name: "e2e-spaces-skip-fork"
+    needs: get-pr-info
+    if: needs.get-pr-info.outputs.source_repo != github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      statuses: write
+    steps:
+      - name: Set skipped status
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: '${{ needs.get-pr-info.outputs.sha }}',
+              state: 'success',
+              context: 'E2E Spaces Test',
+              description: 'Skipped: fork PR cannot run with repo secrets',
+              target_url: '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+            })


### PR DESCRIPTION
## Problem

`actions/checkout` now refuses to check out fork PR code from a `workflow_run` workflow:

```
##[error]Refusing to check out fork pull request code from a 'workflow_run' workflow.
This workflow runs with the base repository's GITHUB_TOKEN, secrets, default-branch
cache scope, and runner access. Fetching and executing a fork's code in that trusted
context commonly leads to "pwn request" vulnerabilities.
```

`e2e-spaces.yml` checks out the PR head and then runs `pytest tests/e2e-spaces/` with `secrets.HF_TOKEN` in the environment — so the guardrail is correct: opting in with `allow-unsafe-pr-checkout: true` would let any fork PR run arbitrary code with our HF token.

The result is that **every fork PR gets a red `E2E Spaces Test`**, which looks like a failing test rather than a context the job simply cannot run in. Currently affecting #658.

## Fix

Gate the real job to same-repo PRs, and report an explicit skipped status for forks.

This does not reduce coverage: fork PRs already got no e2e coverage — the job failed at checkout before running anything. It just stops the misleading failure.

If we later want genuine fork coverage, the safe route is an Environment with required reviewers (so a maintainer approves before fork code touches the token), and/or a fine-grained token scoped to the `trackio-tests` namespace — not a blanket `allow-unsafe-pr-checkout`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)