### PR TITLE
feat: add trackio.sweep() for local grid/random hyperparameter search

### DIFF
--- a/examples/hyperparameter-sweep.py
+++ b/examples/hyperparameter-sweep.py
@@ -1,0 +1,46 @@
+import random
+import time
+
+import trackio as wandb
+
+
+def main():
+    project_id = random.randint(10000, 99999)
+    project_name = f"sweep-demo-{project_id}"
+    steps = 10
+
+    def train():
+        run = wandb.init(project=project_name)
+        lr = run.config["learning_rate"]
+        batch_size = run.config["batch_size"]
+
+        performance_factor = (1.0 / (lr * 100)) * (32 / batch_size)
+        base_loss = random.uniform(1.2, 1.8) / performance_factor
+        min_loss = random.uniform(0.05, 0.12) / performance_factor
+
+        for step in range(steps):
+            progress = step / (steps - 1)
+            loss = base_loss * (1.0 - 0.85 * progress) + random.uniform(-0.03, 0.03)
+            loss = max(min_loss, loss)
+            wandb.log({"loss": round(loss, 4)}, step=step)
+            time.sleep(0.05)
+
+        wandb.finish()
+
+    wandb.sweep(
+        {
+            "method": "grid",
+            "name": f"{project_name}-sweep",
+            "parameters": {
+                "learning_rate": {"values": [1e-2, 1e-3, 1e-4]},
+                "batch_size": {"values": [16, 32, 64]},
+            },
+        },
+        function=train,
+    )
+
+    print(f"\nDone! View the sweep with: trackio show --project {project_name}")
+
+
+if __name__ == "__main__":
+    main()

--- a/plans/issue-657-hyperparameter-sweeps-plan.md
+++ b/plans/issue-657-hyperparameter-sweeps-plan.md
@@ -1,0 +1,71 @@
+## Issue 657 Plan: Hyperparameter Sweeps
+
+### Goal
+
+Add the ability to define and run a hyperparameter search with Trackio, and
+group the resulting runs so they can be compared in the dashboard.
+
+Full scope of #657 ("define, launch, and monitor sweeps... view results
+along with parallel coordinates chart") is large. This first PR covers the
+backend piece only:
+
+- Define a search space (grid or random) as a small dict/YAML-shaped config.
+- Run it locally, in-process, by calling a user-supplied training function
+  once per configuration.
+- Automatically merge the sweep-selected hyperparameters into `config` and
+  group the resulting runs under a shared sweep id when `trackio.init()` is
+  called from inside that function.
+
+Out of scope for this PR (left for follow-ups):
+
+- A parallel-coordinates chart in the Svelte dashboard.
+- Bayesian / other advanced search strategies.
+- A hosted sweep controller or distributed/remote agents (`wandb agent`-style).
+- CLI-driven sweeps over an arbitrary subprocess command.
+
+### Decisions
+
+- No new storage/schema changes: sweeps reuse the existing `config` (per-run
+  hyperparameters) and `group` (already-supported run grouping) fields, so
+  existing dashboard grouping/filtering works with sweeps for free.
+- Orchestration is local and synchronous (a plain `for` loop calling the
+  training function), matching Trackio's "local-first" design instead of
+  introducing a server-side sweep controller.
+- API mirrors `wandb`'s `sweep_config` shape (`method`, `parameters` with
+  `values` or `min`/`max`) so existing wandb sweep configs mostly drop in.
+- Sweep-selected values take precedence over any matching keys already in
+  the `config` dict passed to `trackio.init()`, since overriding local
+  defaults is the point of a sweep. An explicit `group=` passed to
+  `trackio.init()` still wins over the sweep's auto-assigned group.
+
+### Implementation
+
+1. Add `trackio/sweep.py`.
+   - `SweepParameter`: one parameter's search space (`values`, or
+     `min`/`max` with `distribution="uniform"|"int_uniform"`).
+   - `SweepConfig`: `parameters`, `method` (`"grid"` | `"random"`), `name`.
+   - `generate_configs(sweep_config, count=None)`: materializes the list of
+     configs (full cartesian product for grid, `count` samples for random).
+   - `sweep(sweep_config, function, count=None, sweep_id=None)`: generates
+     configs, then for each one sets context vars for the sweep id/config
+     and calls `function()`.
+
+2. Add two context vars in `trackio/context_vars.py`:
+   `current_sweep_id`, `current_sweep_config`.
+
+3. Wire into `trackio.init()`: if a sweep is active (context var set), merge
+   its config into the run's `config` and default `group` to the sweep id.
+
+4. Export `sweep`, `SweepConfig`, `SweepParameter`, and
+   `generate_configs` (as `sweep_generate_configs`) from `trackio/__init__.py`.
+
+5. Add `examples/hyperparameter-sweep.py` and `tests/unit/test_sweep.py`
+   (config generation edge cases + `init()` integration).
+
+### Follow-ups (separate PRs)
+
+- Parallel-coordinates chart component in `trackio/frontend/src/` that plots
+  each run in a group/sweep as a line across parameter + metric axes.
+- `trackio sweep` CLI command to launch a sweep over an external script
+  (subprocess-based, injecting hyperparameters as CLI flags or env vars).
+- Early stopping / pruning of underperforming sweep runs.

--- a/tests/unit/test_sweep.py
+++ b/tests/unit/test_sweep.py
@@ -1,0 +1,187 @@
+import pytest
+
+import trackio
+from trackio.sweep import SweepConfig, SweepParameter, generate_configs, sweep
+
+
+def test_sweep_parameter_requires_values_or_range():
+    with pytest.raises(ValueError, match="values.*min.*max"):
+        SweepParameter()
+
+
+def test_sweep_parameter_rejects_both_values_and_range():
+    with pytest.raises(ValueError, match="cannot define both"):
+        SweepParameter(values=[1, 2], min=0, max=1)
+
+
+def test_sweep_parameter_rejects_min_greater_than_max():
+    with pytest.raises(ValueError, match="less than or equal to"):
+        SweepParameter(min=10, max=1)
+
+
+def test_sweep_config_from_dict_rejects_unknown_method():
+    with pytest.raises(ValueError, match="Unsupported sweep method"):
+        SweepConfig.from_dict(
+            {"method": "bayes", "parameters": {"lr": {"values": [1e-3]}}}
+        )
+
+
+def test_sweep_config_from_dict_requires_parameters():
+    with pytest.raises(ValueError, match="non-empty"):
+        SweepConfig.from_dict({"method": "grid", "parameters": {}})
+
+
+def test_generate_configs_grid_is_full_cartesian_product():
+    configs = generate_configs(
+        {
+            "method": "grid",
+            "parameters": {
+                "lr": {"values": [0.1, 0.01]},
+                "batch_size": {"values": [16, 32, 64]},
+            },
+        }
+    )
+    assert len(configs) == 6
+    assert {(c["lr"], c["batch_size"]) for c in configs} == {
+        (0.1, 16),
+        (0.1, 32),
+        (0.1, 64),
+        (0.01, 16),
+        (0.01, 32),
+        (0.01, 64),
+    }
+
+
+def test_generate_configs_grid_can_be_truncated_with_count():
+    configs = generate_configs(
+        {"method": "grid", "parameters": {"lr": {"values": [1, 2, 3, 4]}}},
+        count=2,
+    )
+    assert len(configs) == 2
+
+
+def test_generate_configs_grid_rejects_continuous_parameters():
+    with pytest.raises(ValueError, match="Grid search requires discrete"):
+        generate_configs(
+            {"method": "grid", "parameters": {"lr": {"min": 0.0, "max": 1.0}}}
+        )
+
+
+def test_generate_configs_random_requires_count():
+    with pytest.raises(ValueError, match="`count` is required"):
+        generate_configs(
+            {"method": "random", "parameters": {"lr": {"values": [0.1, 0.01]}}}
+        )
+
+
+def test_generate_configs_random_respects_count_and_bounds():
+    configs = generate_configs(
+        {
+            "method": "random",
+            "parameters": {
+                "lr": {"min": 0.0, "max": 1.0},
+                "layers": {"min": 1, "max": 4, "distribution": "int_uniform"},
+                "optimizer": {"values": ["adam", "sgd"]},
+            },
+        },
+        count=25,
+    )
+    assert len(configs) == 25
+    for config in configs:
+        assert 0.0 <= config["lr"] <= 1.0
+        assert 1 <= config["layers"] <= 4
+        assert isinstance(config["layers"], int)
+        assert config["optimizer"] in ("adam", "sgd")
+
+
+def test_sweep_runs_function_once_per_config():
+    calls = []
+
+    def train():
+        calls.append(1)
+
+    sweep_id = sweep(
+        {
+            "method": "grid",
+            "parameters": {"lr": {"values": [0.1, 0.01, 0.001]}},
+        },
+        function=train,
+    )
+    assert len(calls) == 3
+    assert sweep_id.startswith("sweep-")
+
+
+def test_sweep_raises_on_empty_configs():
+    with pytest.raises(ValueError, match="zero configurations"):
+        sweep(
+            {"method": "grid", "parameters": {"lr": {"values": [1, 2]}}},
+            function=lambda: None,
+            count=0,
+        )
+
+
+def test_sweep_uses_provided_sweep_id():
+    seen_ids = []
+
+    def train():
+        seen_ids.append(1)
+
+    result = sweep(
+        {"method": "grid", "parameters": {"lr": {"values": [1]}}},
+        function=train,
+        sweep_id="my-custom-sweep",
+    )
+    assert result == "my-custom-sweep"
+
+
+def test_init_inside_sweep_merges_config_and_sets_group(temp_dir):
+    seen_configs = []
+    seen_groups = []
+
+    def train():
+        run = trackio.init(project="test_sweep_project", config={"epochs": 5})
+        seen_configs.append(dict(run.config))
+        seen_groups.append(run.group)
+        run.finish()
+
+    sweep_id = sweep(
+        {
+            "method": "grid",
+            "parameters": {
+                "lr": {"values": [0.1, 0.01]},
+                "batch_size": {"values": [32]},
+            },
+        },
+        function=train,
+    )
+
+    assert len(seen_configs) == 2
+    for config in seen_configs:
+        assert config["epochs"] == 5
+        assert config["batch_size"] == 32
+        assert config["lr"] in (0.1, 0.01)
+    assert {c["lr"] for c in seen_configs} == {0.1, 0.01}
+    assert seen_groups == [sweep_id, sweep_id]
+
+
+def test_init_config_explicit_group_overrides_sweep_group(temp_dir):
+    seen_groups = []
+
+    def train():
+        run = trackio.init(project="test_sweep_project_2", group="custom-group")
+        seen_groups.append(run.group)
+        run.finish()
+
+    sweep(
+        {"method": "grid", "parameters": {"lr": {"values": [1, 2]}}},
+        function=train,
+    )
+    assert seen_groups == ["custom-group", "custom-group"]
+
+
+def test_init_outside_sweep_is_unaffected(temp_dir):
+    run = trackio.init(project="test_sweep_project_3", config={"epochs": 1})
+    assert run.config["epochs"] == 1
+    assert "lr" not in run.config
+    assert run.group is None
+    run.finish()

--- a/trackio/__init__.py
+++ b/trackio/__init__.py
@@ -46,6 +46,8 @@ from trackio.remote_client import RemoteClient
 from trackio.run import Run
 from trackio.server import TrackioDashboardApp, build_starlette_app_only
 from trackio.sqlite_storage import SQLiteStorage
+from trackio.sweep import SweepConfig, SweepParameter, sweep
+from trackio.sweep import generate_configs as sweep_generate_configs
 from trackio.table import Table
 from trackio.trace import Trace
 from trackio.typehints import UploadEntry
@@ -95,6 +97,10 @@ __all__ = [
     "Markdown",
     "Api",
     "TRACKIO_LOGO_DIR",
+    "sweep",
+    "sweep_generate_configs",
+    "SweepConfig",
+    "SweepParameter",
 ]
 
 Audio = TrackioAudio
@@ -353,6 +359,12 @@ def init(
         `Run`: A [`Run`] object that can be used to log metrics and finish the run.
     """
     SQLiteStorage.validate_project_name(project)
+
+    sweep_config = context_vars.current_sweep_config.get()
+    if sweep_config is not None:
+        config = {**(config or {}), **sweep_config}
+        if group is None:
+            group = context_vars.current_sweep_id.get()
 
     if settings is not None:
         _emit_nonfatal_warning(

--- a/trackio/context_vars.py
+++ b/trackio/context_vars.py
@@ -19,3 +19,9 @@ current_space_id: contextvars.ContextVar[str | None] = contextvars.ContextVar(
 current_server_write_token: contextvars.ContextVar[str | None] = contextvars.ContextVar(
     "current_server_write_token", default=None
 )
+current_sweep_id: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+    "current_sweep_id", default=None
+)
+current_sweep_config: contextvars.ContextVar[dict | None] = contextvars.ContextVar(
+    "current_sweep_config", default=None
+)

--- a/trackio/sweep.py
+++ b/trackio/sweep.py
@@ -1,0 +1,242 @@
+"""Hyperparameter sweep support for Trackio.
+
+Provides a minimal, wandb-compatible way to define a hyperparameter search
+space and run a local grid or random search over it. Each generated
+configuration is executed by calling a user-supplied training function; any
+`trackio.init()` call made from within that function automatically picks up
+the sweep-selected values (merged into `config`) and is grouped under a
+shared sweep id, so the resulting runs can be compared side by side in the
+dashboard (e.g. by filtering to that group).
+
+This is intentionally scoped to local, in-process orchestration: grid and
+random search over a single machine. A hosted sweep controller, distributed
+agents, and Bayesian/other advanced search strategies are not implemented
+here; see https://github.com/gradio-app/trackio/issues/657 for the broader
+feature request.
+"""
+
+import itertools
+import random
+import uuid
+from collections.abc import Callable, Iterator
+from dataclasses import dataclass
+from typing import Any, Literal
+
+from trackio.context_vars import current_sweep_config, current_sweep_id
+
+SweepMethod = Literal["grid", "random"]
+
+
+@dataclass
+class SweepParameter:
+    """A single parameter's search space within a sweep.
+
+    Either `values` (a discrete set to choose from) or both `min` and `max`
+    (a continuous or integer range, used by random search) must be provided.
+    """
+
+    values: list[Any] | None = None
+    min: float | None = None
+    max: float | None = None
+    distribution: Literal["uniform", "int_uniform"] = "uniform"
+
+    def __post_init__(self):
+        has_values = self.values is not None
+        has_range = self.min is not None or self.max is not None
+        if not has_values and not has_range:
+            raise ValueError(
+                "Each sweep parameter must define either `values` or both "
+                "`min` and `max`."
+            )
+        if has_values and has_range:
+            raise ValueError(
+                "A sweep parameter cannot define both `values` and a `min`/`max` range."
+            )
+        if has_range and (self.min is None or self.max is None):
+            raise ValueError(
+                "A sweep parameter with a range must define both `min` and `max`."
+            )
+        if has_range and self.min > self.max:
+            raise ValueError(
+                f"`min` ({self.min}) must be less than or equal to `max` ({self.max})."
+            )
+
+    def is_discrete(self) -> bool:
+        return self.values is not None
+
+    def sample(self) -> Any:
+        if self.values is not None:
+            return random.choice(self.values)
+        if self.distribution == "int_uniform":
+            return random.randint(int(self.min), int(self.max))
+        return random.uniform(self.min, self.max)
+
+
+@dataclass
+class SweepConfig:
+    parameters: dict[str, SweepParameter]
+    method: SweepMethod = "grid"
+    name: str | None = None
+
+    @classmethod
+    def from_dict(cls, config: "SweepConfig | dict[str, Any]") -> "SweepConfig":
+        if isinstance(config, SweepConfig):
+            return config
+        method = config.get("method", "grid")
+        if method not in ("grid", "random"):
+            raise ValueError(
+                f"Unsupported sweep method {method!r}. Supported methods: 'grid', 'random'."
+            )
+        raw_parameters = config.get("parameters")
+        if not raw_parameters:
+            raise ValueError("Sweep config must define a non-empty `parameters` dict.")
+        parameters = {}
+        for param_name, param_spec in raw_parameters.items():
+            if isinstance(param_spec, SweepParameter):
+                parameters[param_name] = param_spec
+            elif isinstance(param_spec, dict):
+                parameters[param_name] = SweepParameter(**param_spec)
+            else:
+                raise ValueError(
+                    f"Sweep parameter '{param_name}' must be a dict like "
+                    f"{{'values': [...]}} or {{'min': ..., 'max': ...}}, got {type(param_spec)}."
+                )
+        return cls(parameters=parameters, method=method, name=config.get("name"))
+
+
+def _grid_configs(parameters: dict[str, SweepParameter]) -> Iterator[dict[str, Any]]:
+    for param_name, param in parameters.items():
+        if not param.is_discrete():
+            raise ValueError(
+                f"Grid search requires discrete `values` for every parameter, but "
+                f"'{param_name}' defines a min/max range instead. Use method='random' "
+                "for continuous or integer ranges, or provide `values` for a grid search."
+            )
+    names = list(parameters.keys())
+    value_lists = [parameters[name].values for name in names]
+    for combo in itertools.product(*value_lists):
+        yield dict(zip(names, combo))
+
+
+def _random_configs(
+    parameters: dict[str, SweepParameter], count: int
+) -> Iterator[dict[str, Any]]:
+    for _ in range(count):
+        yield {name: param.sample() for name, param in parameters.items()}
+
+
+def generate_configs(
+    sweep_config: "SweepConfig | dict[str, Any]", count: int | None = None
+) -> list[dict[str, Any]]:
+    """Materializes the list of hyperparameter configurations a sweep will run.
+
+    Args:
+        sweep_config (`SweepConfig` or `dict`):
+            A `SweepConfig`, or a dict with `method` (`"grid"` or `"random"`,
+            defaults to `"grid"`) and `parameters` (a dict mapping parameter
+            name to either `{"values": [...]}` for a discrete set, or
+            `{"min": ..., "max": ...}` for a continuous/integer range).
+        count (`int`, *optional*):
+            Number of configurations to generate. Required when
+            `method="random"`. For `method="grid"`, defaults to the full
+            cartesian product of `values`; if provided and smaller than the
+            full grid, the grid is truncated to the first `count` combinations.
+
+    Returns:
+        A list of dicts, each mapping parameter name to its sampled value.
+    """
+    resolved = SweepConfig.from_dict(sweep_config)
+
+    if resolved.method == "grid":
+        configs = list(_grid_configs(resolved.parameters))
+        if count is not None:
+            configs = configs[:count]
+        return configs
+
+    if count is None:
+        raise ValueError("`count` is required when method='random'.")
+    if count < 1:
+        raise ValueError("`count` must be a positive integer.")
+    return list(_random_configs(resolved.parameters, count))
+
+
+def sweep(
+    sweep_config: "SweepConfig | dict[str, Any]",
+    function: Callable[[], Any],
+    count: int | None = None,
+    sweep_id: str | None = None,
+) -> str:
+    """Runs a local hyperparameter sweep by calling `function` once per configuration.
+
+    For each generated configuration, `function` is called with the sweep's
+    context set so that any `trackio.init()` call made inside it automatically
+    merges the sweep-selected hyperparameters into `config` (overriding any
+    matching keys already in that run's `config`) and groups the run under
+    the returned sweep id, unless `group` is explicitly passed to that
+    `init()` call.
+
+    Args:
+        sweep_config (`SweepConfig` or `dict`):
+            See [`generate_configs`].
+        function (`Callable`):
+            A zero-argument callable that runs one training iteration,
+            typically calling `trackio.init()`, logging metrics, then
+            `run.finish()`.
+        count (`int`, *optional*):
+            Number of configurations to run. Required when `method="random"`,
+            optional for `method="grid"` (caps the grid if provided).
+        sweep_id (`str`, *optional*):
+            Identifier for this sweep, used as the run group name so results
+            can be compared in the dashboard. Defaults to `sweep_config.name`
+            if set, otherwise a short generated id.
+
+    Returns:
+        The sweep id used to group the runs.
+
+    Example:
+        ```python
+        import trackio
+
+        def train():
+            run = trackio.init(project="my-project")
+            lr = run.config["learning_rate"]
+            batch_size = run.config["batch_size"]
+            # ... train and log metrics ...
+            run.finish()
+
+        trackio.sweep(
+            {
+                "method": "grid",
+                "parameters": {
+                    "learning_rate": {"values": [1e-2, 1e-3, 1e-4]},
+                    "batch_size": {"values": [16, 32, 64]},
+                },
+            },
+            function=train,
+        )
+        ```
+    """
+    resolved = SweepConfig.from_dict(sweep_config)
+    configs = generate_configs(resolved, count=count)
+    if not configs:
+        raise ValueError("Sweep produced zero configurations to run.")
+
+    resolved_sweep_id = sweep_id or resolved.name or f"sweep-{uuid.uuid4().hex[:8]}"
+
+    plural = "s" if len(configs) != 1 else ""
+    print(
+        f"* Starting sweep '{resolved_sweep_id}' ({resolved.method} search, "
+        f"{len(configs)} run{plural})"
+    )
+
+    for i, run_config in enumerate(configs, start=1):
+        print(f"* Sweep run {i}/{len(configs)} [{resolved_sweep_id}]: {run_config}")
+        config_token = current_sweep_config.set(run_config)
+        id_token = current_sweep_id.set(resolved_sweep_id)
+        try:
+            function()
+        finally:
+            current_sweep_config.reset(config_token)
+            current_sweep_id.reset(id_token)
+
+    return resolved_sweep_id


### PR DESCRIPTION
Partially addresses #657.

Adds the backend piece of hyperparameter sweep support: `trackio.sweep()`
runs a local grid or random search over a defined parameter space by
calling a user-supplied training function once per configuration.

- `trackio.sweep(sweep_config, function, count=None, sweep_id=None)` ,API
  shape roughly mirrors wandb's sweep config (`method`, `parameters` with
  `values` or `min`/`max`) so existing configs mostly drop in
- Any `trackio.init()` called inside `function` automatically merges the
  sweep-selected hyperparameters into `config` and groups the run under a
  shared sweep id (unless `group` is explicitly passed), reusing the
  existing `config`/`group` fields ,no schema changes
- Added `examples/hyperparameter-sweep.py` and `tests/unit/test_sweep.py`
  (16 tests covering config generation edge cases and `init()` integration)

**Not included in this PR** (see `plans/issue-657-hyperparameter-sweeps-plan.md`
for a scoped breakdown and follow-up ideas):
- Parallel-coordinates chart in the dashboard
- CLI-driven sweeps over an external script
- Bayesian/other advanced search strategies

Ran `pytest tests/unit/test_sweep.py` (16 passed) and the full unit suite
locally with no new failures, plus `ruff check --fix --select I && ruff format`.

Commented on the issue beforehand to flag this scope:  https://github.com/gradio-app/trackio/issues/657#issuecomment-5248744380