### PR TITLE
Fix PyPI publish: pin wheel core metadata version to 2.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling>=1.27"]
 build-backend = "hatchling.build"
 
 [project]
@@ -69,6 +69,7 @@ trackio = "trackio.cli:main"
 [tool.hatch.build.hooks.custom]
 
 [tool.hatch.build.targets.wheel]
+core-metadata-version = "2.4"
 packages = ["trackio"]
 artifacts = ["trackio/frontend/dist/**", "trackio/frontend_templates/**"]
 


### PR DESCRIPTION
The 0.34.1 publish [failed](https://github.com/gradio-app/trackio/actions/runs/31496585592/job/93795716701) with:

```
ERROR InvalidDistribution: Invalid distribution metadata: '2.5' is not a valid metadata version
```

`hatchling` 1.32.0 (released a few hours before that run) bumped its `DEFAULT_METADATA_VERSION` from 2.4 to 2.5. The build env installs hatchling unpinned, so the wheel came out with `Metadata-Version: 2.5`. The `twine` in `gradio-app/github/actions/publish-pypi` validates metadata via `packaging` 25.0 (preinstalled on the runner), which only knows up to 2.4, so the upload was rejected.

This pins the wheel target to `core-metadata-version = "2.4"` (and requires `hatchling>=1.27`, the first version with the 2.4 constructor), so hatchling stays free to upgrade while the emitted metadata remains what the publisher accepts.

Verified locally: built with hatchling 1.32.0 → `Metadata-Version: 2.4`, and `twine 6.2.0` + `packaging 25.0` (the failing combo) now passes `twine check`.

No changeset — this is release plumbing, and merging it should republish 0.34.1 (never made it to PyPI).

Note: the same failure will hit any repo using that publish action; the durable fix there is bumping `twine`/`packaging` in the action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)