### PR TITLE
Add hierarchical trace UI and improve the Trackio CLI for inspecting traces

### DIFF
--- a/.agents/skills/trackio/SKILL.md
+++ b/.agents/skills/trackio/SKILL.md
@@ -14,7 +14,7 @@ Trackio is an experiment tracking library for logging and visualizing ML trainin
 | **Logging metrics** during training | Python API | [logging_metrics.md](logging_metrics.md) |
 | **Firing alerts** for training diagnostics | Python API | [alerts.md](alerts.md) |
 | **Retrieving metrics & alerts** after/during training | CLI | [retrieving_metrics.md](retrieving_metrics.md) |
-| **Inspecting agent traces** (latency, cost, tool failures) | CLI | [retrieving_metrics.md](retrieving_metrics.md#trace-commands) |
+| **Analyzing agent traces** (latency, cost, tool failures) | CLI | [traces.md](traces.md) |
 | **Inspecting storage schema and running direct SQL** | CLI | [storage_schema.md](storage_schema.md) |
 | **Sharing an experiment campaign as a logbook** | CLI | [logbook.md](logbook.md) |
 
@@ -69,14 +69,30 @@ Use the `trackio` command to query logged metrics and alerts:
 
 **Remote Spaces**: Add `--space <space_id_or_url>` to any `list`/`get`/`query` command to query a remote HF Space instead of local data. Use `--hf-token` for private Spaces.
 
-**Answering "look at the traces and tell me what we can improve"**: start with
-`trackio get trace-summary --project <name>`, which rolls every span up by
-operation (calls, errors, latency, tokens, cost). Then use
-`trackio list traces --search ...` and `trackio get trace --trace-id ...` to
-drill into specific sessions, and `trackio query project --sql` with
-`json_each(traces.spans)` for anything else.
-
 → See [retrieving_metrics.md](retrieving_metrics.md) for all commands, workflows, and JSON output formats.
+
+### CLI → Analyzing agent traces
+
+Traces are agent/LLM sessions: messages plus execution spans (model generations,
+tool calls) carrying latency, status, token usage, and cost. Use these to answer
+questions about **production agent behaviour** rather than training progress:
+*"look at the traces and tell me what we can improve"*, *"why is the agent slow
+or expensive"*, *"what's failing"*.
+
+- `trackio get trace-summary --project <name>` — per-operation rollup (calls, errors, latency, tokens, cost)
+- `trackio list traces --project <name> [--search <text>]` — the trace index
+- `trackio get trace --project <name> --trace-id <id>` — one session's full span tree
+- `trackio query project --sql "... json_each(traces.spans) ..."` — arbitrary span analysis
+
+**Key concept for LLM agents**: no single command answers "what can we improve".
+Follow the funnel — **orient → rollup → quantify → verify**. Read
+`trace-summary` for anomalies (each is a *hypothesis*), then use SQL to measure
+what each one actually costs by comparing affected against unaffected sessions,
+then read one full trace to confirm. Report measured impact, never the raw
+anomaly.
+
+→ See [traces.md](traces.md) for the funnel, the SQL recipes for each hypothesis,
+and reporting rules.
 → See [storage_schema.md](storage_schema.md) for SQLite tables, parquet layout, and direct query examples.
 
 ## Minimal Logging Setup

--- a/.agents/skills/trackio/SKILL.md
+++ b/.agents/skills/trackio/SKILL.md
@@ -14,6 +14,7 @@ Trackio is an experiment tracking library for logging and visualizing ML trainin
 | **Logging metrics** during training | Python API | [logging_metrics.md](logging_metrics.md) |
 | **Firing alerts** for training diagnostics | Python API | [alerts.md](alerts.md) |
 | **Retrieving metrics & alerts** after/during training | CLI | [retrieving_metrics.md](retrieving_metrics.md) |
+| **Inspecting agent traces** (latency, cost, tool failures) | CLI | [retrieving_metrics.md](retrieving_metrics.md#trace-commands) |
 | **Inspecting storage schema and running direct SQL** | CLI | [storage_schema.md](storage_schema.md) |
 | **Sharing an experiment campaign as a logbook** | CLI | [logbook.md](logbook.md) |
 
@@ -60,12 +61,20 @@ Use the `trackio` command to query logged metrics and alerts:
 - `trackio get project/run/metric` — retrieve summaries and values
 - `trackio query project --project <name> --sql "SELECT ..."` — run catch-all read-only SQL
 - `trackio list alerts --project <name> --json` — retrieve alerts
+- `trackio list traces` / `get trace` / `get trace-summary` — inspect agent traces and spans
 - `trackio show` — launch the dashboard
 - `trackio sync` — sync to HF Space
 
 **Key concept**: Add `--json` for programmatic output suitable for automation and LLM agents.
 
 **Remote Spaces**: Add `--space <space_id_or_url>` to any `list`/`get`/`query` command to query a remote HF Space instead of local data. Use `--hf-token` for private Spaces.
+
+**Answering "look at the traces and tell me what we can improve"**: start with
+`trackio get trace-summary --project <name>`, which rolls every span up by
+operation (calls, errors, latency, tokens, cost). Then use
+`trackio list traces --search ...` and `trackio get trace --trace-id ...` to
+drill into specific sessions, and `trackio query project --sql` with
+`json_each(traces.spans)` for anything else.
 
 → See [retrieving_metrics.md](retrieving_metrics.md) for all commands, workflows, and JSON output formats.
 → See [storage_schema.md](storage_schema.md) for SQLite tables, parquet layout, and direct query examples.

--- a/.agents/skills/trackio/SKILL.md
+++ b/.agents/skills/trackio/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: hugging-face-trackio
-description: Track and visualize ML training experiments with Trackio. Use when logging metrics during training (Python API), firing alerts for training diagnostics, or retrieving/analyzing logged metrics (CLI). Supports real-time dashboard visualization, alerts with webhooks, HF Space syncing, and JSON output for automation.
+description: Track and visualize ML training experiments and agent traces with Trackio. Use when logging metrics during training, firing alerts for training, or retrieving/analyzing logged data.
 ---
 
 # Trackio - Experiment Tracking for ML Training
 
-Trackio is an experiment tracking library for logging and visualizing ML training metrics. It syncs to Hugging Face Spaces for real-time monitoring dashboards.
+Trackio is an experiment tracking library for logging and visualizing ML training metrics. It can be used locally or optionally syncs to Hugging Face Spaces for real-time monitoring dashboards.
 
-## Three Interfaces
+## Tasks
 
 | Task | Interface | Reference |
 |------|-----------|-----------|
@@ -75,7 +75,7 @@ Use the `trackio` command to query logged metrics and alerts:
 
 Traces are agent/LLM sessions: messages plus execution spans (model generations,
 tool calls) carrying latency, status, token usage, and cost. Use these to answer
-questions about **production agent behaviour** rather than training progress:
+questions about **agent behaviour** rather than training progress:
 *"look at the traces and tell me what we can improve"*, *"why is the agent slow
 or expensive"*, *"what's failing"*.
 
@@ -84,16 +84,7 @@ or expensive"*, *"what's failing"*.
 - `trackio get trace --project <name> --trace-id <id>` — one session's full span tree
 - `trackio query project --sql "... json_each(traces.spans) ..."` — arbitrary span analysis
 
-**Key concept for LLM agents**: no single command answers "what can we improve".
-Follow the funnel — **orient → rollup → quantify → verify**. Read
-`trace-summary` for anomalies (each is a *hypothesis*), then use SQL to measure
-what each one actually costs by comparing affected against unaffected sessions,
-then read one full trace to confirm. Report measured impact, never the raw
-anomaly.
-
-→ See [traces.md](traces.md) for the funnel, the SQL recipes for each hypothesis,
-and reporting rules.
-→ See [storage_schema.md](storage_schema.md) for SQLite tables, parquet layout, and direct query examples.
+Often you might need to run multiple commands to answer a question that a user has about the traces.
 
 ## Minimal Logging Setup
 

--- a/.agents/skills/trackio/retrieving_metrics.md
+++ b/.agents/skills/trackio/retrieving_metrics.md
@@ -11,6 +11,7 @@ The `trackio` CLI provides direct terminal access to query Trackio experiment tr
 | List metrics | `trackio list metrics --project <name> --run <name>` |
 | List system metrics | `trackio list system-metrics --project <name> --run <name>` |
 | List alerts | `trackio list alerts --project <name> [--run <name>] [--level <level>] [--since <timestamp>]` |
+| List traces | `trackio list traces --project <name> [--run <name>] [--search <text>] [--step <N>]` |
 | Get project summary | `trackio get project --project <name>` |
 | Get run summary | `trackio get run --project <name> --run <name>` |
 | Get metric values | `trackio get metric --project <name> --run <name> --metric <name>` |
@@ -18,6 +19,8 @@ The `trackio` CLI provides direct terminal access to query Trackio experiment tr
 | Get metric around step | `trackio get metric ... --metric <name> --around <N> --window <W>` |
 | Get all metrics snapshot | `trackio get snapshot --project <name> --run <name> --step <N>` |
 | Get system metrics | `trackio get system-metric --project <name> --run <name>` |
+| Get one trace + span tree | `trackio get trace --project <name> --trace-id <id>` |
+| Roll up trace operations | `trackio get trace-summary --project <name> [--run <name>]` |
 | Run direct SQL | `trackio query project --project <name> --sql "SELECT ..."` |
 | Query remote Space | `trackio list projects --space <space_id_or_url>` |
 | Show dashboard | `trackio show [--project <name>]` |
@@ -68,6 +71,61 @@ trackio get snapshot --project <name> --run <name> --at-time <ts> --window 60 --
 trackio get system-metric --project <name> --run <name>           # All system metrics
 trackio get system-metric --project <name> --run <name> --metric <name>  # Specific metric
 trackio get system-metric --project <name> --run <name> --json
+```
+
+### Trace Commands
+
+Traces are agent/LLM sessions: OpenAI-style messages plus execution spans
+(model generations, tool calls) carrying latency, status, token usage, and cost.
+Use these to answer questions about *production agent behaviour* — where latency
+and spend go, which tools fail, how context grows.
+
+```bash
+trackio list traces --project <name>                          # Newest traces across all runs
+trackio list traces --project <name> --run <name>             # One run
+trackio list traces --project <name> --search "rate limit"    # Match messages, metadata, span names/models/errors
+trackio list traces --project <name> --step 12                # Traces logged at one step
+trackio list traces --project <name> --sort step_desc --limit 100
+trackio list traces --project <name> --json                   # Adds a per-trace `summary` rollup
+
+trackio get trace --project <name> --trace-id <id>            # Full span tree, per-span cost/tokens/errors
+trackio get trace --project <name> --trace-id <id> --json
+
+trackio get trace-summary --project <name>                    # Per-operation rollup across traces
+trackio get trace-summary --project <name> --run <name> --json
+```
+
+`list traces` prints the short trace id (the `log_id` segment); `get trace`
+accepts either that or the full stored id.
+
+`get trace-summary` groups every span by operation name and returns calls,
+errors, avg/max latency in ms, input/output tokens, and cost — the fastest way
+to find what to improve:
+
+```bash
+$ trackio get trace-summary --project paperswithcode-chat
+operation                  | kind       | calls | errors | avg_ms  | max_ms  | input_tokens | output_tokens | cost_usd
+provider-request           | generation | 205   | 0      | 3380.8  | 5535.0  | 2915829      | 63020         | 9.6928
+run-bash-command           | tool       | 157   | 25     | 818.4   | 1548.0  | 0            | 0             | 0.0
+acquire-sandbox            | span       | 48    | 0      | 2438.6  | 10615.0 | 0            | 0             | 0.0
+```
+
+Read that as: input tokens are 98% of all tokens (context is being re-sent, so
+prompt caching is the biggest cost lever), 25 of 157 tool calls fail, and
+`acquire-sandbox` has a 10.6s worst case against a 2.4s average (cold starts).
+
+For anything the rollup does not cover, query the `traces` table directly. The
+`spans` column is JSON, so `json_each` works:
+
+```bash
+# Which tool failures happen, and in how many sessions?
+trackio query project --project <name> --sql "
+SELECT json_extract(s.value,'\$.name') AS op,
+       json_extract(s.value,'\$.error.stderr') AS stderr,
+       COUNT(*) AS failures, COUNT(DISTINCT traces.id) AS sessions
+FROM traces, json_each(traces.spans) AS s
+WHERE json_extract(s.value,'\$.status') = 'error'
+GROUP BY op, stderr ORDER BY failures DESC"
 ```
 
 ### Query Command
@@ -193,7 +251,12 @@ trackio list alerts --project my-project --json --since "2025-06-01T00:00:00"
 # 6. When an alert fires at step N, get all metrics around that point
 trackio get snapshot --project my-project --run my-run --around 200 --window 5 --json
 
-# 7. Fall back to direct SQL for one-off inspection
+# 7. Review production agent behaviour: rollup first, then drill into a trace
+trackio get trace-summary --project <name> --json
+trackio list traces --project <name> --search "error" --json
+trackio get trace --project <name> --trace-id <id> --json
+
+# 8. Fall back to direct SQL for one-off inspection
 trackio query project --project my-project --sql "SELECT timestamp, run_name, level, title FROM alerts ORDER BY timestamp DESC LIMIT 20" --json
 ```
 

--- a/.agents/skills/trackio/retrieving_metrics.md
+++ b/.agents/skills/trackio/retrieving_metrics.md
@@ -75,58 +75,30 @@ trackio get system-metric --project <name> --run <name> --json
 
 ### Trace Commands
 
-Traces are agent/LLM sessions: OpenAI-style messages plus execution spans
-(model generations, tool calls) carrying latency, status, token usage, and cost.
-Use these to answer questions about *production agent behaviour* — where latency
-and spend go, which tools fail, how context grows.
+Traces are agent/LLM sessions carrying execution spans (model generations, tool
+calls) with latency, status, token usage, and cost.
 
 ```bash
 trackio list traces --project <name>                          # Newest traces across all runs
 trackio list traces --project <name> --run <name>             # One run
 trackio list traces --project <name> --search "rate limit"    # Match messages, metadata, span names/models/errors
 trackio list traces --project <name> --step 12                # Traces logged at one step
-trackio list traces --project <name> --sort step_desc --limit 100
+trackio list traces --project <name> --sort step_desc --limit 100 --offset 50
 trackio list traces --project <name> --json                   # Adds a per-trace `summary` rollup
 
 trackio get trace --project <name> --trace-id <id>            # Full span tree, per-span cost/tokens/errors
-trackio get trace --project <name> --trace-id <id> --json
-
-trackio get trace-summary --project <name>                    # Per-operation rollup across traces
-trackio get trace-summary --project <name> --run <name> --json
+trackio get trace-summary --project <name> [--run <name>]     # Per-operation rollup
 ```
 
 `list traces` prints the short trace id (the `log_id` segment); `get trace`
-accepts either that or the full stored id.
+accepts either that or the full stored id. `--sort` accepts
+`request_time_desc` (default), `request_time_asc`, `step_asc`, `step_desc`.
 
-`get trace-summary` groups every span by operation name and returns calls,
-errors, avg/max latency in ms, input/output tokens, and cost — the fastest way
-to find what to improve:
-
-```bash
-$ trackio get trace-summary --project paperswithcode-chat
-operation                  | kind       | calls | errors | avg_ms  | max_ms  | input_tokens | output_tokens | cost_usd
-provider-request           | generation | 205   | 0      | 3380.8  | 5535.0  | 2915829      | 63020         | 9.6928
-run-bash-command           | tool       | 157   | 25     | 818.4   | 1548.0  | 0            | 0             | 0.0
-acquire-sandbox            | span       | 48    | 0      | 2438.6  | 10615.0 | 0            | 0             | 0.0
-```
-
-Read that as: input tokens are 98% of all tokens (context is being re-sent, so
-prompt caching is the biggest cost lever), 25 of 157 tool calls fail, and
-`acquire-sandbox` has a 10.6s worst case against a 2.4s average (cold starts).
-
-For anything the rollup does not cover, query the `traces` table directly. The
-`spans` column is JSON, so `json_each` works:
-
-```bash
-# Which tool failures happen, and in how many sessions?
-trackio query project --project <name> --sql "
-SELECT json_extract(s.value,'\$.name') AS op,
-       json_extract(s.value,'\$.error.stderr') AS stderr,
-       COUNT(*) AS failures, COUNT(DISTINCT traces.id) AS sessions
-FROM traces, json_each(traces.spans) AS s
-WHERE json_extract(s.value,'\$.status') = 'error'
-GROUP BY op, stderr ORDER BY failures DESC"
-```
+**To analyze traces** — "what can we improve", "why is the agent slow or
+expensive", "what's failing" — follow the funnel in
+[traces.md](traces.md): orient, roll up, quantify each anomaly with SQL, then
+verify against one full trace. That reference also has the `json_each` recipes
+for tool failures, cost attribution, bimodal latency, and context growth.
 
 ### Query Command
 
@@ -251,7 +223,7 @@ trackio list alerts --project my-project --json --since "2025-06-01T00:00:00"
 # 6. When an alert fires at step N, get all metrics around that point
 trackio get snapshot --project my-project --run my-run --around 200 --window 5 --json
 
-# 7. Review production agent behaviour: rollup first, then drill into a trace
+# 7. Review production agent behaviour (see traces.md for the full funnel)
 trackio get trace-summary --project <name> --json
 trackio list traces --project <name> --search "error" --json
 trackio get trace --project <name> --trace-id <id> --json

--- a/.agents/skills/trackio/storage_schema.md
+++ b/.agents/skills/trackio/storage_schema.md
@@ -89,6 +89,43 @@ Indexes:
 - `timestamp`
 - unique partial index on `alert_id`
 
+### `traces`
+
+- `id` (primary key, `run_id:log_id:key[:index]`)
+- `run_id`
+- `run_name`
+- `timestamp`
+- `step`
+- `key` — the key used in the `trackio.log()` payload
+- `trace_index` — position when traces were logged as a list, else NULL
+- `messages` — JSON, OpenAI-style messages
+- `metadata` — JSON, trace-level metadata
+- `spans` — JSON array of execution spans, defaults to `[]`
+- `search_text` — flattened text backing `--search`
+- `log_id`, `space_id`
+
+Indexes:
+
+- `(run_id, step)`
+- `(run_id, timestamp)`
+- `search_text`
+
+`spans` is a JSON array, so use `json_each` to analyze it. Each span may carry
+`id`, `parent_id`, `name`, `kind` (`span`/`generation`/`tool`), `start_time`,
+`end_time`, `duration_ms`, `status`, `error`, `input`, `output`, `model`,
+`usage.input_tokens`, `usage.output_tokens`, `cost_usd`, and `metadata`:
+
+```bash
+trackio query project --project <name> --sql "
+SELECT json_extract(s.value,'\$.name') AS operation, COUNT(*) AS calls
+FROM traces, json_each(traces.spans) AS s
+GROUP BY operation ORDER BY calls DESC"
+```
+
+Prefer the dedicated commands (`trackio get trace-summary`, `trackio list
+traces`) over hand-written SQL where they cover the question — see
+[traces.md](traces.md).
+
 ## Parquet Layout
 
 Trackio flattens JSON blobs when exporting parquet:

--- a/.agents/skills/trackio/traces.md
+++ b/.agents/skills/trackio/traces.md
@@ -1,0 +1,206 @@
+# Analyzing Agent Traces with Trackio CLI
+
+Traces are agent or LLM sessions: OpenAI-style messages plus **execution spans**
+(model generations, tool calls, sub-steps) carrying latency, status, model, token
+usage, and cost. Where metrics answer "how is training going", traces answer
+"what is my agent actually doing in production, and what should I fix".
+
+Use this reference when asked things like *"look at the traces and tell me what
+we can improve"*, *"why is the agent slow/expensive"*, *"what's failing in
+production"*, or *"where do the tokens go"*.
+
+## The funnel
+
+No single command answers "what can we improve". Work through four steps, and do
+not skip step 3 — it is the difference between a bug report and a prioritized
+one.
+
+```
+1. Orient      -> is there trace data, and does it carry spans?
+2. Rollup      -> one command for the whole shape; read it for anomalies
+3. Quantify    -> turn each anomaly into a measured cost or latency impact
+4. Verify      -> read one full trace to confirm the story holds
+```
+
+### Step 1: Orient
+
+```bash
+trackio list projects --json
+trackio list traces --project <name> --limit 5
+```
+
+Check the `Ops` column. If it is 0 everywhere, the traces carry no spans — only
+messages are available, so latency/cost/tool analysis is not possible. Say so
+instead of guessing.
+
+Add `--space <space_id_or_url>` to every command below to analyze a deployed
+Space rather than local data.
+
+### Step 2: Rollup — one command for the whole shape
+
+```bash
+trackio get trace-summary --project <name>
+```
+
+```
+operation                  | kind       | calls | errors | avg_ms  | max_ms  | input_tokens | output_tokens | cost_usd
+provider-request           | generation | 205   | 0      | 3380.8  | 5535.0  | 2915829      | 63020         | 9.6928
+run-bash-command           | tool       | 157   | 25     | 818.4   | 1548.0  | 0            | 0             | 0.0
+acquire-sandbox            | span       | 48    | 0      | 2438.6  | 10615.0 | 0            | 0             | 0.0
+```
+
+Read it for anomalies. Each is a **hypothesis**, not yet a finding:
+
+| Signal | Hypothesis to test |
+|---|---|
+| `errors` > 0 | A systematic tool/prompt bug, or genuine flakiness — step 3 distinguishes them |
+| `input_tokens` >> `output_tokens` | Context re-sent every turn; prompt caching or tool-output truncation is the lever |
+| `max_ms` >> `avg_ms` | Bimodal latency (cold starts, retries), not a uniformly slow operation |
+| High `cost_usd` on one operation | Where optimization effort actually pays off |
+| `calls` >> session count | Repeated work per session; look for retry loops |
+
+### Step 3: Quantify — make each hypothesis a measured impact
+
+The rollup cannot tell you whether 25 errors are one bug or twenty, or whether
+they cost anything. Drop to SQL. `spans` is a JSON column, so `json_each` works.
+
+**Which failures, and are they systematic?** A command that fails *every* time it
+is attempted is a bug in the prompt or tooling; one that fails sometimes is
+flakiness. Very different fixes.
+
+```bash
+trackio query project --project <name> --sql "
+SELECT json_extract(s.value,'\$.input.command') AS cmd,
+       json_extract(s.value,'\$.status') AS status,
+       COUNT(*) AS n, COUNT(DISTINCT traces.id) AS sessions
+FROM traces, json_each(traces.spans) AS s
+WHERE json_extract(s.value,'\$.kind') = 'tool'
+GROUP BY cmd, status ORDER BY n DESC"
+```
+
+**What does it cost?** Compare sessions that hit the problem against those that
+did not. This is the step that turns an observation into a priority:
+
+```bash
+trackio query project --project <name> --sql "
+WITH per_session AS (
+  SELECT traces.id AS tid,
+         SUM(COALESCE(json_extract(s.value,'\$.cost_usd'),0)) AS cost,
+         SUM(CASE WHEN json_extract(s.value,'\$.name')='provider-request'
+                  THEN 1 ELSE 0 END) AS model_calls,
+         MAX(CASE WHEN json_extract(s.value,'\$.status')='error'
+                  THEN 1 ELSE 0 END) AS hit
+  FROM traces, json_each(traces.spans) AS s GROUP BY traces.id
+)
+SELECT hit, COUNT(*) AS sessions, ROUND(AVG(cost),4) AS avg_cost_usd,
+       ROUND(AVG(model_calls),2) AS avg_model_calls
+FROM per_session GROUP BY hit"
+```
+
+**Is a slow operation bimodal?** Group by whatever metadata marks the two modes
+(e.g. a `cold_start` flag), or bucket the durations:
+
+```bash
+trackio query project --project <name> --sql "
+SELECT json_extract(s.value,'\$.metadata.cold_start') AS cold_start,
+       COUNT(*) AS n,
+       ROUND(AVG((julianday(json_extract(s.value,'\$.end_time'))
+                - julianday(json_extract(s.value,'\$.start_time')))*86400),2) AS avg_s,
+       ROUND(MAX((julianday(json_extract(s.value,'\$.end_time'))
+                - julianday(json_extract(s.value,'\$.start_time')))*86400),2) AS max_s
+FROM traces, json_each(traces.spans) AS s
+WHERE json_extract(s.value,'\$.name') = '<operation>'
+GROUP BY cold_start"
+```
+
+**Is context growing within a session?** Compare per-turn input tokens, and
+check whether any caching is happening at all:
+
+```bash
+trackio query project --project <name> --sql "
+SELECT SUM(COALESCE(json_extract(s.value,'\$.usage.input_tokens'),0)) AS input_tokens,
+       SUM(COALESCE(json_extract(s.value,'\$.usage.output_tokens'),0)) AS output_tokens,
+       SUM(COALESCE(json_extract(s.value,'\$.metadata.cache_read_input_tokens'),0)) AS cached
+FROM traces, json_each(traces.spans) AS s
+WHERE json_extract(s.value,'\$.kind') = 'generation'"
+```
+
+Also useful: `trackio list traces --project <name> --search "<error text>"`
+finds the affected sessions, since search covers span names, models, statuses,
+and errors.
+
+### Step 4: Verify — read one trace end to end
+
+```bash
+trackio get trace --project <name> --trace-id <id>
+```
+
+```
+Trace f179746a789348639e1f1963f320bd02
+  Totals:   error | 25.0s | $0.33 | 101338 in / 1804 out tokens | 21 operation(s)
+
+Execution:
+  answer-research-question [span]  25.0s
+    generate-research-response [span]  23.7s
+      acquire-sandbox [span]  914ms
+      dispatch-model-request [span]  2.18s
+        provider-request [generation]  2.18s  my-model  8347->239 tok  $0.03
+      ERROR run-bash-command [tool]  168ms
+        -> {"exit_code": 2, "stderr": "error: unrecognized arguments: --full"}
+      dispatch-model-request [span]  3.40s
+        provider-request [generation]  3.40s  my-model  14632->110 tok  $0.05
+```
+
+This confirms the aggregate story in one concrete session — here, input tokens
+climbing 8347 -> 14632 per turn, with the failing call visible in place. It is
+also the most legible artifact to show a human, so quote it when reporting.
+
+`--trace-id` accepts the short id from `list traces` or the full stored id.
+
+## Reporting rules
+
+- **Report findings, not hypotheses.** "25 tool calls failed" is step 2 output.
+  "This command failed 21/21 times, costing $0.03 and 0.6 extra model calls per
+  affected session" is a finding. Do not present the former as the latter.
+- **Attach a number to every recommendation**, drawn from step 3.
+- **Distinguish systematic from flaky.** A 100% failure rate points at a prompt
+  or tooling bug; a partial rate points at rate limits, timeouts, or retries.
+- **Say when spans are missing.** Without `end_time`/`usage`/`cost_usd`, latency
+  and cost analysis is not possible; recommend instrumenting those rather than
+  inferring.
+- **Do not trust a trace's `status` alone.** Operations derived from messages
+  have no success signal (OpenAI-style tool results carry none), so their status
+  is intentionally unset. Use the `errors` column and `error` fields.
+
+## Cost and payload notes
+
+`get trace-summary` and `query project` aggregate inside SQLite and return only
+the result rows. `list traces` and `get trace` return full trace payloads,
+including span `input`/`output`, which routinely contain the whole conversation
+per generation. On projects with large prompts:
+
+- Start with `trace-summary` and `query project`.
+- Use `--limit` on `list traces`.
+- Reach for `get trace` only once you know which trace you want.
+
+Span `input`/`output` are deliberately **not** covered by `--search`, precisely
+because they duplicate the conversation. Search matches message content, trace
+metadata, and each span's `id`, `name`, `kind`, `model`, `status`, and `error`.
+
+## Command reference
+
+| Task | Command |
+|---|---|
+| List traces (all runs) | `trackio list traces --project <name>` |
+| Filter by run / step / text | `trackio list traces --project <name> [--run <r>] [--step <n>] [--search <t>]` |
+| Sort and page | `trackio list traces --project <name> --sort step_desc --limit 100 --offset 50` |
+| One trace + span tree | `trackio get trace --project <name> --trace-id <id>` |
+| Per-operation rollup | `trackio get trace-summary --project <name> [--run <r>]` |
+| Arbitrary span analysis | `trackio query project --project <name> --sql "... json_each(traces.spans) ..."` |
+
+`--sort` accepts `request_time_desc` (default), `request_time_asc`, `step_asc`,
+`step_desc`. All commands accept `--json` and `--space`. With `--json`,
+`list traces` adds a per-trace `summary` (latency, cost, tokens, status, span
+count) so you can compute without re-deriving it.
+
+See [storage_schema.md](storage_schema.md) for the full `traces` table schema.

--- a/.changeset/tidy-traces-observe.md
+++ b/.changeset/tidy-traces-observe.md
@@ -1,0 +1,5 @@
+---
+"trackio": minor
+---
+
+Add hierarchical execution spans and a trace inspector with per-operation latency, status, token usage, cost, and input/output details.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,7 +84,6 @@ When given a GitHub issue to solve, follow this workflow:
 2. **Implement the solution** following the existing code patterns and conventions
 3. **Run tests** to ensure nothing is broken: `pytest`
 4. **Run linting/formatting**: `ruff check --fix --select I && ruff format`
-5. That's it. Never use the `git` commit command after a task is finished.
 
 ### Git Commands for Issue Workflow
 ```bash

--- a/docs/source/_toctree.yml
+++ b/docs/source/_toctree.yml
@@ -11,6 +11,8 @@
 - sections:
   - local: track
     title: Track
+  - local: traces
+    title: Traces
   - local: artifacts
     title: Artifacts
   - local: registry

--- a/docs/source/api.md
+++ b/docs/source/api.md
@@ -92,6 +92,10 @@
 
 [[autodoc]] Table
 
+## Trace
+
+[[autodoc]] Trace
+
 ## Histogram
 
 [[autodoc]] Histogram

--- a/docs/source/cli_commands.md
+++ b/docs/source/cli_commands.md
@@ -216,7 +216,82 @@ Output in JSON format:
 trackio list reports --project "my-project" --run "my-run" --json
 ```
 
+### List Traces
+
+List [traces](./traces) (agent or conversation sessions) across all runs in a project:
+
+```sh
+trackio list traces --project "my-project"
+```
+
+Each row shows the trace's status, wall-clock latency, cost, operation count, and
+the user request that started it. Filter by run, step, or text:
+
+```sh
+trackio list traces --project "my-project" --run "production"
+trackio list traces --project "my-project" --step 12
+trackio list traces --project "my-project" --search "rate limit"
+```
+
+Search matches message content, trace metadata, and each span's name, kind,
+model, status, and error. Control ordering and paging:
+
+```sh
+trackio list traces --project "my-project" --sort step_desc --limit 100 --offset 50
+```
+
+`--sort` accepts `request_time_desc` (default), `request_time_asc`, `step_asc`,
+and `step_desc`. Adding `--json` includes a `summary` rollup per trace.
+
 ## Get Commands
+
+### Get Trace
+
+Show one trace with its full execution tree:
+
+```sh
+trackio get trace --project "my-project" --trace-id "fe04ed264a8a4bd6afcf266b56d9297e"
+```
+
+```
+Trace fe04ed264a8a4bd6afcf266b56d9297e
+  Run:      production
+  Totals:   error | 25.0s | $0.33 | 101338 in / 1804 out tokens | 21 operation(s)
+
+Execution:
+  answer-research-question [span]  25.0s
+    generate-research-response [span]  23.7s
+      acquire-sandbox [span]  914ms
+      dispatch-model-request [span]  2.18s
+        provider-request [generation]  2.18s  my-model  8347->239 tok  $0.03
+      ERROR run-bash-command [tool]  168ms
+        -> {"exit_code": 2, "stderr": "hf datasets list: error: unrecognized arguments: --full"}
+```
+
+`--trace-id` accepts the short id printed by `trackio list traces` or the full
+stored id. Add `--json` for the complete trace, including span inputs and
+outputs.
+
+### Get Trace Summary
+
+Roll every span up by operation name to see where latency, tokens, and cost go,
+and which operations fail:
+
+```sh
+trackio get trace-summary --project "my-project"
+```
+
+```
+operation                  | kind       | calls | errors | avg_ms  | max_ms  | input_tokens | output_tokens | cost_usd
+provider-request           | generation | 205   | 0      | 3380.8  | 5535.0  | 2915829      | 63020         | 9.6928
+run-bash-command           | tool       | 157   | 25     | 818.4   | 1548.0  | 0            | 0             | 0.0
+acquire-sandbox            | span       | 48    | 0      | 2438.6  | 10615.0 | 0            | 0             | 0.0
+```
+
+Restrict to one run with `--run`, or emit machine-readable rows with `--json`.
+For anything the rollup does not cover, query the `traces` table directly with
+[`trackio query project`](#query-command) — `spans` is a JSON column, so
+`json_each` works.
 
 ### Get Project Summary
 

--- a/docs/source/storage_schema.md
+++ b/docs/source/storage_schema.md
@@ -85,6 +85,30 @@ Indexes:
 - `idx_system_metrics_log_id` unique partial index on `log_id`
 - `idx_system_metrics_pending` partial index on `space_id`
 
+### `traces`
+
+| Column | Type | Notes |
+|--------|------|-------|
+| `id` | `TEXT` | Primary key |
+| `run_id` | `TEXT` | Stable run identifier |
+| `timestamp` | `TEXT` | ISO timestamp when the trace was logged |
+| `run_name` | `TEXT` | Run display name |
+| `step` | `INTEGER` | Training or logging step |
+| `key` | `TEXT` | Key used in the `trackio.log()` payload |
+| `trace_index` | `INTEGER` | Position when traces were logged as a list |
+| `messages` | `TEXT` | JSON OpenAI-style messages |
+| `metadata` | `TEXT` | JSON trace metadata |
+| `search_text` | `TEXT` | Flattened text used by trace search |
+| `log_id` | `TEXT` | Optional source log deduplication key |
+| `space_id` | `TEXT` | Optional pending-sync marker |
+| `spans` | `TEXT` | JSON execution spans; defaults to `[]` |
+
+Indexes:
+
+- `idx_traces_run_step` on `(run_id, step)`
+- `idx_traces_run_timestamp` on `(run_id, timestamp)`
+- `idx_traces_search` on `search_text`
+
 ### `project_metadata`
 
 | Column | Type | Notes |

--- a/docs/source/storage_schema.md
+++ b/docs/source/storage_schema.md
@@ -7,6 +7,7 @@ Trackio stores each project in its own SQLite database and can export that data 
 - Local project databases live in `TRACKIO_DIR`, which defaults to `~/.cache/huggingface/trackio`.
 - Each project is stored as a separate SQLite file: `{project}.db`.
 - Media and uploaded files live under `TRACKIO_DIR/media/`.
+- Each trace is additionally written as a Hub-renderable agent session file under `TRACKIO_DIR/traces/` (on a Space, the bucket's `traces/` prefix). These are a rendering artifact for the Hub's agent trace viewer; the `traces` table stays authoritative. See [Traces](./traces).
 - When syncing to Hugging Face, Trackio exports parquet files from the SQLite database before upload.
 
 ## Querying Data Directly

--- a/docs/source/traces.md
+++ b/docs/source/traces.md
@@ -137,6 +137,42 @@ FROM traces, json_each(traces.spans) AS s
 GROUP BY operation ORDER BY input_tokens DESC"
 ```
 
+## Viewing traces on the Hugging Face Hub
+
+Every logged trace is also written as an agent session `.jsonl` file, in the
+format the Hub's agent trace viewer renders. When Trackio runs on a Space, the
+bucket is mounted at `/data`, so these land in the bucket under
+`traces/{project}/{run}/{trace_id}.jsonl` — open one from the bucket's file
+browser to step through the conversation, its tool calls, and their results.
+
+Trackio emits [Pi's session
+format](https://github.com/earendil-works/pi/blob/main/packages/coding-agent/docs/session-format.md)
+(version 3), which the Hub supports natively. The Hub also documents a Session
+Trace Simple Format, but files written to that spec are not currently rendered
+by the viewer.
+
+The session files are a rendering artifact, never the source of truth. The
+`traces` table stays authoritative, and everything else on this page — search,
+the span tree, `trace-summary`, direct SQL — reads from it. What the session
+file carries is the linear conversation, enriched from the spans with the
+details the viewer can display:
+
+| From the span | Appears in the session as |
+|---|---|
+| `model` on a generation | a `model_change` entry |
+| `usage`, `cost_usd` | `usage` on the assistant turn it produced |
+| `status`, `error` on a tool | `isError` on the tool result |
+| `input`, `output` on a tool | the `toolCall` arguments and result, for traces with no `messages` |
+
+Token usage is paired with the assistant turn that produced it rather than
+repeated on every turn, so the viewer does not double-count. Span hierarchy,
+`duration_ms`, per-span `metadata`, and the `kind` of non-tool spans have no
+place in the format and stay in SQLite.
+
+Session files sit beside the `trackio/` prefix rather than inside it, so
+`trackio` CLI commands that sync a bucket down do not pull a second copy of
+every trace. Set `TRACKIO_TRACE_SESSIONS_DIR` to write them somewhere else.
+
 ## Trace-level metadata
 
 Spans are the preferred source for latency, cost, and status. When a trace has no

--- a/docs/source/traces.md
+++ b/docs/source/traces.md
@@ -1,0 +1,104 @@
+# Traces
+
+Trackio traces capture a user request, the assistant response, and the operations
+that produced it. Open the **Traces** page in the dashboard to search requests,
+inspect model and tool operations, and see latency, token, cost, and status totals.
+
+## Log a conversation
+
+Pass a [`Trace`](./api#trace) to `trackio.log()` with OpenAI-style
+messages:
+
+```python
+import trackio
+
+trackio.init(project="research-agent")
+trackio.log(
+    {
+        "trace": trackio.Trace(
+            messages=[
+                {"role": "user", "content": "Find agent training datasets."},
+                {"role": "assistant", "content": "Here are three datasets..."},
+            ],
+            metadata={"session_id": "session-123", "environment": "production"},
+        )
+    }
+)
+trackio.finish()
+```
+
+Messages can include `tool_calls` and `tool` results. When a trace has no explicit
+spans, the dashboard pairs those calls and results into tool operations for easier
+inspection.
+
+## Add execution spans
+
+Use `spans` when you need timings, hierarchy, model usage, cost, or operation
+status. Each span is a dictionary. The minimal fields are `id`, `name`, and `kind`:
+
+```python
+trackio.Trace(
+    messages=messages,
+    spans=[
+        {
+            "id": "research",
+            "name": "answer-research-question",
+            "kind": "span",
+            "start_time": "2026-08-19T12:00:00Z",
+            "end_time": "2026-08-19T12:00:03Z",
+            "status": "success",
+        },
+        {
+            "id": "generation-1",
+            "parent_id": "research",
+            "name": "provider-request",
+            "kind": "generation",
+            "start_time": "2026-08-19T12:00:00Z",
+            "end_time": "2026-08-19T12:00:01.2Z",
+            "model": "my-model",
+            "input": {"messages": messages},
+            "output": {"text": "I will search for datasets."},
+            "usage": {"input_tokens": 8439, "output_tokens": 188},
+            "cost_usd": 0.0042,
+            "status": "success",
+        },
+        {
+            "id": "tool-1",
+            "parent_id": "research",
+            "name": "hf search",
+            "kind": "tool",
+            "start_time": "2026-08-19T12:00:01.3Z",
+            "end_time": "2026-08-19T12:00:02Z",
+            "input": {"query": "agent training datasets"},
+            "output": {"datasets": ["example/dataset"]},
+            "status": "success",
+        },
+    ],
+)
+```
+
+Supported span fields:
+
+| Field | Description |
+|---|---|
+| `id` | Identifier unique within the trace |
+| `parent_id` | Optional parent span ID; creates the execution tree |
+| `name` | Operation name shown in the inspector |
+| `kind` | `span`, `generation`, or `tool` |
+| `start_time`, `end_time` | ISO-8601 timestamps used to derive latency |
+| `duration_ms` | Optional duration when timestamps are unavailable |
+| `status` | Usually `success` or `error` |
+| `error` | Structured or textual error details |
+| `input`, `output` | Any JSON-serializable operation payload |
+| `model` | Model identifier for a generation |
+| `usage` | `input_tokens`, `output_tokens`, and optional `total_tokens` |
+| `cost_usd` | Cost for this operation in US dollars |
+| `metadata` | Additional operation metadata |
+
+Trace latency is wall-clock time from the earliest span start to the latest span
+end. Token and cost totals sum the values on individual spans, so `cost_usd` should
+describe the local operation rather than a parent aggregate. Trackio does not
+maintain a model pricing catalog; instrumentation should supply the actual cost.
+
+Nested Trackio media values in messages, metadata, span input, or span output are
+stored alongside the trace.

--- a/docs/source/traces.md
+++ b/docs/source/traces.md
@@ -96,9 +96,66 @@ Supported span fields:
 | `metadata` | Additional operation metadata |
 
 Trace latency is wall-clock time from the earliest span start to the latest span
-end. Token and cost totals sum the values on individual spans, so `cost_usd` should
-describe the local operation rather than a parent aggregate. Trackio does not
+end; when no span carries an `end_time`, the longest single `duration_ms` is used
+instead. Token and cost totals sum the values on individual spans, so `usage` and
+`cost_usd` should describe the local operation rather than a parent aggregate — a
+parent that repeats its children's totals will double-count. Trackio does not
 maintain a model pricing catalog; instrumentation should supply the actual cost.
 
+A span is reported as failed when its `status` is `error` or `failed`, or when it
+carries an `error`. For spans derived from messages, a tool result marks its
+operation failed when the message sets `is_error`, `error`, or an error `status`;
+OpenAI-style tool results carry no success signal, so those operations are left
+without a status rather than assumed successful.
+
+## Inspect traces from the CLI
+
+The dashboard is not the only way to read traces back. The CLI works against
+local data, or against a Space with `--space`:
+
+```bash
+trackio list traces --project research-agent
+trackio list traces --project research-agent --search "rate limit"
+trackio get trace --project research-agent --trace-id <id>
+trackio get trace-summary --project research-agent
+```
+
+`trackio get trace` prints the execution tree with per-span latency, model,
+tokens, cost, and errors. `trackio get trace-summary` groups every span by
+operation name and reports calls, errors, average and worst-case latency, token
+usage, and cost — useful for finding which operation dominates spend or fails
+most often. Both accept `--json`.
+
+For anything else, `spans` is a JSON column, so `json_each` works with
+[`trackio query project`](./cli_commands):
+
+```bash
+trackio query project --project research-agent --sql "
+SELECT json_extract(s.value, '\$.name') AS operation,
+       SUM(COALESCE(json_extract(s.value, '\$.usage.input_tokens'), 0)) AS input_tokens
+FROM traces, json_each(traces.spans) AS s
+GROUP BY operation ORDER BY input_tokens DESC"
+```
+
+## Trace-level metadata
+
+Spans are the preferred source for latency, cost, and status. When a trace has no
+spans, or its spans omit these values, the dashboard falls back to these
+`metadata` keys:
+
+| Key | Used for |
+|---|---|
+| `status` | Trace status, unless a span reports an error |
+| `duration_ms`, `latency_ms` | Trace latency |
+| `cost_usd` | Trace cost, when no span reports a cost |
+
+## Search
+
+Trace search matches message content, trace metadata, and each span's `id`,
+`name`, `kind`, `model`, `status`, `error`, and `metadata`. Span `input` and
+`output` payloads are not indexed: they routinely repeat the whole conversation
+for every generation, so indexing them would multiply stored trace size for
+little search value.
+
 Nested Trackio media values in messages, metadata, span input, or span output are
-stored alongside the trace.
+stored alongside the trace, and images are rendered inline in the inspector.

--- a/examples/traces/complex-trace.py
+++ b/examples/traces/complex-trace.py
@@ -1,4 +1,5 @@
 import random
+from datetime import datetime, timedelta, timezone
 
 import numpy as np
 
@@ -18,6 +19,8 @@ for run_idx in range(2):
 
     for step in range(4):
         screenshot = make_screenshot(run_idx * 10 + step)
+        started = datetime.now(timezone.utc)
+        agent_span_id = f"agent_{run_idx}_{step}"
         trackio.log(
             {
                 "agent_trace": trackio.Trace(
@@ -65,7 +68,64 @@ for run_idx in range(2):
                         "environment": "browser",
                         "category": "complex-example",
                         "variant": step,
+                        "session_id": f"demo-session-{run_idx}",
+                        "status": "success",
                     },
+                    spans=[
+                        {
+                            "id": agent_span_id,
+                            "name": "inspect-page",
+                            "kind": "span",
+                            "start_time": started.isoformat(),
+                            "end_time": (started + timedelta(seconds=2.5)).isoformat(),
+                            "status": "success",
+                        },
+                        {
+                            "id": f"plan_{run_idx}_{step}",
+                            "parent_id": agent_span_id,
+                            "name": "provider-request",
+                            "kind": "generation",
+                            "start_time": started.isoformat(),
+                            "end_time": (started + timedelta(seconds=0.8)).isoformat(),
+                            "model": "demo-model",
+                            "input": {
+                                "prompt": "Inspect the page and decide what to do."
+                            },
+                            "output": {"tool": "extract_title"},
+                            "usage": {"input_tokens": 8439, "output_tokens": 188},
+                            "cost_usd": 0.0042,
+                            "status": "success",
+                        },
+                        {
+                            "id": f"call_{run_idx}_{step}",
+                            "parent_id": agent_span_id,
+                            "name": "extract_title",
+                            "kind": "tool",
+                            "start_time": (
+                                started + timedelta(seconds=0.9)
+                            ).isoformat(),
+                            "end_time": (started + timedelta(seconds=1.4)).isoformat(),
+                            "input": {"selector": "title"},
+                            "output": {"title": f"Trackio Demo {run_idx}-{step}"},
+                            "status": "success",
+                        },
+                        {
+                            "id": f"answer_{run_idx}_{step}",
+                            "parent_id": agent_span_id,
+                            "name": "provider-request",
+                            "kind": "generation",
+                            "start_time": (
+                                started + timedelta(seconds=1.5)
+                            ).isoformat(),
+                            "end_time": (started + timedelta(seconds=2.5)).isoformat(),
+                            "model": "demo-model",
+                            "input": {"title": f"Trackio Demo {run_idx}-{step}"},
+                            "output": {"answer": f"The page is demo variant {step}."},
+                            "usage": {"input_tokens": 1024, "output_tokens": 64},
+                            "cost_usd": 0.0008,
+                            "status": "success",
+                        },
+                    ],
                 )
             },
             step=step,

--- a/tests/unit/test_trace.py
+++ b/tests/unit/test_trace.py
@@ -1,9 +1,11 @@
+import json
 import os
 import sqlite3
+from pathlib import Path
 
 import pytest
 
-from trackio import Run, Trace, fragments
+from trackio import Run, Trace, agent_sessions, fragments
 from trackio.cli_helpers import (
     format_trace,
     parse_span_timestamp,
@@ -480,3 +482,290 @@ def test_format_trace_renders_span_tree_and_errors():
     assert "answer-question [span]  2.00s" in rendered
     assert "  ERROR run-bash-command [tool]" in rendered
     assert "unrecognized arguments: --full" in rendered
+
+
+def _session_records(path):
+    return [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+
+
+def _session_files(root):
+    return sorted(Path(root).rglob("*.jsonl"))
+
+
+def _log_trace(project, run, trace, **kwargs):
+    SQLiteStorage.bulk_log(
+        project=project,
+        run=run,
+        metrics_list=[{"trace": {"_type": "trackio.trace", **trace}}],
+        **kwargs,
+    )
+
+
+def test_logging_a_trace_writes_a_hub_native_session(temp_dir, monkeypatch, tmp_path):
+    sessions = tmp_path / "sessions"
+    monkeypatch.setenv("TRACKIO_TRACE_SESSIONS_DIR", str(sessions))
+
+    _log_trace(
+        "sts",
+        "run-a",
+        {
+            "messages": [
+                {"role": "system", "content": "be helpful"},
+                {"role": "user", "content": "hello"},
+                {
+                    "role": "assistant",
+                    "content": "looking",
+                    "tool_calls": [
+                        {
+                            "id": "t1",
+                            "function": {"name": "search", "arguments": {"q": "x"}},
+                        }
+                    ],
+                },
+                {"role": "tool", "tool_call_id": "t1", "content": "done"},
+            ],
+            "metadata": {"session_id": "s1"},
+            "spans": [
+                {
+                    "id": "g1",
+                    "name": "provider-request",
+                    "kind": "generation",
+                    "model": "my-model",
+                    "usage": {"input_tokens": 10, "output_tokens": 2},
+                    "cost_usd": 0.5,
+                    "status": "success",
+                }
+            ],
+        },
+    )
+
+    files = _session_files(sessions)
+    assert len(files) == 1
+    assert agent_sessions.is_hub_native_jsonl(files[0])
+
+    header, *entries = _session_records(files[0])
+    assert header["type"] == "session"
+    assert header["version"] == 3
+    assert header["harness"] == "trackio"
+    assert header["name"] == "hello"
+    assert header["trackio"]["run_name"] == "run-a"
+    assert header["trackio"]["metadata"] == {"session_id": "s1"}
+
+    # Every entry chains to the one before it.
+    parents = [e["parentId"] for e in entries]
+    assert parents[0] is None
+    assert parents[1:] == [e["id"] for e in entries[:-1]]
+
+    assert entries[0]["type"] == "model_change"
+    assert entries[0]["modelId"] == "my-model"
+
+    roles = [e["message"]["role"] for e in entries if e["type"] == "message"]
+    assert roles == ["developer", "user", "assistant", "toolResult"]
+
+    assistant = next(
+        e["message"] for e in entries if e.get("message", {}).get("role") == "assistant"
+    )
+    call = next(b for b in assistant["content"] if b["type"] == "toolCall")
+    assert call["arguments"] == {"q": "x"}  # a real object, not a JSON string
+    assert assistant["usage"]["totalTokens"] == 12
+    assert assistant["usage"]["cost"]["total"] == 0.5
+
+    result = next(
+        e["message"]
+        for e in entries
+        if e.get("message", {}).get("role") == "toolResult"
+    )
+    assert result["toolCallId"] == "t1"
+    assert result["toolName"] == "search"
+    assert "isError" not in result
+
+
+def test_tool_failure_marks_the_result_as_an_error(temp_dir, monkeypatch, tmp_path):
+    sessions = tmp_path / "sessions"
+    monkeypatch.setenv("TRACKIO_TRACE_SESSIONS_DIR", str(sessions))
+
+    _log_trace(
+        "sts",
+        "run-a",
+        {
+            "messages": [
+                {"role": "user", "content": "run it"},
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {"id": "t1", "function": {"name": "bash", "arguments": "{}"}}
+                    ],
+                },
+                {"role": "tool", "tool_call_id": "t1", "content": "boom"},
+            ],
+            "metadata": {},
+            "spans": [
+                {
+                    "id": "span-tool",
+                    "name": "bash",
+                    "kind": "tool",
+                    "status": "error",
+                    "error": {"code": 2},
+                }
+            ],
+        },
+    )
+
+    _, *entries = _session_records(_session_files(sessions)[0])
+    result = next(
+        e["message"]
+        for e in entries
+        if e.get("message", {}).get("role") == "toolResult"
+    )
+    assert result["isError"] is True
+    assert result["toolName"] == "bash"
+
+
+def test_usage_is_paired_per_assistant_turn_not_repeated(
+    temp_dir, monkeypatch, tmp_path
+):
+    """Repeating one span's totals on every turn would double-count in the viewer."""
+    sessions = tmp_path / "sessions"
+    monkeypatch.setenv("TRACKIO_TRACE_SESSIONS_DIR", str(sessions))
+
+    _log_trace(
+        "sts",
+        "run-a",
+        {
+            "messages": [
+                {"role": "user", "content": "hi"},
+                {"role": "assistant", "content": "one"},
+                {"role": "assistant", "content": "two"},
+            ],
+            "metadata": {},
+            "spans": [
+                {
+                    "id": "g1",
+                    "kind": "generation",
+                    "start_time": "2026-08-19T12:00:00Z",
+                    "usage": {"input_tokens": 10, "output_tokens": 1},
+                },
+                {
+                    "id": "g2",
+                    "kind": "generation",
+                    "start_time": "2026-08-19T12:00:05Z",
+                    "usage": {"input_tokens": 20, "output_tokens": 2},
+                },
+            ],
+        },
+    )
+
+    _, *entries = _session_records(_session_files(sessions)[0])
+    totals = [
+        e["message"]["usage"]["totalTokens"]
+        for e in entries
+        if e.get("message", {}).get("role") == "assistant"
+    ]
+    assert totals == [11, 22]
+
+
+def test_session_omits_span_payloads_but_sqlite_keeps_them(
+    temp_dir, monkeypatch, tmp_path
+):
+    sessions = tmp_path / "sessions"
+    monkeypatch.setenv("TRACKIO_TRACE_SESSIONS_DIR", str(sessions))
+    spans = [
+        {
+            "id": "g1",
+            "name": "provider-request",
+            "kind": "generation",
+            "duration_ms": 1234,
+            "metadata": {"cold_start": True},
+            "input": {"messages": ["a very large payload"]},
+        }
+    ]
+
+    _log_trace(
+        "sts",
+        "run-a",
+        {
+            "messages": [{"role": "user", "content": "hello"}],
+            "metadata": {},
+            "spans": spans,
+        },
+    )
+
+    text = _session_files(sessions)[0].read_text()
+    assert "a very large payload" not in text
+
+    stored = SQLiteStorage.get_traces("sts", "run-a")
+    assert stored[0]["spans"] == spans
+
+
+def test_span_only_trace_synthesizes_renderable_entries(
+    temp_dir, monkeypatch, tmp_path
+):
+    sessions = tmp_path / "sessions"
+    monkeypatch.setenv("TRACKIO_TRACE_SESSIONS_DIR", str(sessions))
+
+    _log_trace(
+        "sts",
+        "run-a",
+        {
+            "messages": [],
+            "metadata": {},
+            "spans": [
+                {
+                    "id": "b1",
+                    "name": "run-bash",
+                    "kind": "tool",
+                    "start_time": "2026-08-19T12:00:01Z",
+                    "input": {"command": "ls"},
+                    "output": "ok",
+                }
+            ],
+        },
+    )
+
+    _, *entries = _session_records(_session_files(sessions)[0])
+    roles = [e["message"]["role"] for e in entries]
+    assert roles == ["assistant", "toolResult"]
+    call = entries[0]["message"]["content"][0]
+    assert call["type"] == "toolCall"
+    assert call["arguments"] == {"command": "ls"}
+    assert entries[1]["message"]["toolCallId"] == call["id"]
+
+
+def test_trace_session_write_failure_does_not_break_logging(
+    temp_dir, monkeypatch, tmp_path
+):
+    monkeypatch.setenv("TRACKIO_TRACE_SESSIONS_DIR", str(tmp_path / "sessions"))
+    monkeypatch.setattr(
+        agent_sessions,
+        "write_session",
+        lambda *a, **k: (_ for _ in ()).throw(OSError("disk full")),
+    )
+
+    with pytest.warns(UserWarning, match="Could not write trace session file"):
+        _log_trace(
+            "sts",
+            "run-a",
+            {
+                "messages": [{"role": "user", "content": "hello"}],
+                "metadata": {},
+                "spans": [],
+            },
+        )
+
+    assert len(SQLiteStorage.get_traces("sts", "run-a")) == 1
+
+
+def test_sts_files_are_not_treated_as_hub_native(tmp_path):
+    """STS is a documented format the viewer does not render, so it needs converting."""
+    sts_file = tmp_path / "sts.jsonl"
+    sts_file.write_text(
+        json.dumps({"type": "session", "harness": "trackio", "id": "abc"}) + "\n"
+    )
+    assert not agent_sessions.is_hub_native_jsonl(sts_file)
+
+    pi_file = tmp_path / "pi.jsonl"
+    pi_file.write_text(
+        json.dumps({"type": "session", "version": 3, "id": "abc"}) + "\n"
+    )
+    assert agent_sessions.is_hub_native_jsonl(pi_file)

--- a/tests/unit/test_trace.py
+++ b/tests/unit/test_trace.py
@@ -114,7 +114,7 @@ def test_trace_logging_and_query(temp_dir):
                         "status": "success",
                     }
                 ],
-            )
+            ),
         }
     )
     run.log(

--- a/tests/unit/test_trace.py
+++ b/tests/unit/test_trace.py
@@ -3,7 +3,14 @@ import sqlite3
 
 import pytest
 
-from trackio import Run, Trace
+from trackio import Run, Trace, fragments
+from trackio.cli_helpers import (
+    format_trace,
+    parse_span_timestamp,
+    short_trace_id,
+    trace_id_matches,
+    trace_rollup,
+)
 from trackio.media import TrackioImage
 from trackio.sqlite_storage import SQLiteStorage
 
@@ -150,6 +157,39 @@ def test_trace_logging_and_query(temp_dir):
     assert searched_spans[0]["metadata"]["label"] == "candidate-a"
 
 
+def test_trace_search_text_excludes_span_payloads(temp_dir):
+    run = Run(url=None, project="proj", client=None, name="trace-run", space_id=None)
+    run.log(
+        {
+            "conversation": Trace(
+                messages=[{"role": "user", "content": "find datasets"}],
+                spans=[
+                    {
+                        "id": "generation-a",
+                        "name": "provider-request",
+                        "kind": "generation",
+                        "model": "tiny-model",
+                        "status": "success",
+                        "metadata": {"attempt": "retry-1"},
+                        "input": {"secret_prompt_text": "unindexed-input"},
+                        "output": {"text": "unindexed-output"},
+                    }
+                ],
+            )
+        }
+    )
+    run.finish()
+
+    for needle in ("provider-request", "tiny-model", "retry-1", "generation-a"):
+        assert len(SQLiteStorage.get_traces("proj", "trace-run", search=needle)) == 1
+
+    for needle in ("unindexed-input", "unindexed-output"):
+        assert SQLiteStorage.get_traces("proj", "trace-run", search=needle) == []
+
+    traces = SQLiteStorage.get_traces("proj", "trace-run")
+    assert traces[0]["spans"][0]["input"]["secret_prompt_text"] == "unindexed-input"
+
+
 def test_trace_limit_offset_are_applied_in_storage(temp_dir):
     run = Run(url=None, project="proj", client=None, name="trace-run", space_id=None)
     for index in range(5):
@@ -252,3 +292,235 @@ def test_trace_export_import_roundtrip(temp_dir):
 
     after = SQLiteStorage.get_traces("proj", "trace-run")
     assert after == before
+
+
+def _pending_trace_project(project: str, log_id: str = "log-1") -> dict:
+    SQLiteStorage.bulk_log(
+        project=project,
+        run="buffered-run",
+        run_id="run-1",
+        metrics_list=[
+            {
+                "loss": 0.5,
+                "conversation": {
+                    "_type": "trackio.trace",
+                    "messages": [{"role": "user", "content": "buffered question"}],
+                    "metadata": {"session_id": "s-1"},
+                    "spans": [
+                        {
+                            "id": "gen-1",
+                            "name": "provider-request",
+                            "kind": "generation",
+                            "model": "tiny-model",
+                            "usage": {"input_tokens": 11, "output_tokens": 3},
+                        }
+                    ],
+                },
+            }
+        ],
+        steps=[0],
+        timestamps=["2026-08-19T12:00:00+00:00"],
+        log_ids=[log_id],
+        space_id="user/space",
+    )
+    return SQLiteStorage.get_traces(project, "buffered-run", run_id="run-1")[0]
+
+
+def test_buffered_traces_count_as_pending_data(temp_dir):
+    _pending_trace_project("pending-proj")
+
+    pending = SQLiteStorage.get_pending_traces("pending-proj")
+    assert pending is not None
+    assert pending["space_id"] == "user/space"
+    assert pending["traces"][0]["key"] == "conversation"
+    assert pending["traces"][0]["log_id"] == "log-1"
+    assert SQLiteStorage.has_pending_data("pending-proj") is True
+
+    SQLiteStorage.clear_pending_traces("pending-proj", pending["ids"])
+    SQLiteStorage.clear_pending_logs(
+        "pending-proj", SQLiteStorage.get_pending_logs("pending-proj")["ids"]
+    )
+    assert SQLiteStorage.get_pending_traces("pending-proj") is None
+    assert SQLiteStorage.has_pending_data("pending-proj") is False
+    assert len(SQLiteStorage.get_traces("pending-proj", "buffered-run")) == 1
+
+
+def test_buffered_traces_replay_into_their_original_log_entry(temp_dir):
+    original = _pending_trace_project("replay-source")
+    run = Run(url=None, project="unused", client=None, name="r", space_id=None)
+
+    entries = run._pending_entries_with_traces(
+        SQLiteStorage.get_pending_logs("replay-source"),
+        SQLiteStorage.get_pending_traces("replay-source"),
+    )
+
+    assert len(entries) == 1
+    metrics = entries[0]["metrics"]
+    assert metrics["loss"] == 0.5
+    assert metrics["conversation"]["_type"] == "trackio.trace"
+    assert metrics["conversation"]["spans"][0]["model"] == "tiny-model"
+
+    imported = fragments.import_records(
+        [
+            fragments.metric_record(dict(entry, project="replay-target"))
+            for entry in entries
+        ]
+    )
+    assert imported == 1
+
+    replayed = SQLiteStorage.get_traces("replay-target", "buffered-run", run_id="run-1")
+    assert len(replayed) == 1
+    assert replayed[0]["id"] == original["id"]
+    assert replayed[0]["spans"] == original["spans"]
+    assert replayed[0]["messages"] == original["messages"]
+    logs = SQLiteStorage.get_logs("replay-target", "buffered-run")
+    assert logs[0]["loss"] == 0.5
+
+
+def test_buffered_trace_list_keeps_its_index(temp_dir):
+    SQLiteStorage.bulk_log(
+        project="replay-list",
+        run="buffered-run",
+        run_id="run-1",
+        metrics_list=[
+            {
+                "conversations": [
+                    {
+                        "_type": "trackio.trace",
+                        "messages": [{"role": "user", "content": "a"}],
+                    },
+                    {
+                        "_type": "trackio.trace",
+                        "messages": [{"role": "user", "content": "b"}],
+                    },
+                ]
+            }
+        ],
+        steps=[0],
+        log_ids=["log-list"],
+        space_id="user/space",
+    )
+    original = SQLiteStorage.get_traces("replay-list", "buffered-run", run_id="run-1")
+    run = Run(url=None, project="unused", client=None, name="r", space_id=None)
+
+    entries = run._pending_entries_with_traces(
+        SQLiteStorage.get_pending_logs("replay-list"),
+        SQLiteStorage.get_pending_traces("replay-list"),
+    )
+    fragments.import_records(
+        [
+            fragments.metric_record(dict(entry, project="replay-list-target"))
+            for entry in entries
+        ]
+    )
+
+    replayed = SQLiteStorage.get_traces(
+        "replay-list-target", "buffered-run", run_id="run-1", sort="step_asc"
+    )
+    assert sorted(t["index"] for t in replayed) == [0, 1]
+    assert sorted(t["id"] for t in replayed) == sorted(t["id"] for t in original)
+
+
+@pytest.mark.parametrize(
+    "timestamp",
+    [
+        "2026-08-19T12:00:01.2Z",
+        "2026-08-19T12:00:01.25Z",
+        "2026-08-19T12:00:01.250Z",
+        "2026-08-19T12:00:01.250000Z",
+        "2026-08-19T12:00:01.250000+00:00",
+        "2026-08-19T12:00:01",
+    ],
+)
+def test_span_timestamps_parse_with_any_fractional_precision(timestamp):
+    parsed = parse_span_timestamp(timestamp)
+    assert parsed is not None
+    assert parsed.tzinfo is not None
+    assert parsed.year == 2026
+
+
+def test_span_timestamps_reject_garbage():
+    assert parse_span_timestamp("not-a-time") is None
+    assert parse_span_timestamp(None) is None
+
+
+def test_trace_rollup_uses_wall_clock_and_flags_errors():
+    rollup = trace_rollup(
+        {
+            "spans": [
+                {
+                    "id": "root",
+                    "start_time": "2026-08-19T12:00:00Z",
+                    "end_time": "2026-08-19T12:00:23.79Z",
+                    "status": "success",
+                },
+                {
+                    "id": "gen",
+                    "parent_id": "root",
+                    "start_time": "2026-08-19T12:00:01Z",
+                    "end_time": "2026-08-19T12:00:03Z",
+                    "usage": {"input_tokens": 8439, "output_tokens": 188},
+                    "cost_usd": 0.0042,
+                    "status": "success",
+                },
+                {"id": "tool", "parent_id": "root", "status": "error"},
+            ]
+        }
+    )
+    assert rollup["duration_ms"] == pytest.approx(23790)
+    assert rollup["cost_usd"] == pytest.approx(0.0042)
+    assert rollup["input_tokens"] == 8439
+    assert rollup["output_tokens"] == 188
+    assert rollup["status"] == "error"
+    assert rollup["span_count"] == 3
+
+
+def test_trace_rollup_falls_back_to_metadata():
+    rollup = trace_rollup(
+        {"spans": [], "metadata": {"latency_ms": 1200, "status": "ok"}}
+    )
+    assert rollup["duration_ms"] == 1200
+    assert rollup["status"] == "ok"
+
+
+def test_short_trace_id_round_trips_to_matching():
+    trace = {"id": "run-1:log-abc:conversation"}
+    assert short_trace_id(trace["id"]) == "log-abc"
+    assert trace_id_matches(trace, "log-abc")
+    assert trace_id_matches(trace, "run-1:log-abc:conversation")
+    assert not trace_id_matches(trace, "log-xyz")
+
+    indexed = {"id": "run-1:log-abc:conversations:2"}
+    assert short_trace_id(indexed["id"]) == "log-abc:2"
+    assert trace_id_matches(indexed, "log-abc:2")
+
+
+def test_format_trace_renders_span_tree_and_errors():
+    rendered = format_trace(
+        {
+            "id": "run-1:log-abc:session",
+            "run": "production",
+            "step": 3,
+            "spans": [
+                {
+                    "id": "root",
+                    "name": "answer-question",
+                    "kind": "span",
+                    "start_time": "2026-08-19T12:00:00Z",
+                    "end_time": "2026-08-19T12:00:02Z",
+                },
+                {
+                    "id": "tool",
+                    "parent_id": "root",
+                    "name": "run-bash-command",
+                    "kind": "tool",
+                    "status": "error",
+                    "error": {"stderr": "unrecognized arguments: --full"},
+                },
+            ],
+        }
+    )
+    assert "Trace log-abc" in rendered
+    assert "answer-question [span]  2.00s" in rendered
+    assert "  ERROR run-bash-command [tool]" in rendered
+    assert "unrecognized arguments: --full" in rendered

--- a/tests/unit/test_trace.py
+++ b/tests/unit/test_trace.py
@@ -1,10 +1,53 @@
 import os
+import sqlite3
 
 import pytest
 
 from trackio import Run, Trace
 from trackio.media import TrackioImage
 from trackio.sqlite_storage import SQLiteStorage
+
+
+def test_trace_schema_migrates_existing_database(temp_dir):
+    db_path = SQLiteStorage.get_project_db_path("legacy-proj")
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """
+            CREATE TABLE traces (
+                id TEXT PRIMARY KEY,
+                run_id TEXT NOT NULL,
+                timestamp TEXT NOT NULL,
+                run_name TEXT NOT NULL,
+                step INTEGER NOT NULL,
+                key TEXT NOT NULL,
+                trace_index INTEGER,
+                messages TEXT NOT NULL,
+                metadata TEXT NOT NULL,
+                search_text TEXT NOT NULL,
+                log_id TEXT,
+                space_id TEXT
+            )
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO traces
+            (id, run_id, timestamp, run_name, step, key, messages, metadata, search_text)
+            VALUES ('trace-1', 'run-1', '2026-08-19T12:00:00Z', 'run', 0, 'trace', '[]', '{}', '')
+            """
+        )
+
+    legacy_traces = SQLiteStorage.get_traces("legacy-proj", "run", run_id="run-1")
+    assert legacy_traces[0]["spans"] == []
+
+    SQLiteStorage.init_db("legacy-proj")
+
+    with sqlite3.connect(db_path) as conn:
+        columns = {row[1] for row in conn.execute("PRAGMA table_info(traces)")}
+        spans = conn.execute("SELECT spans FROM traces").fetchone()[0]
+    assert "spans" in columns
+    assert spans == "[]"
 
 
 def test_trace_to_dict(image_ndarray, temp_dir):
@@ -21,6 +64,14 @@ def test_trace_to_dict(image_ndarray, temp_dir):
             },
         ],
         metadata={"label": "demo-trace"},
+        spans=[
+            {
+                "id": "inspect-page",
+                "name": "inspect-page",
+                "kind": "tool",
+                "input": image,
+            }
+        ],
     )
 
     payload = trace._to_dict(project="proj", run="run1", step=0)
@@ -28,11 +79,17 @@ def test_trace_to_dict(image_ndarray, temp_dir):
     assert payload["_type"] == Trace.TYPE
     assert payload["metadata"]["label"] == "demo-trace"
     assert payload["messages"][1]["content"][1]["_type"] == "trackio.image"
+    assert payload["spans"][0]["input"]["_type"] == "trackio.image"
 
 
 def test_trace_requires_message_dicts():
     with pytest.raises(TypeError, match="list of dictionaries"):
         Trace(messages=["bad"])  # type: ignore[arg-type]
+
+
+def test_trace_requires_span_dicts():
+    with pytest.raises(TypeError, match="list of dictionaries"):
+        Trace(messages=[], spans=["bad"])  # type: ignore[list-item]
 
 
 def test_trace_logging_and_query(temp_dir):
@@ -46,6 +103,19 @@ def test_trace_logging_and_query(temp_dir):
                     {"role": "assistant", "content": "Sydney."},
                 ],
                 metadata={"label": "candidate-a", "group": "capitals"},
+                spans=[
+                    {
+                        "id": "generation-a",
+                        "name": "provider-request",
+                        "kind": "generation",
+                        "start_time": "2026-08-19T12:00:00Z",
+                        "end_time": "2026-08-19T12:00:01Z",
+                        "model": "tiny-model",
+                        "usage": {"input_tokens": 8, "output_tokens": 2},
+                        "cost_usd": 0.001,
+                        "status": "success",
+                    }
+                ],
             )
         }
     )
@@ -69,10 +139,15 @@ def test_trace_logging_and_query(temp_dir):
     traces = SQLiteStorage.get_traces("proj", "trace-run", sort="step_desc")
     assert len(traces) == 2
     assert traces[0]["messages"][2]["content"] == "Canberra."
+    assert traces[1]["spans"][0]["usage"]["input_tokens"] == 8
 
     searched = SQLiteStorage.get_traces("proj", "trace-run", search="canberra")
     assert len(searched) == 1
     assert searched[0]["metadata"]["label"] == "candidate-b"
+
+    searched_spans = SQLiteStorage.get_traces("proj", "trace-run", search="tiny-model")
+    assert len(searched_spans) == 1
+    assert searched_spans[0]["metadata"]["label"] == "candidate-a"
 
 
 def test_trace_limit_offset_are_applied_in_storage(temp_dir):
@@ -118,6 +193,31 @@ def test_trace_logging_keeps_scalar_metrics_separate(temp_dir):
     assert len(SQLiteStorage.get_traces("proj", "trace-run")) == 1
 
 
+def test_trace_spans_survive_run_rename(temp_dir):
+    run = Run(url=None, project="proj", client=None, name="old-run", space_id=None)
+    run.log(
+        {
+            "conversation": Trace(
+                messages=[{"role": "user", "content": "rename me"}],
+                spans=[
+                    {
+                        "id": "tool-1",
+                        "name": "hf search",
+                        "kind": "tool",
+                        "input": {"query": "datasets"},
+                    }
+                ],
+            )
+        }
+    )
+    run.finish()
+
+    SQLiteStorage.rename_run("proj", "old-run", "new-run", run_id=run.id)
+
+    traces = SQLiteStorage.get_traces("proj", "new-run", run_id=run.id)
+    assert traces[0]["spans"][0]["name"] == "hf search"
+
+
 def test_trace_export_import_roundtrip(temp_dir):
     run = Run(url=None, project="proj", client=None, name="trace-run", space_id=None)
     run.log(
@@ -128,6 +228,16 @@ def test_trace_export_import_roundtrip(temp_dir):
                     {"role": "assistant", "content": "imported"},
                 ],
                 metadata={"source": "roundtrip"},
+                spans=[
+                    {
+                        "id": "tool-1",
+                        "name": "hf search",
+                        "kind": "tool",
+                        "input": {"query": "agent datasets"},
+                        "output": {"matches": 3},
+                        "status": "success",
+                    }
+                ],
             ),
         }
     )

--- a/tests/unit/test_trace.py
+++ b/tests/unit/test_trace.py
@@ -89,20 +89,11 @@ def test_trace_to_dict(image_ndarray, temp_dir):
     assert payload["spans"][0]["input"]["_type"] == "trackio.image"
 
 
-def test_trace_requires_message_dicts():
-    with pytest.raises(TypeError, match="list of dictionaries"):
-        Trace(messages=["bad"])  # type: ignore[arg-type]
-
-
-def test_trace_requires_span_dicts():
-    with pytest.raises(TypeError, match="list of dictionaries"):
-        Trace(messages=[], spans=["bad"])  # type: ignore[list-item]
-
-
 def test_trace_logging_and_query(temp_dir):
     run = Run(url=None, project="proj", client=None, name="trace-run", space_id=None)
     run.log(
         {
+            "loss": 0.5,
             "conversation": Trace(
                 messages=[
                     {"role": "system", "content": "Answer directly."},
@@ -141,6 +132,7 @@ def test_trace_logging_and_query(temp_dir):
     run.finish()
 
     logs = SQLiteStorage.get_logs("proj", "trace-run")
+    assert logs[0]["loss"] == 0.5
     assert "conversation" not in logs[0]
 
     traces = SQLiteStorage.get_traces("proj", "trace-run", sort="step_desc")
@@ -210,27 +202,6 @@ def test_trace_limit_offset_are_applied_in_storage(temp_dir):
         "proj", "trace-run", sort="step_asc", limit=2, offset=2
     )
     assert [trace["metadata"]["index"] for trace in traces] == [2, 3]
-
-
-def test_trace_logging_keeps_scalar_metrics_separate(temp_dir):
-    run = Run(url=None, project="proj", client=None, name="trace-run", space_id=None)
-    run.log(
-        {
-            "loss": 0.5,
-            "conversation": Trace(
-                messages=[
-                    {"role": "user", "content": "hello"},
-                    {"role": "assistant", "content": "hi"},
-                ],
-            ),
-        }
-    )
-    run.finish()
-
-    logs = SQLiteStorage.get_logs("proj", "trace-run")
-    assert logs[0]["loss"] == 0.5
-    assert "conversation" not in logs[0]
-    assert len(SQLiteStorage.get_traces("proj", "trace-run")) == 1
 
 
 def test_trace_spans_survive_run_rename(temp_dir):
@@ -426,8 +397,6 @@ def test_buffered_trace_list_keeps_its_index(temp_dir):
     [
         "2026-08-19T12:00:01.2Z",
         "2026-08-19T12:00:01.25Z",
-        "2026-08-19T12:00:01.250Z",
-        "2026-08-19T12:00:01.250000Z",
         "2026-08-19T12:00:01.250000+00:00",
         "2026-08-19T12:00:01",
     ],
@@ -437,11 +406,6 @@ def test_span_timestamps_parse_with_any_fractional_precision(timestamp):
     assert parsed is not None
     assert parsed.tzinfo is not None
     assert parsed.year == 2026
-
-
-def test_span_timestamps_reject_garbage():
-    assert parse_span_timestamp("not-a-time") is None
-    assert parse_span_timestamp(None) is None
 
 
 def test_trace_rollup_uses_wall_clock_and_flags_errors():
@@ -473,14 +437,6 @@ def test_trace_rollup_uses_wall_clock_and_flags_errors():
     assert rollup["output_tokens"] == 188
     assert rollup["status"] == "error"
     assert rollup["span_count"] == 3
-
-
-def test_trace_rollup_falls_back_to_metadata():
-    rollup = trace_rollup(
-        {"spans": [], "metadata": {"latency_ms": 1200, "status": "ok"}}
-    )
-    assert rollup["duration_ms"] == 1200
-    assert rollup["status"] == "ok"
 
 
 def test_short_trace_id_round_trips_to_matching():

--- a/trackio/agent_sessions.py
+++ b/trackio/agent_sessions.py
@@ -1,0 +1,533 @@
+"""Agent session serialization for the Hugging Face Hub's trace viewer.
+
+The Hub renders `.jsonl` agent sessions in a dedicated trace viewer, for both
+Datasets and Storage Buckets. This module is the single place Trackio produces
+that format: the logbook's attached agent sessions and the `traces` table both
+serialize through it.
+
+Trackio emits **Pi's session format** (version 3), which the Hub supports
+natively. The Hub also documents a Session Trace Simple Format (STS), but as of
+this writing files written to that spec are not rendered by the viewer — a
+controlled test (same bucket, same folder, one variable) showed a Codex-native
+and a Pi-format session rendering while a spec-compliant STS session displayed
+as raw JSONL, and none of the public datasets tagged `format:agent-traces` use
+STS. Pi's format is also the better fit: `id`/`parentId`, token `usage`, `cost`,
+and `isError` all have native homes, where STS had none.
+
+A session file is a header line followed by one entry per line:
+
+    {"type":"session","version":3,"id":"...","timestamp":"...","cwd":"..."}
+    {"type":"message","id":"...","parentId":null,"timestamp":"...",
+     "message":{"role":"user","content":[{"type":"text","text":"..."}]}}
+
+Entries chain through `parentId`. Message content is a list of typed blocks
+(`text`, `thinking`, `toolCall`); tool results are their own message with
+`role: "toolResult"`, a `toolCallId`, a `toolName`, and an optional `isError`.
+
+Format reference:
+https://github.com/earendil-works/pi/blob/main/packages/coding-agent/docs/session-format.md
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+HARNESS = "trackio"
+SESSION_VERSION = 3
+SESSION_NAME_MAX_CHARS = 120
+
+# Formats the Hub renders without conversion.
+HUB_NATIVE_PROVIDERS = {"Codex", "Claude Code", "Pi"}
+
+# Pi roles. Trackio's OpenAI-style `system` maps onto `developer`, which is what
+# the sessions that render in the viewer use.
+ROLE_BY_OPENAI_ROLE = {
+    "system": "developer",
+    "developer": "developer",
+    "user": "user",
+    "assistant": "assistant",
+}
+
+_NUMERIC_RE = re.compile(r"\d+(?:\.\d+)?")
+_UNSAFE_ID_RE = re.compile(r"[^a-zA-Z0-9._-]+")
+
+
+def parse_time(value: str | int | float | None) -> datetime | None:
+    """Parse an ISO-8601 string or an epoch number (seconds or milliseconds)."""
+    if value in (None, ""):
+        return None
+    if isinstance(value, (int, float)) or (
+        isinstance(value, str) and _NUMERIC_RE.fullmatch(value)
+    ):
+        numeric = float(value)
+        if numeric > 10_000_000_000:
+            numeric /= 1000
+        try:
+            return datetime.fromtimestamp(numeric, tz=timezone.utc)
+        except (OverflowError, OSError, ValueError):
+            return None
+    try:
+        return datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def iso_z(value: str | int | float | None) -> str | None:
+    """An ISO-8601 UTC timestamp with the `Z` suffix Pi sessions use."""
+    parsed = parse_time(value)
+    if parsed is None:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return (
+        parsed.astimezone(timezone.utc)
+        .isoformat(timespec="milliseconds")
+        .replace("+00:00", "Z")
+    )
+
+
+def entry_id(*parts: Any) -> str:
+    """A stable 8-character entry id, matching the width Pi sessions use."""
+    seed = ":".join(str(part) for part in parts)
+    return hashlib.sha1(seed.encode("utf-8")).hexdigest()[:8]
+
+
+def safe_id(value: str) -> str:
+    """A filesystem- and bucket-safe form of an identifier."""
+    cleaned = _UNSAFE_ID_RE.sub("-", str(value)).strip("-.")
+    return cleaned[:100] or f"session-{uuid.uuid4().hex[:12]}"
+
+
+def is_hub_native_jsonl(path: Path, provider: str | None = None) -> bool:
+    """Whether the Hub's trace viewer renders this file without conversion.
+
+    Only the harness-native formats qualify. A session header carrying a
+    `harness` but no `version` is STS, which the viewer does not render, so it
+    still needs converting.
+    """
+    if path.suffix.lower() != ".jsonl":
+        return False
+    if provider in HUB_NATIVE_PROVIDERS:
+        return True
+    try:
+        with path.open(encoding="utf-8") as handle:
+            first_line = next((line for line in handle if line.strip()), "")
+        header = json.loads(first_line)
+    except (OSError, json.JSONDecodeError):
+        return False
+    if not isinstance(header, dict):
+        return False
+    if header.get("type") == "session" and header.get("version") is not None:
+        return True
+    # Codex sessions open with a `session_meta` envelope rather than `session`.
+    return header.get("type") == "session_meta" and isinstance(
+        header.get("payload"), dict
+    )
+
+
+def session_header(
+    session_id: str,
+    timestamp: str | None = None,
+    name: str | None = None,
+    cwd: str | None = None,
+    **extra: Any,
+) -> dict[str, Any]:
+    header: dict[str, Any] = {
+        "type": "session",
+        "version": SESSION_VERSION,
+        "id": str(session_id),
+        "timestamp": iso_z(timestamp) or iso_z(datetime.now(timezone.utc)),
+        "cwd": cwd or "/",
+        "harness": HARNESS,
+    }
+    if name:
+        header["name"] = name
+    header.update({key: value for key, value in extra.items() if value is not None})
+    return header
+
+
+def dumps(records: list[dict[str, Any]]) -> str:
+    return (
+        "\n".join(json.dumps(record, ensure_ascii=False) for record in records) + "\n"
+    )
+
+
+def write_session(path: Path, records: list[dict[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(dumps(records), encoding="utf-8")
+
+
+def content_text(value: Any) -> str:
+    """Flatten an OpenAI-style `content` value to text.
+
+    Content may be a plain string, a list of typed blocks, or a serialized
+    Trackio media object. Non-text blocks keep a readable placeholder rather
+    than being dropped, so the viewer shows that something was there.
+    """
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    if isinstance(value, list):
+        parts = [content_text(item) for item in value]
+        return "\n".join(part for part in parts if part)
+    if isinstance(value, dict):
+        media_type = value.get("_type")
+        if isinstance(media_type, str) and media_type.startswith("trackio."):
+            label = media_type.split(".", 1)[1]
+            caption = value.get("caption") or value.get("file_path") or ""
+            return f"[{label}{': ' + str(caption) if caption else ''}]"
+        for key in ("text", "content", "output", "value"):
+            if isinstance(value.get(key), str):
+                return value[key]
+        return json.dumps(value, ensure_ascii=False)
+    return str(value)
+
+
+def text_block(text: str) -> dict[str, Any]:
+    return {"type": "text", "text": text}
+
+
+def thinking_block(text: str) -> dict[str, Any]:
+    return {"type": "thinking", "thinking": text}
+
+
+def tool_call_block(call_id: str, name: str, arguments: Any) -> dict[str, Any]:
+    """A `toolCall` block. Unlike STS, `arguments` stays a real object."""
+    if isinstance(arguments, str):
+        try:
+            arguments = json.loads(arguments)
+        except json.JSONDecodeError:
+            arguments = {"input": arguments}
+    if not isinstance(arguments, dict):
+        arguments = {} if arguments is None else {"input": arguments}
+    return {
+        "type": "toolCall",
+        "id": str(call_id),
+        "name": str(name or "tool"),
+        "arguments": arguments,
+    }
+
+
+class _Chain:
+    """Accumulates entries, chaining each to the one before via `parentId`."""
+
+    def __init__(self, session_id: str, default_timestamp: str | None):
+        self.session_id = session_id
+        self.default_timestamp = default_timestamp
+        self.records: list[dict[str, Any]] = []
+        self._parent: str | None = None
+
+    def add(self, entry: dict[str, Any], timestamp: str | None = None) -> str:
+        entry["parentId"] = self._parent
+        entry["timestamp"] = iso_z(timestamp) or self.default_timestamp
+        self._parent = entry["id"]
+        self.records.append(entry)
+        return entry["id"]
+
+    def message(
+        self, index: Any, message: dict[str, Any], timestamp: str | None = None
+    ) -> str:
+        return self.add(
+            {
+                "type": "message",
+                "id": entry_id(self.session_id, "msg", index),
+                "message": message,
+            },
+            timestamp,
+        )
+
+
+def span_usage(span: dict[str, Any]) -> dict[str, Any] | None:
+    """Pi's `usage` block from a Trackio span's `usage` and `cost_usd`."""
+    usage = span.get("usage") or {}
+    raw_input = usage.get("input_tokens", usage.get("prompt_tokens"))
+    raw_output = usage.get("output_tokens", usage.get("completion_tokens"))
+    cost = span.get("cost_usd")
+    if raw_input is None and raw_output is None and cost is None:
+        return None
+    try:
+        input_tokens = int(raw_input or 0)
+        output_tokens = int(raw_output or 0)
+    except (TypeError, ValueError):
+        input_tokens = output_tokens = 0
+    total = usage.get("total_tokens") or (input_tokens + output_tokens)
+    block: dict[str, Any] = {
+        "input": input_tokens,
+        "output": output_tokens,
+        "cacheRead": int(usage.get("cache_read_input_tokens") or 0),
+        "cacheWrite": int(usage.get("cache_creation_input_tokens") or 0),
+        "totalTokens": total,
+    }
+    if cost is not None:
+        try:
+            block["cost"] = {
+                "input": 0,
+                "output": 0,
+                "cacheRead": 0,
+                "cacheWrite": 0,
+                "total": float(cost),
+            }
+        except (TypeError, ValueError):
+            pass
+    return block
+
+
+def _span_is_error(span: dict[str, Any]) -> bool:
+    status = str(span.get("status") or "").lower()
+    return status in {"error", "failed"} or bool(span.get("error"))
+
+
+def _message_is_error(message: dict[str, Any]) -> bool:
+    if message.get("is_error") is True or message.get("isError") is True:
+        return True
+    if message.get("error"):
+        return True
+    return str(message.get("status") or "").lower() in {"error", "failed"}
+
+
+def _generation_output_text(span: dict[str, Any]) -> str:
+    output = span.get("output")
+    if isinstance(output, dict):
+        for key in ("text", "content", "message", "output"):
+            if output.get(key) is not None:
+                return content_text(output[key])
+    return content_text(output)
+
+
+def _span_sort_key(indexed_span: tuple[int, dict[str, Any]]) -> tuple[float, int]:
+    index, span = indexed_span
+    started = parse_time(span.get("start_time") or span.get("startTime"))
+    return (started.timestamp() if started else float("inf"), index)
+
+
+def _ordered_spans(spans: list[dict[str, Any]], kind: str) -> list[dict[str, Any]]:
+    indexed = [
+        (index, span)
+        for index, span in enumerate(spans)
+        if str(span.get("kind") or "").lower() == kind
+    ]
+    return [span for _, span in sorted(indexed, key=_span_sort_key)]
+
+
+def _session_name(records: list[dict[str, Any]], fallback: str) -> str:
+    """Title for the session: the request, when there is one."""
+    for wanted_role in ("user", None):
+        for record in records:
+            message = record.get("message") or {}
+            role = str(message.get("role") or "")
+            if wanted_role is not None and role != wanted_role:
+                continue
+            text = " ".join(content_text(message.get("content")).split())
+            if text:
+                return text[:SESSION_NAME_MAX_CHARS]
+    return fallback
+
+
+def _messages_to_entries(
+    chain: _Chain,
+    messages: list[dict[str, Any]],
+    generations: list[dict[str, Any]],
+    tool_spans: list[dict[str, Any]],
+) -> None:
+    """Emit message entries, enriched with what the spans know.
+
+    Spans supply what the message layer cannot: token usage and cost on the
+    generation that produced each assistant turn, and failure status on a tool
+    result. Tool call ids and span ids come from different namespaces, so a
+    result is matched to its span by call id first and by order second.
+    """
+    tool_names: dict[str, str] = {}
+    tool_span_by_id = {str(span.get("id")): span for span in tool_spans}
+    remaining_tool_spans = list(tool_spans)
+    generation_index = 0
+
+    for index, message in enumerate(messages):
+        role = str(message.get("role") or "assistant").lower()
+        timestamp = message.get("timestamp") or message.get("created_at")
+
+        if role == "tool":
+            call_id = str(
+                message.get("tool_call_id")
+                or message.get("toolCallId")
+                or f"call-{index}"
+            )
+            span = tool_span_by_id.get(call_id)
+            if span is None and remaining_tool_spans:
+                span = remaining_tool_spans[0]
+            if span is not None and span in remaining_tool_spans:
+                remaining_tool_spans.remove(span)
+            result: dict[str, Any] = {
+                "role": "toolResult",
+                "toolCallId": call_id,
+                "toolName": tool_names.get(call_id)
+                or str((span or {}).get("name") or "tool"),
+                "content": [text_block(content_text(message.get("content")))],
+            }
+            if _message_is_error(message) or (
+                span is not None and _span_is_error(span)
+            ):
+                result["isError"] = True
+            chain.message(index, result, timestamp)
+            continue
+
+        blocks: list[dict[str, Any]] = []
+        reasoning = (
+            message.get("reasoning_content")
+            or message.get("reasoningContent")
+            or message.get("reasoning")
+        )
+        if reasoning:
+            blocks.append(thinking_block(content_text(reasoning)))
+        text = content_text(message.get("content"))
+        if text:
+            blocks.append(text_block(text))
+
+        calls = list(message.get("tool_calls") or message.get("toolCalls") or [])
+        if message.get("function_call"):
+            calls.append({"function": message["function_call"]})
+        for call_index, call in enumerate(calls):
+            if not isinstance(call, dict):
+                continue
+            function = (
+                call.get("function") if isinstance(call.get("function"), dict) else call
+            )
+            call_id = str(call.get("id") or f"call-{index}-{call_index}")
+            name = str(function.get("name") or "tool")
+            tool_names[call_id] = name
+            blocks.append(tool_call_block(call_id, name, function.get("arguments")))
+
+        entry_message: dict[str, Any] = {
+            "role": ROLE_BY_OPENAI_ROLE.get(role, "assistant"),
+            "content": blocks,
+        }
+        if entry_message["role"] == "assistant":
+            # Pair the Nth assistant turn with the Nth generation span rather
+            # than repeating one span's totals on every turn, which would make
+            # the viewer double-count tokens and cost.
+            if generation_index < len(generations):
+                usage = span_usage(generations[generation_index])
+                if usage:
+                    entry_message["usage"] = usage
+                generation_index += 1
+        chain.message(index, entry_message, timestamp)
+
+
+def _spans_to_entries(
+    chain: _Chain, spans: list[dict[str, Any]], generations: list[dict[str, Any]]
+) -> None:
+    """Emit entries for a trace that carries spans but no messages."""
+    ordered = sorted(
+        ((index, span) for index, span in enumerate(spans) if isinstance(span, dict)),
+        key=_span_sort_key,
+    )
+    for index, span in ordered:
+        kind = str(span.get("kind") or "span").lower()
+        timestamp = span.get("start_time") or span.get("startTime")
+        if kind == "generation":
+            message: dict[str, Any] = {
+                "role": "assistant",
+                "content": [text_block(_generation_output_text(span))],
+            }
+            usage = span_usage(span)
+            if usage:
+                message["usage"] = usage
+            chain.message(f"span-{index}", message, timestamp)
+        elif kind == "tool":
+            call_id = str(span.get("id") or f"span-tool-{index}")
+            name = str(span.get("name") or "tool")
+            chain.message(
+                f"span-{index}-call",
+                {
+                    "role": "assistant",
+                    "content": [tool_call_block(call_id, name, span.get("input"))],
+                },
+                timestamp,
+            )
+            result: dict[str, Any] = {
+                "role": "toolResult",
+                "toolCallId": call_id,
+                "toolName": name,
+                "content": [
+                    text_block(content_text(span.get("error") or span.get("output")))
+                ],
+            }
+            if _span_is_error(span):
+                result["isError"] = True
+            chain.message(f"span-{index}-result", result, timestamp)
+        else:
+            chain.message(
+                f"span-{index}",
+                {
+                    "role": "developer",
+                    "content": [text_block(str(span.get("name") or kind))],
+                },
+                timestamp,
+            )
+
+
+def trace_to_records(
+    trace: dict[str, Any], project: str | None = None
+) -> list[dict[str, Any]]:
+    """Serialize one Trackio trace row into a Pi-format agent session.
+
+    The entries form the linear conversation the viewer renders, enriched from
+    the spans with model, token usage, cost, and failure status. The full span
+    tree — hierarchy, `duration_ms`, per-span `metadata`, and the `kind` of
+    non-tool spans — stays in SQLite, which remains authoritative for every
+    Trackio reader.
+    """
+    messages = [m for m in (trace.get("messages") or []) if isinstance(m, dict)]
+    spans = [s for s in (trace.get("spans") or []) if isinstance(s, dict)]
+    generations = _ordered_spans(spans, "generation")
+    tool_spans = _ordered_spans(spans, "tool")
+
+    trace_id = str(trace.get("id") or uuid.uuid4().hex)
+    timestamp = iso_z(trace.get("timestamp"))
+    chain = _Chain(trace_id, timestamp)
+
+    model = next(
+        (str(span["model"]) for span in generations if span.get("model")),
+        None,
+    )
+    if model:
+        chain.add(
+            {
+                "type": "model_change",
+                "id": entry_id(trace_id, "model"),
+                "modelId": model,
+            },
+            trace.get("timestamp"),
+        )
+
+    if messages:
+        _messages_to_entries(chain, messages, generations, tool_spans)
+    else:
+        _spans_to_entries(chain, spans, generations)
+
+    header = session_header(
+        trace_id,
+        timestamp=trace.get("timestamp"),
+        name=_session_name(chain.records, trace_id),
+        cwd=f"/{project}" if project else "/",
+        trackio={
+            "project": project,
+            "run_id": trace.get("run_id"),
+            "run_name": trace.get("run_name"),
+            "step": trace.get("step"),
+            "key": trace.get("key"),
+            "trace_index": trace.get("trace_index"),
+            "metadata": trace.get("metadata") or {},
+        },
+    )
+    return [header, *chain.records]
+
+
+def trace_session_filename(trace_id: Any) -> str:
+    return f"{safe_id(str(trace_id))}.jsonl"

--- a/trackio/cli.py
+++ b/trackio/cli.py
@@ -2796,6 +2796,7 @@ def _handle_skills_add(args):
         "logging_metrics.md",
         "retrieving_metrics.md",
         "storage_schema.md",
+        "traces.md",
         "logbook.md",
     ]
     COMMAND_PREFIX = ".agents/commands"

--- a/trackio/cli.py
+++ b/trackio/cli.py
@@ -30,6 +30,11 @@ from trackio.cli_helpers import (
     format_spaces,
     format_system_metric_names,
     format_system_metrics,
+    format_trace,
+    format_trace_summary,
+    format_traces,
+    trace_id_matches,
+    trace_rollup,
 )
 from trackio.deploy import sync_incremental
 from trackio.frontend_config import (
@@ -184,6 +189,186 @@ def _extract_reports(
                         }
                     )
     return reports
+
+
+TRACE_SORTS = {
+    "request_time_desc",
+    "request_time_asc",
+    "step_asc",
+    "step_desc",
+}
+
+_TRACE_SUMMARY_SQL = """
+SELECT json_extract(s.value, '$.name') AS operation,
+       json_extract(s.value, '$.kind') AS kind,
+       COUNT(*) AS calls,
+       SUM(CASE WHEN LOWER(COALESCE(json_extract(s.value, '$.status'), '')) IN ('error', 'failed')
+                     OR json_extract(s.value, '$.error') IS NOT NULL
+                THEN 1 ELSE 0 END) AS errors,
+       ROUND(AVG(COALESCE(json_extract(s.value, '$.duration_ms'),
+              (julianday(json_extract(s.value, '$.end_time'))
+               - julianday(json_extract(s.value, '$.start_time'))) * 86400000)), 1) AS avg_ms,
+       ROUND(MAX(COALESCE(json_extract(s.value, '$.duration_ms'),
+              (julianday(json_extract(s.value, '$.end_time'))
+               - julianday(json_extract(s.value, '$.start_time'))) * 86400000)), 1) AS max_ms,
+       SUM(COALESCE(json_extract(s.value, '$.usage.input_tokens'), 0)) AS input_tokens,
+       SUM(COALESCE(json_extract(s.value, '$.usage.output_tokens'), 0)) AS output_tokens,
+       ROUND(SUM(COALESCE(json_extract(s.value, '$.cost_usd'), 0)), 4) AS cost_usd
+FROM traces, json_each(traces.spans) AS s
+{where}
+GROUP BY operation, kind
+ORDER BY cost_usd DESC, calls DESC
+"""
+
+
+def _trace_sort_key(sort):
+    if sort in ("step_asc", "step_desc"):
+        return lambda trace: trace.get("step") or 0, sort == "step_desc"
+    return lambda trace: str(trace.get("timestamp") or ""), sort != "request_time_asc"
+
+
+def _project_run_names(args, remote) -> list[str]:
+    if remote:
+        records = remote.predict(args.project, api_name="/get_runs_for_project")
+        return [r["name"] if isinstance(r, dict) else r for r in records]
+    return SQLiteStorage.get_runs(args.project)
+
+
+def _fetch_traces_for_run(args, remote, run, *, limit, offset, search, sort, step):
+    if remote:
+        return remote.predict(
+            args.project,
+            run,
+            None,
+            search,
+            sort,
+            limit,
+            offset,
+            step,
+            api_name="/get_traces",
+        )
+    return SQLiteStorage.get_traces(
+        args.project,
+        run,
+        search=search,
+        sort=sort,
+        limit=limit,
+        offset=offset,
+        step=step,
+    )
+
+
+def _fetch_traces(args, remote, *, limit, offset, search=None, sort=None, step=None):
+    """Fetch traces for one run, or merge across every run in the project.
+
+    Traces are stored per run, so with no `--run` this merges each run's page
+    the way the dashboard does, then re-sorts and slices the combined result.
+    """
+    if not remote:
+        db_path = SQLiteStorage.get_project_db_path(args.project)
+        if not db_path.exists():
+            error_exit(f"Project '{args.project}' not found.")
+
+    run = getattr(args, "run", None)
+    if run:
+        return _fetch_traces_for_run(
+            args,
+            remote,
+            run,
+            limit=limit,
+            offset=offset,
+            search=search,
+            sort=sort,
+            step=step,
+        )
+
+    runs = _project_run_names(args, remote)
+    if not runs:
+        return []
+    per_run_limit = None if limit is None else limit + max(0, offset)
+    merged: list[dict] = []
+    for name in runs:
+        merged.extend(
+            _fetch_traces_for_run(
+                args,
+                remote,
+                name,
+                limit=per_run_limit,
+                offset=0,
+                search=search,
+                sort=sort,
+                step=step,
+            )
+            or []
+        )
+    key, reverse = _trace_sort_key(sort)
+    merged.sort(key=key, reverse=reverse)
+    if offset:
+        merged = merged[offset:]
+    return merged if limit is None else merged[:limit]
+
+
+def _handle_list_traces(args, remote):
+    traces = _fetch_traces(
+        args,
+        remote,
+        limit=args.limit,
+        offset=args.offset,
+        search=args.search,
+        sort=args.sort,
+        step=args.step,
+    )
+    if args.json:
+        print(
+            format_json(
+                {
+                    "project": args.project,
+                    "run": args.run,
+                    "traces": [
+                        {**trace, "summary": trace_rollup(trace)} for trace in traces
+                    ],
+                }
+            )
+        )
+    else:
+        print(format_traces(traces))
+
+
+def _handle_get_trace(args, remote):
+    traces = _fetch_traces(args, remote, limit=None, offset=0)
+    match = next(
+        (trace for trace in traces if trace_id_matches(trace, args.trace_id)), None
+    )
+    if match is None:
+        error_exit(
+            f"Trace '{args.trace_id}' not found in project '{args.project}'. "
+            "Use `trackio list traces` to see available trace ids."
+        )
+    if args.json:
+        print(format_json({**match, "summary": trace_rollup(match)}))
+    else:
+        print(format_trace(match))
+
+
+def _handle_get_trace_summary(args, remote):
+    where = ""
+    if args.run:
+        escaped = args.run.replace("'", "''")
+        where = f"WHERE traces.run_name = '{escaped}'"
+    sql = _TRACE_SUMMARY_SQL.format(where=where)
+    try:
+        if remote:
+            result = remote.predict(args.project, sql, api_name="/query_project")
+        else:
+            result = SQLiteStorage.query_project(args.project, sql)
+    except FileNotFoundError as e:
+        error_exit(str(e))
+    except ValueError as e:
+        error_exit(str(e))
+    if args.json:
+        print(format_json({"project": args.project, "run": args.run, **result}))
+    else:
+        print(format_trace_summary(result))
 
 
 def _handle_query(args):
@@ -887,6 +1072,37 @@ def main():
         help="Only show alerts after this ISO 8601 timestamp",
     )
 
+    list_traces_parser = list_subparsers.add_parser(
+        "traces",
+        help="List agent/conversation traces for a project or run",
+    )
+    list_traces_parser.add_argument("--project", required=True, help="Project name")
+    list_traces_parser.add_argument("--run", required=False, help="Run name (optional)")
+    list_traces_parser.add_argument(
+        "--search",
+        required=False,
+        help="Only show traces matching this text (messages, metadata, span names)",
+    )
+    list_traces_parser.add_argument(
+        "--step", required=False, type=int, help="Only show traces at this step"
+    )
+    list_traces_parser.add_argument(
+        "--sort",
+        required=False,
+        choices=sorted(TRACE_SORTS),
+        default="request_time_desc",
+        help="Sort order (default: request_time_desc)",
+    )
+    list_traces_parser.add_argument(
+        "--limit", required=False, type=int, default=50, help="Maximum traces to return"
+    )
+    list_traces_parser.add_argument(
+        "--offset", required=False, type=int, default=0, help="Traces to skip"
+    )
+    list_traces_parser.add_argument(
+        "--json", action="store_true", help="Output in JSON format"
+    )
+
     list_reports_parser = list_subparsers.add_parser(
         "reports",
         help="List markdown reports for a project or run",
@@ -1104,6 +1320,33 @@ def main():
         "--json",
         action="store_true",
         help="Output in JSON format",
+    )
+
+    get_trace_parser = get_subparsers.add_parser(
+        "trace",
+        help="Get one trace with its full execution span tree",
+    )
+    get_trace_parser.add_argument("--project", required=True, help="Project name")
+    get_trace_parser.add_argument(
+        "--trace-id", required=True, help="Trace id (from `trackio list traces`)"
+    )
+    get_trace_parser.add_argument("--run", required=False, help="Run name (optional)")
+    get_trace_parser.add_argument(
+        "--json", action="store_true", help="Output in JSON format"
+    )
+
+    get_trace_summary_parser = get_subparsers.add_parser(
+        "trace-summary",
+        help="Aggregate trace spans by operation (calls, errors, latency, tokens, cost)",
+    )
+    get_trace_summary_parser.add_argument(
+        "--project", required=True, help="Project name"
+    )
+    get_trace_summary_parser.add_argument(
+        "--run", required=False, help="Run name (optional)"
+    )
+    get_trace_summary_parser.add_argument(
+        "--json", action="store_true", help="Output in JSON format"
     )
 
     get_alerts_parser = get_subparsers.add_parser(
@@ -1788,6 +2031,8 @@ def main():
                 )
             else:
                 print(format_alerts(alerts))
+        elif args.list_type == "traces":
+            _handle_list_traces(args, remote)
         elif args.list_type == "reports":
             if remote:
                 run_records = remote.predict(
@@ -2114,6 +2359,10 @@ def main():
                         )
                     else:
                         print(format_system_metrics(system_metrics))
+        elif args.get_type == "trace":
+            _handle_get_trace(args, remote)
+        elif args.get_type == "trace-summary":
+            _handle_get_trace_summary(args, remote)
         elif args.get_type == "alerts":
             if remote:
                 alerts = remote.predict(

--- a/trackio/cli_helpers.py
+++ b/trackio/cli_helpers.py
@@ -1,5 +1,7 @@
 import json
+import re
 import sys
+from datetime import datetime, timezone
 from typing import Any
 
 from trackio import references
@@ -320,3 +322,352 @@ def error_exit(message: str, code: int = 1) -> None:
     """Print error message and exit."""
     print(f"Error: {message}", file=sys.stderr)
     sys.exit(code)
+
+
+def format_duration_ms(value: Any) -> str:
+    """Render a millisecond duration the way the trace dashboard does."""
+    if value is None or value == "":
+        return "-"
+    try:
+        ms = float(value)
+    except (TypeError, ValueError):
+        return "-"
+    if ms < 1000:
+        return f"{round(ms)}ms"
+    if ms < 60_000:
+        return f"{ms / 1000:.2f}s" if ms < 10_000 else f"{ms / 1000:.1f}s"
+    minutes = int(ms // 60_000)
+    seconds = round((ms % 60_000) / 1000)
+    return f"{minutes}m {seconds}s"
+
+
+def format_cost_usd(value: Any) -> str:
+    if value is None or value == "":
+        return "-"
+    try:
+        cost = float(value)
+    except (TypeError, ValueError):
+        return "-"
+    if cost == 0:
+        return "$0"
+    if cost < 0.0001:
+        return "<$0.0001"
+    if cost < 0.01:
+        return f"${cost:.4f}"
+    return f"${cost:.2f}"
+
+
+_ISO_FRACTION_RE = re.compile(r"\.(\d+)")
+
+
+def parse_span_timestamp(value: Any) -> datetime | None:
+    """Parse a span timestamp, tolerating any number of fractional digits.
+
+    `datetime.fromisoformat` accepts only 3 or 6 fractional digits before
+    Python 3.11, and instrumentation commonly emits fewer (or a `Z` suffix),
+    so those are normalized first. Naive timestamps are assumed to be UTC so
+    that spans from mixed sources stay comparable.
+    """
+    if not value:
+        return None
+    text = str(value).strip()
+    if text.endswith(("Z", "z")):
+        text = text[:-1] + "+00:00"
+    text = _ISO_FRACTION_RE.sub(
+        lambda match: "." + (match.group(1) + "000000")[:6], text, count=1
+    )
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    return parsed if parsed.tzinfo else parsed.replace(tzinfo=timezone.utc)
+
+
+def _span_duration_ms(span: dict) -> float | None:
+    explicit = span.get("duration_ms")
+    if explicit is not None:
+        try:
+            return max(0.0, float(explicit))
+        except (TypeError, ValueError):
+            pass
+    started = parse_span_timestamp(span.get("start_time"))
+    ended = parse_span_timestamp(span.get("end_time"))
+    if started is None or ended is None:
+        return None
+    return max(0.0, (ended - started).total_seconds() * 1000)
+
+
+def _span_is_error(span: dict) -> bool:
+    status = str(span.get("status") or "").lower()
+    return status in {"error", "failed"} or bool(span.get("error"))
+
+
+def trace_rollup(trace: dict) -> dict:
+    """Latency, cost, token, and status totals for one trace."""
+    spans = trace.get("spans") or []
+    starts, ends, durations = [], [], []
+    cost = 0.0
+    has_cost = False
+    input_tokens = output_tokens = 0
+    has_usage = has_error = False
+
+    for span in spans:
+        if not isinstance(span, dict):
+            continue
+        for field, sink in (("start_time", starts), ("end_time", ends)):
+            parsed = parse_span_timestamp(span.get(field))
+            if parsed is not None:
+                sink.append(parsed)
+        duration = _span_duration_ms(span)
+        if duration is not None:
+            durations.append(duration)
+        span_cost = span.get("cost_usd")
+        if span_cost is not None:
+            try:
+                cost += float(span_cost)
+                has_cost = True
+            except (TypeError, ValueError):
+                pass
+        usage = span.get("usage") or {}
+        for key, add in (("input_tokens", "in"), ("output_tokens", "out")):
+            value = usage.get(key)
+            if value is None:
+                continue
+            try:
+                if add == "in":
+                    input_tokens += int(value)
+                else:
+                    output_tokens += int(value)
+                has_usage = True
+            except (TypeError, ValueError):
+                pass
+        if _span_is_error(span):
+            has_error = True
+
+    metadata = trace.get("metadata") or {}
+    if starts and ends:
+        duration_ms = max(0.0, (max(ends) - min(starts)).total_seconds() * 1000)
+    elif durations:
+        duration_ms = max(durations)
+    else:
+        duration_ms = metadata.get("duration_ms") or metadata.get("latency_ms")
+
+    all_success = bool(spans) and all(
+        str(span.get("status") or "").lower() == "success"
+        for span in spans
+        if isinstance(span, dict)
+    )
+    metadata_status = metadata.get("status")
+    status = (
+        "error"
+        if has_error
+        else (
+            metadata_status
+            if isinstance(metadata_status, str) and metadata_status
+            else ("success" if all_success else None)
+        )
+    )
+    return {
+        "duration_ms": duration_ms,
+        "cost_usd": cost if has_cost else metadata.get("cost_usd"),
+        "input_tokens": input_tokens if has_usage else None,
+        "output_tokens": output_tokens if has_usage else None,
+        "status": status,
+        "span_count": len(spans),
+    }
+
+
+def short_trace_id(trace_id: Any) -> str:
+    """Shorten a stored trace id for display, as the dashboard does.
+
+    Stored ids are `run_id:log_id:key[:index]`; the `log_id` (plus the list
+    index, when the key held several traces) identifies the trace on its own.
+    """
+    text = str(trace_id or "")
+    parts = text.split(":")
+    if len(parts) < 3:
+        return text
+    short = parts[1]
+    last = parts[-1]
+    if len(parts) >= 4 and last.lstrip("-").isdigit():
+        return f"{short}:{last}"
+    return short
+
+
+def trace_id_matches(trace: dict, wanted: str) -> bool:
+    stored = str(trace.get("id") or "")
+    return wanted in (stored, short_trace_id(stored))
+
+
+def _first_message_text(trace: dict, role: str) -> str:
+    for message in trace.get("messages") or []:
+        if not isinstance(message, dict) or message.get("role") != role:
+            continue
+        content = message.get("content")
+        if isinstance(content, str):
+            return content
+        if isinstance(content, list):
+            for part in content:
+                if isinstance(part, dict) and isinstance(part.get("text"), str):
+                    return part["text"]
+    return ""
+
+
+def format_traces(traces: list[dict]) -> str:
+    """Format a trace index in human-readable format."""
+    if not traces:
+        return "No traces found."
+
+    output = [f"Found {len(traces)} trace(s):\n"]
+    output.append("ID | Run | Step | Status | Latency | Cost | Ops | Request")
+    output.append("-" * 100)
+    for trace in traces:
+        rollup = trace_rollup(trace)
+        request = _first_message_text(trace, "user").replace("\n", " ")
+        if len(request) > 48:
+            request = request[:45] + "..."
+        output.append(
+            " | ".join(
+                [
+                    short_trace_id(trace.get("id")) or "-",
+                    str(trace.get("run", "-")),
+                    str(trace.get("step", "-")),
+                    rollup["status"] or "-",
+                    format_duration_ms(rollup["duration_ms"]),
+                    format_cost_usd(rollup["cost_usd"]),
+                    str(rollup["span_count"]),
+                    request or "-",
+                ]
+            )
+        )
+    return "\n".join(output)
+
+
+def _ordered_span_tree(spans: list[dict]) -> list[tuple[int, dict]]:
+    """Depth-annotated spans, parents before children, siblings by start time."""
+    normalized = [span for span in spans if isinstance(span, dict)]
+    by_id: dict[str, dict] = {}
+    for index, span in enumerate(normalized):
+        span_id = str(span.get("id") or f"span-{index + 1}")
+        by_id.setdefault(span_id, span)
+
+    children: dict[int, list[dict]] = {}
+    roots: list[dict] = []
+    for span in normalized:
+        parent_id = span.get("parent_id")
+        parent = by_id.get(str(parent_id)) if parent_id else None
+        if parent is None or parent is span:
+            roots.append(span)
+        else:
+            children.setdefault(id(parent), []).append(span)
+
+    def sort_key(span: dict) -> tuple:
+        started = parse_span_timestamp(span.get("start_time"))
+        return (
+            0 if started else 1,
+            started.timestamp() if started else 0.0,
+            normalized.index(span),
+        )
+
+    rows: list[tuple[int, dict]] = []
+    seen: set[int] = set()
+
+    def walk(span: dict, depth: int) -> None:
+        if id(span) in seen:
+            return
+        seen.add(id(span))
+        rows.append((depth, span))
+        for child in sorted(children.get(id(span), []), key=sort_key):
+            walk(child, depth + 1)
+
+    for root in sorted(roots, key=sort_key):
+        walk(root, 0)
+    for span in normalized:
+        walk(span, 0)
+    return rows
+
+
+def format_trace(trace: dict) -> str:
+    """Format a single trace, including its span tree, in human-readable format."""
+    rollup = trace_rollup(trace)
+    output = [f"Trace {short_trace_id(trace.get('id')) or '-'}"]
+    output.append(f"  Full id:  {trace.get('id', '-')}")
+    output.append(f"  Run:      {trace.get('run', '-')}")
+    output.append(f"  Step:     {trace.get('step', '-')}")
+    output.append(
+        f"  Logged:   {trace.get('timestamp', '-')} (key: {trace.get('key', '-')})"
+    )
+    output.append(
+        f"  Totals:   {rollup['status'] or 'no status'} | "
+        f"{format_duration_ms(rollup['duration_ms'])} | "
+        f"{format_cost_usd(rollup['cost_usd'])} | "
+        f"{rollup['input_tokens'] if rollup['input_tokens'] is not None else '-'} in / "
+        f"{rollup['output_tokens'] if rollup['output_tokens'] is not None else '-'} out tokens | "
+        f"{rollup['span_count']} operation(s)"
+    )
+    metadata = trace.get("metadata") or {}
+    if metadata:
+        rendered = ", ".join(
+            f"{key}={value}"
+            for key, value in metadata.items()
+            if not isinstance(value, (dict, list))
+        )
+        if rendered:
+            output.append(f"  Metadata: {rendered}")
+
+    spans = trace.get("spans") or []
+    if spans:
+        output.append("\nExecution:")
+        for depth, span in _ordered_span_tree(spans):
+            indent = "  " * (depth + 1)
+            bits = [format_duration_ms(_span_duration_ms(span))]
+            if span.get("model"):
+                bits.append(str(span["model"]))
+            usage = span.get("usage") or {}
+            if (
+                usage.get("input_tokens") is not None
+                or usage.get("output_tokens") is not None
+            ):
+                bits.append(
+                    f"{usage.get('input_tokens', 0)}->{usage.get('output_tokens', 0)} tok"
+                )
+            if span.get("cost_usd") is not None:
+                bits.append(format_cost_usd(span.get("cost_usd")))
+            marker = "ERROR " if _span_is_error(span) else ""
+            output.append(
+                f"{indent}{marker}{span.get('name', span.get('kind', 'span'))} "
+                f"[{span.get('kind', 'span')}]  {'  '.join(bits)}"
+            )
+            error = span.get("error")
+            if error:
+                detail = error if isinstance(error, str) else json.dumps(error)
+                output.append(f"{indent}  -> {detail[:160]}")
+    else:
+        output.append("\nExecution: no spans logged for this trace.")
+
+    messages = trace.get("messages") or []
+    if messages:
+        output.append("\nConversation:")
+        for message in messages:
+            if not isinstance(message, dict):
+                continue
+            role = message.get("role", "message")
+            content = message.get("content")
+            if not isinstance(content, str):
+                content = json.dumps(content) if content is not None else ""
+            content = content.replace("\n", " ")
+            if len(content) > 160:
+                content = content[:157] + "..."
+            output.append(f"  {role}: {content}")
+    return "\n".join(output)
+
+
+def format_trace_summary(result: dict[str, Any]) -> str:
+    """Format the per-operation trace rollup in human-readable format."""
+    rows = result.get("rows") or []
+    if not rows:
+        return "No trace spans found."
+    columns = result.get("columns") or []
+    return format_query_result(
+        {"columns": columns, "rows": rows, "row_count": len(rows)}
+    )

--- a/trackio/frontend/src/lib/staticApi.js
+++ b/trackio/frontend/src/lib/staticApi.js
@@ -237,6 +237,16 @@ export async function getLogs(_project, run, options = {}) {
   });
 }
 
+const SEARCHABLE_SPAN_FIELDS = [
+  "id",
+  "name",
+  "kind",
+  "model",
+  "status",
+  "error",
+  "metadata",
+];
+
 function flattenTraceSearchText(trace) {
   const parts = [];
 
@@ -255,7 +265,9 @@ function flattenTraceSearchText(trace) {
 
   visit(trace.messages || []);
   visit(trace.metadata || {});
-  visit(trace.spans || []);
+  for (const span of trace.spans || []) {
+    for (const field of SEARCHABLE_SPAN_FIELDS) visit(span?.[field]);
+  }
   return parts.join(" ").toLowerCase();
 }
 

--- a/trackio/frontend/src/lib/staticApi.js
+++ b/trackio/frontend/src/lib/staticApi.js
@@ -255,6 +255,7 @@ function flattenTraceSearchText(trace) {
 
   visit(trace.messages || []);
   visit(trace.metadata || {});
+  visit(trace.spans || []);
   return parts.join(" ").toLowerCase();
 }
 
@@ -329,6 +330,7 @@ export async function getTraces(_project, run, options = {}) {
       timestamp: row.timestamp,
       messages: parseTraceJsonField(row.messages, []),
       metadata: parseTraceJsonField(row.metadata, {}),
+      spans: parseTraceJsonField(row.spans, []),
     };
     trace._search_text = (row.search_text || `${trace.id} ${trace.key} ${flattenTraceSearchText(trace)}`).toLowerCase();
     return trace;

--- a/trackio/frontend/src/lib/traceUtils.js
+++ b/trackio/frontend/src/lib/traceUtils.js
@@ -66,9 +66,21 @@ function toolResultByCallId(messages) {
   for (const message of messages || []) {
     if (String(message?.role || "").toLowerCase() !== "tool") continue;
     const callId = message.tool_call_id || message.toolCallId;
-    if (callId) results.set(String(callId), message);
+    if (callId && !results.has(String(callId))) results.set(String(callId), message);
   }
   return results;
+}
+
+function isErrorStatus(status) {
+  return ["error", "failed"].includes(String(status || "").toLowerCase());
+}
+
+function toolResultStatus(result) {
+  if (!result) return null;
+  if (result.is_error === true || result.isError === true) return "error";
+  if (result.error) return "error";
+  if (isErrorStatus(result.status)) return "error";
+  return null;
 }
 
 export function messageToolSpans(messages) {
@@ -90,7 +102,7 @@ export function messageToolSpans(messages) {
         kind: "tool",
         input: parseJsonValue(fn.arguments ?? call?.arguments ?? null),
         output: parseJsonValue(result?.content ?? null),
-        status: result ? (result.isError ? "error" : "success") : null,
+        status: toolResultStatus(result),
         derived_from_messages: true,
       });
     }
@@ -214,10 +226,7 @@ export function traceSummary(trace) {
       totalTokens += usage.totalTokens;
       hasUsage = true;
     }
-    if (
-      ["error", "failed"].includes(String(span?.status || "").toLowerCase()) ||
-      span?.error
-    ) {
+    if (isErrorStatus(span?.status) || span?.error) {
       hasError = true;
     }
   }
@@ -233,9 +242,11 @@ export function traceSummary(trace) {
   const allSucceeded =
     spans.length > 0 &&
     spans.every((span) => String(span?.status || "").toLowerCase() === "success");
+  const metadataStatus =
+    typeof metadata.status === "string" && metadata.status ? metadata.status : null;
   const status = hasError
     ? "error"
-    : metadata.status || (allSucceeded ? "success" : null);
+    : metadataStatus || (allSucceeded ? "success" : null);
 
   return {
     durationMs,

--- a/trackio/frontend/src/lib/traceUtils.js
+++ b/trackio/frontend/src/lib/traceUtils.js
@@ -1,0 +1,273 @@
+function finiteNumber(value) {
+  if (value === null || value === undefined || value === "") return null;
+  const number = Number(value);
+  return Number.isFinite(number) ? number : null;
+}
+
+function firstNumber(...values) {
+  for (const value of values) {
+    const number = finiteNumber(value);
+    if (number !== null) return number;
+  }
+  return null;
+}
+
+function parseTimestamp(value) {
+  if (!value) return null;
+  const time = new Date(value).getTime();
+  return Number.isFinite(time) ? time : null;
+}
+
+function parseJsonValue(value) {
+  if (typeof value !== "string") return value;
+  try {
+    return JSON.parse(value);
+  } catch {
+    return value;
+  }
+}
+
+export function spanDurationMs(span) {
+  const explicit = firstNumber(span?.duration_ms, span?.durationMs);
+  if (explicit !== null) return Math.max(0, explicit);
+  const start = parseTimestamp(span?.start_time || span?.startTime);
+  const end = parseTimestamp(span?.end_time || span?.endTime);
+  if (start === null || end === null) return null;
+  return Math.max(0, end - start);
+}
+
+export function spanUsage(span) {
+  const usage = span?.usage || {};
+  const inputTokens = firstNumber(
+    usage.input_tokens,
+    usage.prompt_tokens,
+    span?.input_tokens,
+  );
+  const outputTokens = firstNumber(
+    usage.output_tokens,
+    usage.completion_tokens,
+    span?.output_tokens,
+  );
+  const suppliedTotal = firstNumber(usage.total_tokens, span?.total_tokens);
+  const totalTokens =
+    suppliedTotal ??
+    (inputTokens !== null || outputTokens !== null
+      ? (inputTokens || 0) + (outputTokens || 0)
+      : null);
+  return { inputTokens, outputTokens, totalTokens };
+}
+
+export function spanCostUsd(span) {
+  return firstNumber(span?.cost_usd, span?.costUsd);
+}
+
+function toolResultByCallId(messages) {
+  const results = new Map();
+  for (const message of messages || []) {
+    if (String(message?.role || "").toLowerCase() !== "tool") continue;
+    const callId = message.tool_call_id || message.toolCallId;
+    if (callId) results.set(String(callId), message);
+  }
+  return results;
+}
+
+export function messageToolSpans(messages) {
+  const results = toolResultByCallId(messages);
+  const spans = [];
+  for (const [messageIndex, message] of (messages || []).entries()) {
+    const calls = [...(message?.tool_calls || message?.toolCalls || [])];
+    if (message?.function_call) {
+      calls.push({ function: message.function_call });
+    }
+    for (const [callIndex, call] of calls.entries()) {
+      const fn = call?.function || call || {};
+      const id = String(call?.id || `message-tool-${messageIndex}-${callIndex}`);
+      const result = results.get(id);
+      spans.push({
+        id,
+        parent_id: null,
+        name: fn.name || call?.name || "tool",
+        kind: "tool",
+        input: parseJsonValue(fn.arguments ?? call?.arguments ?? null),
+        output: parseJsonValue(result?.content ?? null),
+        status: result ? (result.isError ? "error" : "success") : null,
+        derived_from_messages: true,
+      });
+    }
+  }
+  return spans;
+}
+
+export function traceSpans(trace) {
+  if (Array.isArray(trace?.spans) && trace.spans.length) return trace.spans;
+  return messageToolSpans(trace?.messages || []);
+}
+
+function normalizedSpan(span, index, usedIds) {
+  const requestedId = String(span?.id || `span-${index + 1}`);
+  let treeId = requestedId;
+  let suffix = 2;
+  while (usedIds.has(treeId)) {
+    treeId = `${requestedId}-${suffix}`;
+    suffix += 1;
+  }
+  usedIds.add(treeId);
+  return {
+    ...span,
+    id: requestedId,
+    _treeId: treeId,
+    _index: index,
+    parent_id: span?.parent_id ?? span?.parentId ?? null,
+    name: span?.name || span?.kind || `Span ${index + 1}`,
+    kind: String(span?.kind || "span").toLowerCase(),
+  };
+}
+
+function compareSpans(left, right) {
+  const leftStart = parseTimestamp(left.start_time || left.startTime);
+  const rightStart = parseTimestamp(right.start_time || right.startTime);
+  if (leftStart !== null && rightStart !== null && leftStart !== rightStart) {
+    return leftStart - rightStart;
+  }
+  return left._index - right._index;
+}
+
+export function flattenSpanTree(spans, collapsedIds = new Set()) {
+  const usedIds = new Set();
+  const normalized = (spans || []).map((span, index) =>
+    normalizedSpan(span, index, usedIds),
+  );
+  const firstByPublicId = new Map();
+  for (const span of normalized) {
+    if (!firstByPublicId.has(span.id)) firstByPublicId.set(span.id, span);
+  }
+  const children = new Map(normalized.map((span) => [span._treeId, []]));
+  const roots = [];
+  for (const span of normalized) {
+    const parent = span.parent_id ? firstByPublicId.get(String(span.parent_id)) : null;
+    if (!parent || parent._treeId === span._treeId) {
+      roots.push(span);
+    } else {
+      children.get(parent._treeId).push(span);
+    }
+  }
+  roots.sort(compareSpans);
+  for (const childSpans of children.values()) childSpans.sort(compareSpans);
+
+  const rows = [];
+  const visited = new Set();
+  function hideDescendants(span) {
+    for (const child of children.get(span._treeId) || []) {
+      if (visited.has(child._treeId)) continue;
+      visited.add(child._treeId);
+      hideDescendants(child);
+    }
+  }
+  function visit(span, depth) {
+    if (visited.has(span._treeId)) return;
+    visited.add(span._treeId);
+    const childSpans = children.get(span._treeId) || [];
+    rows.push({ ...span, depth, hasChildren: childSpans.length > 0 });
+    if (collapsedIds.has(span._treeId)) {
+      hideDescendants(span);
+      return;
+    }
+    for (const child of childSpans) visit(child, depth + 1);
+  }
+  for (const root of roots) visit(root, 0);
+  for (const span of normalized) visit(span, 0);
+  return rows;
+}
+
+export function traceSummary(trace) {
+  const spans = traceSpans(trace);
+  let earliest = null;
+  let latest = null;
+  let costUsd = 0;
+  let hasCost = false;
+  let inputTokens = 0;
+  let outputTokens = 0;
+  let totalTokens = 0;
+  let hasUsage = false;
+  let hasError = false;
+  let maxDurationMs = null;
+
+  for (const span of spans) {
+    const start = parseTimestamp(span?.start_time || span?.startTime);
+    const end = parseTimestamp(span?.end_time || span?.endTime);
+    if (start !== null) earliest = earliest === null ? start : Math.min(earliest, start);
+    if (end !== null) latest = latest === null ? end : Math.max(latest, end);
+    const duration = spanDurationMs(span);
+    if (duration !== null) {
+      maxDurationMs =
+        maxDurationMs === null ? duration : Math.max(maxDurationMs, duration);
+    }
+    const cost = spanCostUsd(span);
+    if (cost !== null) {
+      costUsd += cost;
+      hasCost = true;
+    }
+    const usage = spanUsage(span);
+    if (usage.totalTokens !== null) {
+      inputTokens += usage.inputTokens || 0;
+      outputTokens += usage.outputTokens || 0;
+      totalTokens += usage.totalTokens;
+      hasUsage = true;
+    }
+    if (
+      ["error", "failed"].includes(String(span?.status || "").toLowerCase()) ||
+      span?.error
+    ) {
+      hasError = true;
+    }
+  }
+
+  const metadata = trace?.metadata || {};
+  const derivedDuration =
+    earliest !== null && latest !== null ? Math.max(0, latest - earliest) : null;
+  const durationMs =
+    derivedDuration ??
+    maxDurationMs ??
+    firstNumber(metadata.duration_ms, metadata.latency_ms);
+  const metadataCost = firstNumber(metadata.cost_usd);
+  const allSucceeded =
+    spans.length > 0 &&
+    spans.every((span) => String(span?.status || "").toLowerCase() === "success");
+  const status = hasError
+    ? "error"
+    : metadata.status || (allSucceeded ? "success" : null);
+
+  return {
+    durationMs,
+    costUsd: hasCost ? costUsd : metadataCost,
+    inputTokens: hasUsage ? inputTokens : null,
+    outputTokens: hasUsage ? outputTokens : null,
+    totalTokens: hasUsage ? totalTokens : null,
+    status,
+    spanCount: spans.length,
+  };
+}
+
+export function formatDuration(ms) {
+  const value = finiteNumber(ms);
+  if (value === null) return "—";
+  if (value < 1) return `${Math.round(value * 1000)}µs`;
+  if (value < 1000) return `${Math.round(value)}ms`;
+  if (value < 60_000) return `${(value / 1000).toFixed(value < 10_000 ? 2 : 1)}s`;
+  const minutes = Math.floor(value / 60_000);
+  const seconds = Math.round((value % 60_000) / 1000);
+  return `${minutes}m ${seconds}s`;
+}
+
+export function formatCost(cost) {
+  const value = finiteNumber(cost);
+  if (value === null) return "—";
+  if (value === 0) return "$0";
+  if (value < 0.01) return `$${value.toFixed(4)}`;
+  return `$${value.toFixed(2)}`;
+}
+
+export function formatTokens(tokens) {
+  const value = finiteNumber(tokens);
+  return value === null ? "—" : Math.round(value).toLocaleString();
+}

--- a/trackio/frontend/src/lib/traceUtils.test.js
+++ b/trackio/frontend/src/lib/traceUtils.test.js
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  flattenSpanTree,
+  formatCost,
+  formatDuration,
+  messageToolSpans,
+  spanDurationMs,
+  traceSummary,
+} from "./traceUtils.js";
+
+describe("traceUtils", () => {
+  it("builds a stable parent-child execution tree", () => {
+    const rows = flattenSpanTree([
+      { id: "tool", parent_id: "agent", name: "hf search", kind: "tool" },
+      { id: "agent", name: "research", kind: "span" },
+      { id: "model", parent_id: "agent", name: "provider", kind: "generation" },
+    ]);
+
+    expect(rows.map((row) => [row.id, row.depth])).toEqual([
+      ["agent", 0],
+      ["tool", 1],
+      ["model", 1],
+    ]);
+    expect(rows[0].hasChildren).toBe(true);
+  });
+
+  it("omits descendants of collapsed spans", () => {
+    const rows = flattenSpanTree(
+      [
+        { id: "agent", name: "research" },
+        { id: "tool", parent_id: "agent", name: "hf search" },
+      ],
+      new Set(["agent"]),
+    );
+
+    expect(rows.map((row) => row.id)).toEqual(["agent"]);
+  });
+
+  it("derives tool spans from existing OpenAI-style messages", () => {
+    const spans = messageToolSpans([
+      {
+        role: "assistant",
+        tool_calls: [
+          {
+            id: "call-1",
+            function: { name: "hf", arguments: '{"query":"agent data"}' },
+          },
+        ],
+      },
+      {
+        role: "tool",
+        tool_call_id: "call-1",
+        content: '{"matches":3}',
+      },
+    ]);
+
+    expect(spans).toHaveLength(1);
+    expect(spans[0]).toMatchObject({
+      id: "call-1",
+      name: "hf",
+      input: { query: "agent data" },
+      output: { matches: 3 },
+      status: "success",
+    });
+  });
+
+  it("summarizes wall-clock latency, usage, cost, and errors", () => {
+    const summary = traceSummary({
+      spans: [
+        {
+          id: "generation",
+          start_time: "2026-08-19T12:00:00.000Z",
+          end_time: "2026-08-19T12:00:02.000Z",
+          usage: { input_tokens: 100, output_tokens: 20 },
+          cost_usd: 0.002,
+          status: "success",
+        },
+        {
+          id: "tool",
+          start_time: "2026-08-19T12:00:01.500Z",
+          end_time: "2026-08-19T12:00:03.000Z",
+          cost_usd: 0.001,
+          status: "error",
+        },
+      ],
+    });
+
+    expect(summary).toMatchObject({
+      durationMs: 3000,
+      costUsd: 0.003,
+      inputTokens: 100,
+      outputTokens: 20,
+      totalTokens: 120,
+      status: "error",
+      spanCount: 2,
+    });
+  });
+
+  it("formats span metrics compactly", () => {
+    expect(spanDurationMs({ duration_ms: 750 })).toBe(750);
+    expect(traceSummary({ spans: [{ duration_ms: 750 }] }).durationMs).toBe(750);
+    expect(formatDuration(23790)).toBe("23.8s");
+    expect(formatCost(0.00425)).toBe("$0.0043");
+  });
+});

--- a/trackio/frontend/src/lib/traceUtils.test.js
+++ b/trackio/frontend/src/lib/traceUtils.test.js
@@ -61,7 +61,7 @@ describe("traceUtils", () => {
       name: "hf",
       input: { query: "agent data" },
       output: { matches: 3 },
-      status: "success",
+      status: null,
     });
   });
 
@@ -95,6 +95,40 @@ describe("traceUtils", () => {
       status: "error",
       spanCount: 2,
     });
+  });
+
+  it("does not assume success from an OpenAI-style tool result", () => {
+    const trace = {
+      messages: [
+        {
+          role: "assistant",
+          tool_calls: [{ id: "call-1", function: { name: "hf", arguments: "{}" } }],
+        },
+        { role: "tool", tool_call_id: "call-1", content: "ok" },
+      ],
+    };
+
+    expect(messageToolSpans(trace.messages)[0].status).toBe(null);
+    expect(traceSummary(trace).status).toBe(null);
+  });
+
+  it("marks a derived tool operation failed from an error flag", () => {
+    const spans = messageToolSpans([
+      {
+        role: "assistant",
+        tool_calls: [{ id: "call-1", function: { name: "hf", arguments: "{}" } }],
+      },
+      { role: "tool", tool_call_id: "call-1", is_error: true, content: "boom" },
+    ]);
+
+    expect(spans[0].status).toBe("error");
+    expect(traceSummary({ spans }).status).toBe("error");
+  });
+
+  it("ignores a non-string trace metadata status", () => {
+    expect(traceSummary({ spans: [], metadata: { status: { code: 2 } } }).status).toBe(
+      null,
+    );
   });
 
   it("formats span metrics compactly", () => {

--- a/trackio/frontend/src/pages/Traces.svelte
+++ b/trackio/frontend/src/pages/Traces.svelte
@@ -330,6 +330,29 @@
     return part?.caption || part?.alt || "Trace image";
   }
 
+  function mediaParts(value) {
+    const found = [];
+    function visit(node) {
+      if (!node || typeof node !== "object") return;
+      if (isImagePart(node)) {
+        found.push(node);
+        return;
+      }
+      for (const item of Array.isArray(node) ? node : Object.values(node)) visit(item);
+    }
+    visit(value);
+    return found;
+  }
+
+  function withoutMediaParts(value) {
+    if (!value || typeof value !== "object") return value;
+    if (isImagePart(value)) return `[${imageAlt(value)}]`;
+    if (Array.isArray(value)) return value.map(withoutMediaParts);
+    return Object.fromEntries(
+      Object.entries(value).map(([key, item]) => [key, withoutMediaParts(item)]),
+    );
+  }
+
   function longText(text) {
     return typeof text === "string" && text.length > 500;
   }
@@ -563,6 +586,7 @@
                           <section class="operation-panel">
                             {#if selectedSpan}
                               {@const usage = spanUsage(selectedSpan)}
+                              {@const payload = selectedSpan.error || selectedSpan.output}
                               <header class="operation-header">
                                 <div>
                                   <div class="operation-kind">{selectedSpan.kind}</div>
@@ -589,11 +613,17 @@
                               <div class="io-grid">
                                 <section>
                                   <h4>Input</h4>
-                                  <pre>{formatValue(selectedSpan.input)}</pre>
+                                  {#each mediaParts(selectedSpan.input) as part}
+                                    <img class="trace-image" src={imageSrc(part)} alt={imageAlt(part)} />
+                                  {/each}
+                                  <pre>{formatValue(withoutMediaParts(selectedSpan.input))}</pre>
                                 </section>
                                 <section>
                                   <h4>{selectedSpan.error ? "Error" : "Output"}</h4>
-                                  <pre class:error-output={Boolean(selectedSpan.error)}>{formatValue(selectedSpan.error || selectedSpan.output)}</pre>
+                                  {#each mediaParts(payload) as part}
+                                    <img class="trace-image" src={imageSrc(part)} alt={imageAlt(part)} />
+                                  {/each}
+                                  <pre class:error-output={Boolean(selectedSpan.error)}>{formatValue(withoutMediaParts(payload))}</pre>
                                 </section>
                               </div>
                               {#if selectedSpan.metadata}
@@ -1028,6 +1058,9 @@
     font-weight: 700;
     letter-spacing: 0.08em;
     text-transform: uppercase;
+  }
+  .io-grid .trace-image {
+    margin-bottom: 8px;
   }
   .io-grid pre,
   .span-metadata pre {

--- a/trackio/frontend/src/pages/Traces.svelte
+++ b/trackio/frontend/src/pages/Traces.svelte
@@ -1,6 +1,17 @@
 <script>
   import LoadingTrackio from "../components/LoadingTrackio.svelte";
   import { getMediaUrl, getTraces, getTraceSteps } from "../lib/api.js";
+  import {
+    flattenSpanTree,
+    formatCost,
+    formatDuration,
+    formatTokens,
+    spanCostUsd,
+    spanDurationMs,
+    spanUsage,
+    traceSpans,
+    traceSummary,
+  } from "../lib/traceUtils.js";
 
   let {
     project = null,
@@ -15,6 +26,8 @@
   let stepFilter = $state("all");
   let page = $state(0);
   let expandedTraceId = $state(null);
+  let selectedSpanId = $state(null);
+  let collapsedSpanIds = $state(new Set());
   let traces = $state([]);
   let availableSteps = $state([]);
   let totalCount = $state(0);
@@ -52,6 +65,8 @@
       run: trace.run || runLabel,
       request: textFromContent(firstUser?.content) || "(no user message)",
       preview: textFromContent(firstAssistant?.content) || "(no assistant response)",
+      executionSpans: traceSpans(trace),
+      summary: traceSummary(trace),
     };
   }
 
@@ -108,6 +123,8 @@
     if (!project || selectedRuns.length === 0) {
       traces = [];
       expandedTraceId = null;
+      selectedSpanId = null;
+      collapsedSpanIds = new Set();
       return;
     }
 
@@ -139,6 +156,8 @@
       traces = merged;
       if (!traces.find((trace) => trace.id === expandedTraceId)) {
         expandedTraceId = null;
+        selectedSpanId = null;
+        collapsedSpanIds = new Set();
       }
     } catch (error) {
       if (requestId !== loadRequestId) return;
@@ -163,6 +182,8 @@
       page = 0;
       stepFilter = "all";
       expandedTraceId = null;
+      selectedSpanId = null;
+      collapsedSpanIds = new Set();
       traces = [];
       loadSummary();
     }
@@ -187,14 +208,63 @@
     return () => clearTimeout(timeout);
   });
 
-  function toggleTrace(traceId) {
-    expandedTraceId = expandedTraceId === traceId ? null : traceId;
+  function executionRows(trace, includeCollapsed = true) {
+    return flattenSpanTree(
+      trace.executionSpans || [],
+      includeCollapsed ? collapsedSpanIds : new Set(),
+    );
   }
 
-  function handleRowKeydown(event, traceId) {
+  function toggleTrace(trace) {
+    if (expandedTraceId === trace.id) {
+      expandedTraceId = null;
+      selectedSpanId = null;
+      collapsedSpanIds = new Set();
+      return;
+    }
+    expandedTraceId = trace.id;
+    collapsedSpanIds = new Set();
+    selectedSpanId = executionRows(trace, false)[0]?._treeId || null;
+  }
+
+  function handleRowKeydown(event, trace) {
     if (event.key === "Enter" || event.key === " ") {
       event.preventDefault();
-      toggleTrace(traceId);
+      toggleTrace(trace);
+    }
+  }
+
+  function toggleSpan(event, spanId) {
+    event.stopPropagation();
+    const next = new Set(collapsedSpanIds);
+    if (next.has(spanId)) next.delete(spanId);
+    else next.add(spanId);
+    collapsedSpanIds = next;
+  }
+
+  function selectSpan(event, spanId) {
+    event.stopPropagation();
+    selectedSpanId = spanId;
+  }
+
+  function activeSpan(trace) {
+    const rows = executionRows(trace, false);
+    return rows.find((span) => span._treeId === selectedSpanId) || rows[0] || null;
+  }
+
+  function spanIcon(kind) {
+    if (kind === "generation") return "✦";
+    if (kind === "tool") return "⌁";
+    return "◇";
+  }
+
+  function formatValue(value) {
+    if (value === null || value === undefined || value === "") return "—";
+    if (typeof value === "string") return value;
+    try {
+      return JSON.stringify(value, null, 2);
+    } catch {
+      return String(value);
     }
   }
 
@@ -379,6 +449,9 @@
             <col class="request-col" />
             <col class="run-col" />
             <col class="step-col" />
+            <col class="status-col" />
+            <col class="metric-col" />
+            <col class="metric-col" />
             <col class="request-time-col" />
           </colgroup>
           <thead>
@@ -387,6 +460,9 @@
               <th>Request</th>
               <th>Run</th>
               <th>Step</th>
+              <th>Status</th>
+              <th>Latency</th>
+              <th>Cost</th>
               <th>Request time</th>
             </tr>
           </thead>
@@ -397,8 +473,8 @@
                 role="button"
                 tabindex="0"
                 aria-expanded={expandedTraceId === trace.id}
-                onclick={() => toggleTrace(trace.id)}
-                onkeydown={(event) => handleRowKeydown(event, trace.id)}
+                onclick={() => toggleTrace(trace)}
+                onkeydown={(event) => handleRowKeydown(event, trace)}
               >
                 <td class="trace-id-cell">
                   <span class="trace-id-chip" title={publicTraceId(trace.id)}
@@ -413,12 +489,33 @@
                 </td>
                 <td>{trace.run || "—"}</td>
                 <td>{trace.step ?? "—"}</td>
+                <td>
+                  {#if trace.summary.status}
+                    <span class:status-error={trace.summary.status === "error"} class="status-pill">
+                      {trace.summary.status}
+                    </span>
+                  {:else}—{/if}
+                </td>
+                <td class="metric-cell">{formatDuration(trace.summary.durationMs)}</td>
+                <td class="metric-cell">{formatCost(trace.summary.costUsd)}</td>
                 <td>{formatRelativeTime(trace.timestamp)}</td>
               </tr>
               {#if expandedTraceId === trace.id}
+                {@const selectedSpan = activeSpan(trace)}
                 <tr class="expanded-row">
-                  <td colspan="5">
+                  <td colspan="8">
                     <div class="trace-detail">
+                      <div class="trace-summary">
+                        <span><strong>Latency</strong> {formatDuration(trace.summary.durationMs)}</span>
+                        <span><strong>Cost</strong> {formatCost(trace.summary.costUsd)}</span>
+                        <span><strong>Tokens</strong> {formatTokens(trace.summary.totalTokens)}</span>
+                        <span><strong>Operations</strong> {trace.summary.spanCount}</span>
+                        {#if trace.summary.status}
+                          <span class:status-error={trace.summary.status === "error"} class="status-pill">
+                            {trace.summary.status}
+                          </span>
+                        {/if}
+                      </div>
                       <div class="detail-meta">
                         <span>Trace ID: {publicTraceId(trace.id)}</span>
                         <span>Logged as: {trace.key}</span>
@@ -428,54 +525,141 @@
                         {/each}
                       </div>
 
-                      <div class="conversation">
-                        {#each trace.messages as message}
-                          <div class="message" data-role={message.role || "unknown"}>
-                            <div class="message-role">
-                              {message.role || "message"}
-                              {#if message.tool_calls?.length}
-                                <span class="message-tag">tool calls</span>
+                      {#if trace.executionSpans.length}
+                        <div class="trace-inspector">
+                          <aside class="execution-panel">
+                            <div class="panel-title">Execution</div>
+                            <div class="execution-tree">
+                              {#each executionRows(trace) as span (span._treeId)}
+                                <div
+                                  class:span-selected={selectedSpan?._treeId === span._treeId}
+                                  class="span-row"
+                                  style={`--span-depth: ${span.depth}`}
+                                >
+                                  <button
+                                    class:collapse-hidden={!span.hasChildren}
+                                    class="span-collapse"
+                                    type="button"
+                                    aria-label={collapsedSpanIds.has(span._treeId) ? "Expand span" : "Collapse span"}
+                                    onclick={(event) => toggleSpan(event, span._treeId)}
+                                  >{collapsedSpanIds.has(span._treeId) ? "▸" : "▾"}</button>
+                                  <button
+                                    class="span-select"
+                                    type="button"
+                                    onclick={(event) => selectSpan(event, span._treeId)}
+                                  >
+                                    <span class={`span-icon span-icon-${span.kind}`}>{spanIcon(span.kind)}</span>
+                                    <span class="span-name">{span.name}</span>
+                                    {#if span.status === "error" || span.error}
+                                      <span class="span-error-dot" title="Error"></span>
+                                    {/if}
+                                    <span class="span-duration">{formatDuration(spanDurationMs(span))}</span>
+                                  </button>
+                                </div>
+                              {/each}
+                            </div>
+                          </aside>
+
+                          <section class="operation-panel">
+                            {#if selectedSpan}
+                              {@const usage = spanUsage(selectedSpan)}
+                              <header class="operation-header">
+                                <div>
+                                  <div class="operation-kind">{selectedSpan.kind}</div>
+                                  <h3>{selectedSpan.name}</h3>
+                                </div>
+                                <div class="operation-badges">
+                                  {#if selectedSpan.status}
+                                    <span class:status-error={selectedSpan.status === "error"} class="status-pill">
+                                      {selectedSpan.status}
+                                    </span>
+                                  {/if}
+                                  <span>{formatDuration(spanDurationMs(selectedSpan))}</span>
+                                  {#if spanCostUsd(selectedSpan) !== null}
+                                    <span>{formatCost(spanCostUsd(selectedSpan))}</span>
+                                  {/if}
+                                </div>
+                              </header>
+                              <div class="operation-meta">
+                                {#if selectedSpan.model}<span><strong>Model</strong> {selectedSpan.model}</span>{/if}
+                                {#if usage.inputTokens !== null}<span><strong>Input</strong> {formatTokens(usage.inputTokens)} tokens</span>{/if}
+                                {#if usage.outputTokens !== null}<span><strong>Output</strong> {formatTokens(usage.outputTokens)} tokens</span>{/if}
+                                {#if selectedSpan.start_time}<span><strong>Started</strong> {selectedSpan.start_time}</span>{/if}
+                              </div>
+                              <div class="io-grid">
+                                <section>
+                                  <h4>Input</h4>
+                                  <pre>{formatValue(selectedSpan.input)}</pre>
+                                </section>
+                                <section>
+                                  <h4>{selectedSpan.error ? "Error" : "Output"}</h4>
+                                  <pre class:error-output={Boolean(selectedSpan.error)}>{formatValue(selectedSpan.error || selectedSpan.output)}</pre>
+                                </section>
+                              </div>
+                              {#if selectedSpan.metadata}
+                                <details class="span-metadata">
+                                  <summary>Metadata</summary>
+                                  <pre>{formatValue(selectedSpan.metadata)}</pre>
+                                </details>
                               {/if}
+                            {:else}
+                              <div class="operation-empty">Select an operation to inspect it.</div>
+                            {/if}
+                          </section>
+                        </div>
+                      {/if}
+
+                      <details class="conversation-section" open={!trace.executionSpans.length}>
+                        <summary>Conversation</summary>
+                        <div class="conversation">
+                          {#each trace.messages as message}
+                            <div class="message" data-role={message.role || "unknown"}>
+                              <div class="message-role">
+                                {message.role || "message"}
+                                {#if message.tool_calls?.length}
+                                  <span class="message-tag">tool calls</span>
+                                {/if}
+                                {#if message.function_call}
+                                  <span class="message-tag">function call</span>
+                                {/if}
+                              </div>
+
+                              {#if typeof message.content === "string"}
+                                {#if longText(message.content)}
+                                  <details class="message-details">
+                                    <summary>Expand content</summary>
+                                    <pre class="message-content">{message.content}</pre>
+                                  </details>
+                                {:else}
+                                  <pre class="message-content">{message.content}</pre>
+                                {/if}
+                              {:else if hasRenderableParts(message)}
+                                <div class="message-parts">
+                                  {#each renderableParts(message) as part}
+                                    {#if isImagePart(part)}
+                                      <img class="trace-image" src={imageSrc(part)} alt={imageAlt(part)} />
+                                    {:else}
+                                      <pre class="message-content">{JSON.stringify(part, null, 2)}</pre>
+                                    {/if}
+                                  {/each}
+                                </div>
+                              {/if}
+
+                              {#if message.tool_calls?.length}
+                                <div class="tool-blocks">
+                                  {#each message.tool_calls as toolCall}
+                                    <pre class="tool-block">{JSON.stringify(toolCall, null, 2)}</pre>
+                                  {/each}
+                                </div>
+                              {/if}
+
                               {#if message.function_call}
-                                <span class="message-tag">function call</span>
+                                <pre class="tool-block">{JSON.stringify(message.function_call, null, 2)}</pre>
                               {/if}
                             </div>
-
-                            {#if typeof message.content === "string"}
-                              {#if longText(message.content)}
-                                <details class="message-details">
-                                  <summary>Expand content</summary>
-                                  <pre class="message-content">{message.content}</pre>
-                                </details>
-                              {:else}
-                                <pre class="message-content">{message.content}</pre>
-                              {/if}
-                            {:else if hasRenderableParts(message)}
-                              <div class="message-parts">
-                                {#each renderableParts(message) as part}
-                                  {#if isImagePart(part)}
-                                    <img class="trace-image" src={imageSrc(part)} alt={imageAlt(part)} />
-                                  {:else}
-                                    <pre class="message-content">{JSON.stringify(part, null, 2)}</pre>
-                                  {/if}
-                                {/each}
-                              </div>
-                            {/if}
-
-                            {#if message.tool_calls?.length}
-                              <div class="tool-blocks">
-                                {#each message.tool_calls as toolCall}
-                                  <pre class="tool-block">{JSON.stringify(toolCall, null, 2)}</pre>
-                                {/each}
-                              </div>
-                            {/if}
-
-                            {#if message.function_call}
-                              <pre class="tool-block">{JSON.stringify(message.function_call, null, 2)}</pre>
-                            {/if}
-                          </div>
-                        {/each}
-                      </div>
+                          {/each}
+                        </div>
+                      </details>
                     </div>
                   </td>
                 </tr>
@@ -548,7 +732,7 @@
   .traces-table-wrap {
     border: 1px solid var(--border-color-primary, #e5e7eb);
     border-radius: var(--radius-lg, 8px);
-    overflow: hidden;
+    overflow-x: auto;
     transition: opacity 0.15s ease;
   }
   .traces-table-wrap.dim {
@@ -556,24 +740,31 @@
   }
   .traces-table {
     width: 100%;
+    min-width: 850px;
     border-collapse: collapse;
     font-size: 14px;
     table-layout: fixed;
   }
   .trace-id-col {
-    width: 140px;
+    width: 105px;
   }
   .request-col {
     width: auto;
   }
   .run-col {
-    width: 180px;
+    width: 135px;
   }
   .step-col {
+    width: 58px;
+  }
+  .status-col {
+    width: 78px;
+  }
+  .metric-col {
     width: 76px;
   }
   .request-time-col {
-    width: 150px;
+    width: 112px;
   }
   .traces-table th {
     text-align: left;
@@ -616,12 +807,52 @@
     -webkit-box-orient: vertical;
     overflow: hidden;
   }
+  .metric-cell {
+    font-variant-numeric: tabular-nums;
+    white-space: nowrap;
+  }
+  .status-pill {
+    display: inline-flex;
+    align-items: center;
+    border-radius: 999px;
+    background: #dcfce7;
+    color: #166534;
+    font-size: 11px;
+    font-weight: 600;
+    line-height: 1;
+    padding: 5px 8px;
+    text-transform: capitalize;
+  }
+  .status-pill.status-error {
+    background: #fee2e2;
+    color: #991b1b;
+  }
   .expanded-row td {
     padding: 0;
     background: var(--background-fill-secondary, #fafafa);
   }
   .trace-detail {
     padding: 16px 18px 18px;
+  }
+  .trace-summary {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-wrap: wrap;
+    margin-bottom: 10px;
+  }
+  .trace-summary > span:not(.status-pill),
+  .operation-badges > span:not(.status-pill) {
+    border: 1px solid var(--border-color-primary, #e5e7eb);
+    border-radius: 999px;
+    background: var(--background-fill-primary, white);
+    color: var(--body-text-color-subdued, #6b7280);
+    font-size: 12px;
+    padding: 5px 9px;
+  }
+  .trace-summary strong {
+    color: var(--body-text-color, #1f2937);
+    font-weight: 600;
   }
   .detail-meta {
     display: flex;
@@ -630,6 +861,217 @@
     color: var(--body-text-color-subdued, #6b7280);
     font-size: 13px;
     margin-bottom: 14px;
+  }
+  .trace-inspector {
+    display: grid;
+    grid-template-columns: minmax(280px, 34%) minmax(0, 1fr);
+    min-height: 390px;
+    margin-bottom: 16px;
+    overflow: hidden;
+    border: 1px solid var(--border-color-primary, #e5e7eb);
+    border-radius: var(--radius-lg, 8px);
+    background: var(--background-fill-primary, white);
+  }
+  .execution-panel {
+    min-width: 0;
+    border-right: 1px solid var(--border-color-primary, #e5e7eb);
+    background: var(--background-fill-secondary, #f9fafb);
+  }
+  .panel-title {
+    padding: 12px 14px;
+    border-bottom: 1px solid var(--border-color-primary, #e5e7eb);
+    color: var(--body-text-color-subdued, #6b7280);
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+  .execution-tree {
+    padding: 6px;
+  }
+  .span-row {
+    display: flex;
+    align-items: stretch;
+    min-width: 0;
+    padding-left: calc(var(--span-depth) * 18px);
+    border-radius: var(--radius-md, 6px);
+  }
+  .span-row:hover,
+  .span-row.span-selected {
+    background: var(--background-fill-primary, white);
+  }
+  .span-row.span-selected {
+    box-shadow: inset 3px 0 0 var(--color-accent, #7c3aed);
+  }
+  .span-collapse,
+  .span-select {
+    border: 0;
+    background: transparent;
+    color: inherit;
+    cursor: pointer;
+    font-family: inherit;
+  }
+  .span-collapse {
+    flex: 0 0 24px;
+    padding: 0;
+    color: var(--body-text-color-subdued, #6b7280);
+    font-size: 12px;
+  }
+  .span-collapse.collapse-hidden {
+    visibility: hidden;
+  }
+  .span-select {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    min-width: 0;
+    flex: 1;
+    padding: 9px 8px 9px 0;
+    text-align: left;
+  }
+  .span-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 20px;
+    height: 20px;
+    flex: 0 0 20px;
+    border-radius: 5px;
+    background: #ede9fe;
+    color: #7c3aed;
+    font-size: 12px;
+  }
+  .span-icon-tool {
+    background: #ffedd5;
+    color: #c2410c;
+  }
+  .span-icon-generation {
+    background: #fce7f3;
+    color: #be185d;
+  }
+  .span-name {
+    min-width: 0;
+    flex: 1;
+    overflow: hidden;
+    color: var(--body-text-color, #1f2937);
+    font-size: 13px;
+    font-weight: 500;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .span-duration {
+    color: var(--body-text-color-subdued, #6b7280);
+    font-size: 11px;
+    font-variant-numeric: tabular-nums;
+    white-space: nowrap;
+  }
+  .span-error-dot {
+    width: 7px;
+    height: 7px;
+    flex: 0 0 7px;
+    border-radius: 50%;
+    background: #dc2626;
+  }
+  .operation-panel {
+    min-width: 0;
+    padding: 18px;
+  }
+  .operation-header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 16px;
+    padding-bottom: 14px;
+    border-bottom: 1px solid var(--border-color-primary, #e5e7eb);
+  }
+  .operation-kind {
+    margin-bottom: 3px;
+    color: var(--body-text-color-subdued, #6b7280);
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+  }
+  .operation-header h3 {
+    margin: 0;
+    color: var(--body-text-color, #1f2937);
+    font-size: 18px;
+  }
+  .operation-badges,
+  .operation-meta {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-wrap: wrap;
+  }
+  .operation-meta {
+    margin: 12px 0;
+    color: var(--body-text-color-subdued, #6b7280);
+    font-size: 12px;
+  }
+  .operation-meta strong {
+    color: var(--body-text-color, #1f2937);
+    font-weight: 600;
+  }
+  .io-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 12px;
+  }
+  .io-grid section {
+    min-width: 0;
+  }
+  .io-grid h4 {
+    margin: 0 0 6px;
+    color: var(--body-text-color-subdued, #6b7280);
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+  .io-grid pre,
+  .span-metadata pre {
+    max-height: 250px;
+    min-height: 96px;
+    margin: 0;
+    overflow: auto;
+    border: 1px solid var(--border-color-primary, #e5e7eb);
+    border-radius: var(--radius-md, 6px);
+    background: var(--background-fill-secondary, #f9fafb);
+    color: var(--body-text-color, #1f2937);
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    font-size: 12px;
+    line-height: 1.5;
+    padding: 10px;
+    white-space: pre-wrap;
+    word-break: break-word;
+  }
+  .io-grid pre.error-output {
+    border-color: #fecaca;
+    background: #fef2f2;
+    color: #991b1b;
+  }
+  .span-metadata {
+    margin-top: 12px;
+  }
+  .span-metadata summary,
+  .conversation-section > summary {
+    cursor: pointer;
+    color: var(--body-text-color-subdued, #6b7280);
+    font-size: 13px;
+    font-weight: 600;
+  }
+  .operation-empty {
+    padding: 40px 16px;
+    color: var(--body-text-color-subdued, #6b7280);
+    text-align: center;
+  }
+  .conversation-section {
+    border-top: 1px solid var(--border-color-primary, #e5e7eb);
+    padding-top: 12px;
+  }
+  .conversation-section > summary {
+    margin-bottom: 12px;
   }
   .conversation {
     display: flex;
@@ -750,6 +1192,20 @@
     }
     .count {
       margin-left: 0;
+    }
+    .run-col,
+    .status-col {
+      width: 100px;
+    }
+  }
+  @media (max-width: 850px) {
+    .trace-inspector,
+    .io-grid {
+      grid-template-columns: 1fr;
+    }
+    .execution-panel {
+      border-right: 0;
+      border-bottom: 1px solid var(--border-color-primary, #e5e7eb);
     }
   }
 </style>

--- a/trackio/logbook_trace.py
+++ b/trackio/logbook_trace.py
@@ -5,11 +5,15 @@ import os
 import re
 import shutil
 import tempfile
-import uuid
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 from urllib.parse import quote
+
+from trackio import agent_sessions
+from trackio.agent_sessions import is_hub_native_jsonl as _is_hub_native_jsonl
+from trackio.agent_sessions import parse_time as _parse_time
+from trackio.agent_sessions import safe_id as _safe_id
 
 TRACE_SCHEMA_VERSION = 1
 TRACE_CHUNK_SIZE = 200
@@ -191,11 +195,6 @@ def _load_registry(proj: Path) -> dict:
 
 def _save_registry(proj: Path, data: dict) -> None:
     _write_json(_registry_path(proj), data)
-
-
-def _safe_id(value: str) -> str:
-    cleaned = re.sub(r"[^a-zA-Z0-9._-]+", "-", value).strip("-.")
-    return cleaned[:100] or f"session-{uuid.uuid4().hex[:12]}"
 
 
 def _records(path: Path) -> list[dict]:
@@ -786,25 +785,6 @@ def _normalize_generic(records: list[dict]) -> tuple[dict, list[dict]]:
     return meta, events
 
 
-def _parse_time(value: str | int | float | None) -> datetime | None:
-    if value in (None, ""):
-        return None
-    if isinstance(value, (int, float)) or (
-        isinstance(value, str) and re.fullmatch(r"\d+(?:\.\d+)?", value)
-    ):
-        numeric = float(value)
-        if numeric > 10_000_000_000:
-            numeric /= 1000
-        try:
-            return datetime.fromtimestamp(numeric, tz=timezone.utc)
-        except (OverflowError, OSError, ValueError):
-            return None
-    try:
-        return datetime.fromisoformat(str(value).replace("Z", "+00:00"))
-    except ValueError:
-        return None
-
-
 def normalize_trace(path: Path) -> dict:
     records = _records(path)
     provider = _detect_provider(records)
@@ -1316,102 +1296,80 @@ def read_generated(proj: Path) -> dict:
     }
 
 
-def _sts_timestamp(value: str | None) -> int | None:
-    parsed = _parse_time(value)
-    return int(parsed.timestamp() * 1000) if parsed else None
-
-
-def _sts_arguments(value: Any) -> str:
-    if not isinstance(value, str):
-        return json.dumps(value if value is not None else {})
-    try:
-        json.loads(value)
-        return value
-    except json.JSONDecodeError:
-        return json.dumps({"input": value}, ensure_ascii=False)
-
-
-def _is_hub_native_jsonl(path: Path, provider: str | None) -> bool:
-    """Whether Hub's Agent Traces viewer accepts this JSONL without conversion."""
-    if path.suffix.lower() != ".jsonl":
-        return False
-    if provider in {"Codex", "Claude Code", "Pi"}:
-        return True
-    try:
-        with path.open(encoding="utf-8") as handle:
-            first_line = next((line for line in handle if line.strip()), "")
-        header = json.loads(first_line)
-    except (OSError, json.JSONDecodeError):
-        return False
-    if not isinstance(header, dict) or header.get("type") != "session":
-        return False
-    # Session Trace Simple Format requires harness + id. Pi's native format uses
-    # a versioned session header and is also supported directly by the Hub.
-    return bool(
-        header.get("id")
-        and (header.get("harness") or header.get("version") is not None)
+def _write_agent_session(path: Path, index: dict, events: list[dict]) -> None:
+    """Convert normalized logbook events into a Hub-renderable agent session."""
+    session_id = index["id"]
+    chain = agent_sessions._Chain(
+        session_id, agent_sessions.iso_z(index.get("started_at"))
     )
 
+    if index.get("model"):
+        chain.add(
+            {
+                "type": "model_change",
+                "id": agent_sessions.entry_id(session_id, "model"),
+                "modelId": str(index["model"]),
+            },
+            index.get("started_at"),
+        )
 
-def _write_sts_trace(path: Path, index: dict, events: list[dict]) -> None:
-    records = [
-        {
-            "type": "session",
-            "harness": "trackio",
-            "id": index["id"],
-            "name": index.get("title") or index["id"],
-        }
-    ]
-    for event in events:
-        timestamp = _sts_timestamp(event.get("timestamp"))
-        if event.get("kind") in {"user", "assistant"}:
+    for position, event in enumerate(events):
+        kind = event.get("kind")
+        timestamp = event.get("timestamp")
+        text = event.get("text") or ""
+
+        if kind in {"user", "assistant"}:
             message = {
-                "role": event["kind"],
-                "content": event.get("text") or "",
+                "role": kind,
+                "content": [agent_sessions.text_block(text)] if text else [],
             }
-        elif event.get("kind") == "reasoning":
+        elif kind == "reasoning":
             message = {
                 "role": "assistant",
-                "content": "",
-                "reasoningContent": event.get("text") or "",
+                "content": [agent_sessions.thinking_block(text)],
             }
-        elif event.get("kind") == "tool_call":
+        elif kind == "tool_call":
+            call_id = str(event.get("call_id") or event.get("id") or position)
             message = {
                 "role": "assistant",
-                "content": "",
-                "toolCalls": [
-                    {
-                        "id": event.get("call_id") or event.get("id"),
-                        "function": {
-                            "name": event.get("tool_name")
-                            or event.get("title")
-                            or "tool",
-                            "arguments": _sts_arguments(event.get("input")),
-                        },
-                    }
+                "content": [
+                    agent_sessions.tool_call_block(
+                        call_id,
+                        event.get("tool_name") or event.get("title") or "tool",
+                        event.get("input"),
+                    )
                 ],
             }
-        elif event.get("kind") == "tool_result":
+        elif kind == "tool_result":
             message = {
-                "role": "tool",
-                "content": event.get("output") or event.get("text") or "",
+                "role": "toolResult",
+                "toolCallId": str(event.get("call_id") or position),
+                "toolName": str(event.get("tool_name") or event.get("title") or "tool"),
+                "content": [agent_sessions.text_block(event.get("output") or text)],
             }
-            if event.get("call_id"):
-                message["toolCallId"] = event["call_id"]
+            if event.get("is_error") or str(event.get("status") or "").lower() in {
+                "error",
+                "failed",
+            }:
+                message["isError"] = True
         else:
             message = {
-                "role": "system",
-                "content": event.get("title") or event.get("status") or "Status",
+                "role": "developer",
+                "content": [
+                    agent_sessions.text_block(
+                        event.get("title") or event.get("status") or "Status"
+                    )
+                ],
             }
-        if timestamp is not None:
-            message["timestamp"] = timestamp
-        if message["role"] == "assistant" and index.get("model"):
-            message["model"] = index["model"]
-        records.append({"type": "message", "message": message})
-    path.write_text(
-        "\n".join(json.dumps(record, ensure_ascii=False) for record in records) + "\n",
-        encoding="utf-8",
+        chain.message(position, message, timestamp)
+
+    header = agent_sessions.session_header(
+        session_id,
+        timestamp=index.get("started_at"),
+        name=index.get("title") or session_id,
+        cwd=index.get("cwd") or "/",
     )
+    agent_sessions.write_session(path, [header, *chain.records])
 
 
 def prepare_agent_trace_dataset(proj: Path) -> tuple[Path, int]:
@@ -1440,7 +1398,7 @@ def prepare_agent_trace_dataset(proj: Path) -> tuple[Path, int]:
             for chunk in index.get("chunks") or []:
                 chunk_data = _read_json(proj / "logbook" / chunk["file"], {})
                 events.extend(chunk_data.get("events") or [])
-            _write_sts_trace(destination, index, events)
+            _write_agent_session(destination, index, events)
         exported += 1
 
     # Keep the Hub-native JSONL files at the dataset root for the Agent Traces

--- a/trackio/run.py
+++ b/trackio/run.py
@@ -123,6 +123,7 @@ class Run:
         self._last_bucket_flush: float | None = None
         self._spilled_metric_ids: set[int] = set()
         self._spilled_system_ids: set[int] = set()
+        self._spilled_trace_ids: set[str] = set()
         self.id = run_id or uuid.uuid4().hex
         self._existing_runs = existing_runs
         self._initial_last_step = initial_last_step
@@ -797,13 +798,21 @@ class Run:
     def _flush_local_buffer(self) -> bool:
         try:
             buffered_logs = SQLiteStorage.get_pending_logs(self.project)
-            if buffered_logs:
+            buffered_traces = SQLiteStorage.get_pending_traces(self.project)
+            if buffered_logs or buffered_traces:
                 self._client.predict(
                     api_name="/bulk_log",
-                    logs=buffered_logs["logs"],
+                    logs=self._pending_entries_with_traces(
+                        buffered_logs, buffered_traces
+                    ),
                     hf_token=self._hf_token_for_remote(),
                 )
-                SQLiteStorage.clear_pending_logs(self.project, buffered_logs["ids"])
+                if buffered_logs:
+                    SQLiteStorage.clear_pending_logs(self.project, buffered_logs["ids"])
+                if buffered_traces:
+                    SQLiteStorage.clear_pending_traces(
+                        self.project, buffered_traces["ids"]
+                    )
 
             buffered_sys = SQLiteStorage.get_pending_system_logs(self.project)
             if buffered_sys:
@@ -839,6 +848,107 @@ class Run:
             for entry_id, entry in zip(pending["ids"], pending["logs"])
             if entry_id not in spilled_ids
         ]
+
+    def _unspilled_entries_with_traces(
+        self, pending: dict | None, pending_traces: dict | None
+    ) -> list[dict]:
+        fresh_logs = None
+        if pending:
+            keep = [
+                (entry_id, entry)
+                for entry_id, entry in zip(pending["ids"], pending["logs"])
+                if entry_id not in self._spilled_metric_ids
+            ]
+            if keep:
+                fresh_logs = {
+                    "ids": [entry_id for entry_id, _ in keep],
+                    "logs": [entry for _, entry in keep],
+                }
+        fresh_traces = None
+        if pending_traces:
+            keep_traces = [
+                trace
+                for trace_id, trace in zip(
+                    pending_traces["ids"], pending_traces["traces"]
+                )
+                if trace_id not in self._spilled_trace_ids
+            ]
+            if keep_traces:
+                fresh_traces = {"traces": keep_traces}
+        return self._pending_entries_with_traces(fresh_logs, fresh_traces)
+
+    @staticmethod
+    def _restore_trace_key(metrics: dict, key: str, traces: list[dict]) -> None:
+        """Put one key's buffered traces back where `trackio.log()` had them.
+
+        A trace's `trace_index` is the position it held in the original list
+        value and it determines the trace's stored id, so indices are preserved
+        exactly; any non-trace items the key kept fill the remaining slots.
+        """
+        indexed = {
+            trace["trace_index"]: trace["payload"]
+            for trace in traces
+            if trace["trace_index"] is not None
+        }
+        if not indexed:
+            metrics[key] = traces[-1]["payload"]
+            return
+
+        kept = metrics.get(key)
+        if isinstance(kept, list):
+            leftovers = list(kept)
+        elif kept is None:
+            leftovers = []
+        else:
+            leftovers = [kept]
+
+        rebuilt: list = [indexed.get(i) for i in range(max(indexed) + 1)]
+        spare = iter(leftovers)
+        for position, value in enumerate(rebuilt):
+            if value is None:
+                rebuilt[position] = next(spare, None)
+        metrics[key] = rebuilt + list(spare)
+
+    def _pending_entries_with_traces(
+        self, pending: dict | None, pending_traces: dict | None
+    ) -> list[dict]:
+        """Fold buffered traces back into the log entries they were logged with.
+
+        Traces live in their own table, so the buffered `metrics` row for a
+        `trackio.log()` call no longer holds them. Rebuilding the original
+        payload lets traces replay through `/bulk_log` and the metric fragment
+        path unchanged, and keeps `log_id` deduplication correct: there is
+        exactly one record per call, carrying both its scalars and its traces.
+        """
+        entries = [dict(entry) for entry in (pending["logs"] if pending else [])]
+        for entry in entries:
+            entry["metrics"] = dict(entry.get("metrics") or {})
+        by_log_id = {entry["log_id"]: entry for entry in entries if entry.get("log_id")}
+
+        grouped: dict[int, dict[str, list[dict]]] = {}
+        order: list[dict] = []
+        for trace in (pending_traces or {}).get("traces", []):
+            entry = by_log_id.get(trace["log_id"]) if trace["log_id"] else None
+            if entry is None:
+                entry = {
+                    "project": trace["project"],
+                    "run": trace["run"],
+                    "run_id": trace["run_id"],
+                    "metrics": {},
+                    "step": trace["step"],
+                    "timestamp": trace["timestamp"],
+                    "config": None,
+                    "log_id": trace["log_id"],
+                }
+                order.append(entry)
+                if trace["log_id"]:
+                    by_log_id[trace["log_id"]] = entry
+            grouped.setdefault(id(entry), {}).setdefault(trace["key"], []).append(trace)
+
+        for entry in entries + order:
+            for key, traces in grouped.get(id(entry), {}).items():
+                self._restore_trace_key(entry["metrics"], key, traces)
+        return entries + order
 
     def _flush_pending_uploads_to_bucket(self) -> None:
         pending = SQLiteStorage.get_pending_uploads(self.project)
@@ -877,13 +987,17 @@ class Run:
         """
         try:
             pending = SQLiteStorage.get_pending_logs(self.project)
-            entries = self._unspilled_pending(pending, self._spilled_metric_ids)
+            pending_traces = SQLiteStorage.get_pending_traces(self.project)
+            entries = self._unspilled_entries_with_traces(pending, pending_traces)
             if entries:
                 records = self._attach_run_config(
                     [fragments.metric_record(entry) for entry in entries]
                 )
                 self._fragment_writer.write_to_bucket(records, self._bucket_id)
-                self._spilled_metric_ids.update(pending["ids"])
+                if pending:
+                    self._spilled_metric_ids.update(pending["ids"])
+                if pending_traces:
+                    self._spilled_trace_ids.update(pending_traces["ids"])
 
             pending_sys = SQLiteStorage.get_pending_system_logs(self.project)
             entries = self._unspilled_pending(pending_sys, self._spilled_system_ids)
@@ -904,15 +1018,22 @@ class Run:
             return
         try:
             pending = SQLiteStorage.get_pending_logs(self.project)
-            if pending:
-                entries = self._unspilled_pending(pending, self._spilled_metric_ids)
+            pending_traces = SQLiteStorage.get_pending_traces(self.project)
+            if pending or pending_traces:
+                entries = self._unspilled_entries_with_traces(pending, pending_traces)
                 if entries:
                     records = self._attach_run_config(
                         [fragments.metric_record(entry) for entry in entries]
                     )
                     self._fragment_writer.write_to_bucket(records, self._bucket_id)
-                SQLiteStorage.clear_pending_logs(self.project, pending["ids"])
-                self._spilled_metric_ids.update(pending["ids"])
+                if pending:
+                    SQLiteStorage.clear_pending_logs(self.project, pending["ids"])
+                    self._spilled_metric_ids.update(pending["ids"])
+                if pending_traces:
+                    SQLiteStorage.clear_pending_traces(
+                        self.project, pending_traces["ids"]
+                    )
+                    self._spilled_trace_ids.update(pending_traces["ids"])
 
             pending_sys = SQLiteStorage.get_pending_system_logs(self.project)
             if pending_sys:

--- a/trackio/sqlite_storage.py
+++ b/trackio/sqlite_storage.py
@@ -540,10 +540,18 @@ class SQLiteStorage:
                         metadata TEXT NOT NULL,
                         search_text TEXT NOT NULL,
                         log_id TEXT,
-                        space_id TEXT
+                        space_id TEXT,
+                        spans TEXT NOT NULL DEFAULT '[]'
                     )
                     """
                 )
+
+                try:
+                    cursor.execute(
+                        "ALTER TABLE traces ADD COLUMN spans TEXT NOT NULL DEFAULT '[]'"
+                    )
+                except sqlite3.OperationalError:
+                    pass
 
                 cursor.execute(
                     """
@@ -975,7 +983,7 @@ class SQLiteStorage:
         normalized: list[dict[str, object]] = []
         for row in rows:
             new_row = dict(row)
-            for col in ("messages", "metadata"):
+            for col in ("messages", "metadata", "spans"):
                 value = new_row.get(col)
                 if value is None:
                     continue
@@ -1454,6 +1462,10 @@ class SQLiteStorage:
 
             rows = SQLiteStorage._read_parquet_rows(parquet_path)
             SQLiteStorage.init_db(project_name)
+            for row in rows:
+                row["spans"] = SQLiteStorage._normalize_json_column_value(
+                    row.get("spans") if row.get("spans") is not None else []
+                )
             SQLiteStorage._replace_table_rows(
                 db_path,
                 "traces",
@@ -1471,6 +1483,7 @@ class SQLiteStorage:
                     "search_text",
                     "log_id",
                     "space_id",
+                    "spans",
                 ],
             )
 
@@ -2585,6 +2598,7 @@ class SQLiteStorage:
                     "trace_index": trace_index,
                     "messages": trace.get("messages", []),
                     "metadata": trace.get("metadata", {}),
+                    "spans": trace.get("spans", []),
                     "log_id": log_id,
                     "space_id": space_id,
                 }
@@ -2603,8 +2617,8 @@ class SQLiteStorage:
         cursor.executemany(
             """
             INSERT OR IGNORE INTO traces
-            (id, run_id, timestamp, run_name, step, key, trace_index, messages, metadata, search_text, log_id, space_id)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            (id, run_id, timestamp, run_name, step, key, trace_index, messages, metadata, search_text, log_id, space_id, spans)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             [
                 (
@@ -2620,6 +2634,7 @@ class SQLiteStorage:
                     row["search_text"],
                     row["log_id"],
                     row["space_id"],
+                    orjson.dumps(serialize_values(row["spans"])),
                 )
                 for row in trace_rows
             ],
@@ -2644,6 +2659,7 @@ class SQLiteStorage:
 
         visit(trace.get("messages", []))
         visit(trace.get("metadata", {}))
+        visit(trace.get("spans", []))
         return " ".join(parts).lower()
 
     @staticmethod
@@ -2684,6 +2700,7 @@ class SQLiteStorage:
                         "timestamp": timestamp,
                         "messages": candidate.get("messages", []),
                         "metadata": candidate.get("metadata", {}),
+                        "spans": candidate.get("spans", []),
                     }
                     trace_record["_search_text"] = (
                         f"{trace_record['id']} {key} "
@@ -2761,8 +2778,10 @@ class SQLiteStorage:
                         where.append("search_text LIKE ?")
                         params.append(f"%{needle}%")
 
+                has_spans = "spans" in SQLiteStorage._table_columns(conn, "traces")
+                spans_select = ", spans" if has_spans else ""
                 query = f"""
-                    SELECT id, key, trace_index, run_name, run_id, step, timestamp, messages, metadata
+                    SELECT id, key, trace_index, run_name, run_id, step, timestamp, messages, metadata{spans_select}
                     FROM traces
                     WHERE {" AND ".join(where)}
                     ORDER BY {order_by}
@@ -2795,6 +2814,11 @@ class SQLiteStorage:
                 "timestamp": row["timestamp"],
                 "messages": deserialize_values(orjson.loads(row["messages"])),
                 "metadata": deserialize_values(orjson.loads(row["metadata"])),
+                "spans": (
+                    deserialize_values(orjson.loads(row["spans"]))
+                    if "spans" in row.keys()
+                    else []
+                ),
             }
             for row in rows
         ]
@@ -3375,12 +3399,16 @@ class SQLiteStorage:
         for row in trace_rows:
             messages = deserialize_values(orjson.loads(row["messages"]))
             metadata = deserialize_values(orjson.loads(row["metadata"]))
+            spans = deserialize_values(
+                orjson.loads(row["spans"] if "spans" in row.keys() else b"[]")
+            )
             messages = SQLiteStorage._update_media_paths(
                 messages, old_prefix, new_prefix
             )
             metadata = SQLiteStorage._update_media_paths(
                 metadata, old_prefix, new_prefix
             )
+            spans = SQLiteStorage._update_media_paths(spans, old_prefix, new_prefix)
             result.append(
                 (
                     row["id"],
@@ -3395,6 +3423,7 @@ class SQLiteStorage:
                     row["search_text"],
                     row["log_id"],
                     row["space_id"],
+                    orjson.dumps(serialize_values(spans)),
                 )
             )
         return result
@@ -3431,6 +3460,11 @@ class SQLiteStorage:
         with SQLiteStorage._get_process_lock(project):
             with SQLiteStorage._get_connection(db_path) as conn:
                 cursor = conn.cursor()
+                trace_columns = SQLiteStorage._table_columns(conn, "traces")
+                if trace_columns and "spans" not in trace_columns:
+                    cursor.execute(
+                        "ALTER TABLE traces ADD COLUMN spans TEXT NOT NULL DEFAULT '[]'"
+                    )
                 supports_run_ids = SQLiteStorage._supports_run_ids(conn)
                 run_identity = SQLiteStorage._resolve_run_identity(
                     conn, run_name=old_name, run_id=run_id
@@ -3540,7 +3574,7 @@ class SQLiteStorage:
                     try:
                         cursor.execute(
                             f"""
-                            SELECT id, run_id, timestamp, step, key, trace_index, messages, metadata, search_text, log_id, space_id
+                            SELECT id, run_id, timestamp, step, key, trace_index, messages, metadata, search_text, log_id, space_id, spans
                             FROM traces WHERE {run_col} = ?
                             """,
                             (run_value,),
@@ -3559,8 +3593,8 @@ class SQLiteStorage:
                         cursor.executemany(
                             """
                             INSERT INTO traces
-                            (id, run_id, timestamp, run_name, step, key, trace_index, messages, metadata, search_text, log_id, space_id)
-                            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                            (id, run_id, timestamp, run_name, step, key, trace_index, messages, metadata, search_text, log_id, space_id, spans)
+                            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                             """,
                             updated_trace_rows,
                         )
@@ -3724,9 +3758,16 @@ class SQLiteStorage:
                     if traces_identity is not None:
                         try:
                             traces_col, traces_val = traces_identity
+                            source_has_trace_spans = (
+                                "spans"
+                                in SQLiteStorage._table_columns(source_conn, "traces")
+                            )
+                            trace_spans_select = (
+                                ", spans" if source_has_trace_spans else ""
+                            )
                             source_cursor.execute(
                                 f"""
-                                SELECT id, run_id, timestamp, step, key, trace_index, messages, metadata, search_text, log_id, space_id
+                                SELECT id, run_id, timestamp, step, key, trace_index, messages, metadata, search_text, log_id, space_id{trace_spans_select}
                                 FROM traces WHERE {traces_col} = ?
                                 """,
                                 (traces_val,),
@@ -3977,8 +4018,8 @@ class SQLiteStorage:
                                 target_cursor.executemany(
                                     """
                                     INSERT OR IGNORE INTO traces
-                                    (id, run_id, timestamp, run_name, step, key, trace_index, messages, metadata, search_text, log_id, space_id)
-                                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                                    (id, run_id, timestamp, run_name, step, key, trace_index, messages, metadata, search_text, log_id, space_id, spans)
+                                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                                     """,
                                     updated_trace_rows,
                                 )

--- a/trackio/sqlite_storage.py
+++ b/trackio/sqlite_storage.py
@@ -65,6 +65,8 @@ _SQL_IN_CHUNK = 500
 _READ_ONLY_PRAGMAS = frozenset(
     {"table_info", "table_xinfo", "index_list", "index_info", "index_xinfo"}
 )
+SEARCHABLE_SPAN_FIELDS = ("id", "name", "kind", "model", "status", "error", "metadata")
+TRACE_PAYLOAD_TYPE = "trackio.trace"
 
 
 def _env_pragma_choice(name: str, whitelist: frozenset[str]) -> str | None:
@@ -2547,7 +2549,7 @@ class SQLiteStorage:
 
     @staticmethod
     def _is_trace_payload(value: Any) -> bool:
-        return isinstance(value, dict) and value.get("_type") == "trackio.trace"
+        return isinstance(value, dict) and value.get("_type") == TRACE_PAYLOAD_TYPE
 
     @staticmethod
     def _split_trace_metrics(
@@ -2642,6 +2644,13 @@ class SQLiteStorage:
 
     @staticmethod
     def _flatten_trace_search_text(trace: dict[str, Any]) -> str:
+        """Flatten a trace into the text that backs trace search.
+
+        Span `input` and `output` payloads are deliberately excluded: they
+        routinely repeat the whole conversation for every generation, so
+        indexing them can multiply a trace's on-disk size several times over
+        for little search value.
+        """
         parts: list[str] = []
 
         def visit(value: Any):
@@ -2659,7 +2668,12 @@ class SQLiteStorage:
 
         visit(trace.get("messages", []))
         visit(trace.get("metadata", {}))
-        visit(trace.get("spans", []))
+        for span in trace.get("spans") or []:
+            if not isinstance(span, dict):
+                visit(span)
+                continue
+            for field in SEARCHABLE_SPAN_FIELDS:
+                visit(span.get(field))
         return " ".join(parts).lower()
 
     @staticmethod
@@ -4341,6 +4355,14 @@ class SQLiteStorage:
             except sqlite3.OperationalError:
                 pass
             try:
+                cursor.execute(
+                    "SELECT EXISTS(SELECT 1 FROM traces WHERE space_id IS NOT NULL LIMIT 1)"
+                )
+                if cursor.fetchone()[0]:
+                    return True
+            except sqlite3.OperationalError:
+                pass
+            try:
                 cursor.execute("SELECT EXISTS(SELECT 1 FROM pending_uploads LIMIT 1)")
                 if cursor.fetchone()[0]:
                     return True
@@ -4413,6 +4435,63 @@ class SQLiteStorage:
     @staticmethod
     def clear_pending_system_logs(project: str, metric_ids: list[int]) -> None:
         SQLiteStorage._clear_pending(project, "system_metrics", metric_ids)
+
+    @staticmethod
+    def get_pending_traces(project: str) -> dict | None:
+        """Return trace rows still buffered for a remote server.
+
+        Each entry carries the `log_id` of the `trackio.log()` call it came
+        from, so callers can fold the trace payload back into that call's
+        metrics and replay it through the normal logging path.
+        """
+        db_path = SQLiteStorage.get_project_db_path(project)
+        if not db_path.exists():
+            return None
+        with SQLiteStorage._get_connection(db_path) as conn:
+            has_spans = "spans" in SQLiteStorage._table_columns(conn, "traces")
+            spans_select = ", spans" if has_spans else ""
+            cursor = conn.cursor()
+            try:
+                cursor.execute(
+                    f"""SELECT id, run_id, run_name, step, key, trace_index, timestamp,
+                    messages, metadata, log_id, space_id{spans_select}
+                    FROM traces WHERE space_id IS NOT NULL
+                    ORDER BY timestamp, key, trace_index"""
+                )
+            except sqlite3.OperationalError:
+                return None
+            rows = cursor.fetchall()
+            if not rows:
+                return None
+            traces = []
+            ids = []
+            for row in rows:
+                payload = {
+                    "_type": TRACE_PAYLOAD_TYPE,
+                    "messages": deserialize_values(orjson.loads(row["messages"])),
+                    "metadata": deserialize_values(orjson.loads(row["metadata"])),
+                }
+                if has_spans:
+                    payload["spans"] = deserialize_values(orjson.loads(row["spans"]))
+                traces.append(
+                    {
+                        "project": project,
+                        "run": row["run_name"],
+                        "run_id": row["run_id"],
+                        "step": row["step"],
+                        "timestamp": row["timestamp"],
+                        "key": row["key"],
+                        "trace_index": row["trace_index"],
+                        "log_id": row["log_id"],
+                        "payload": payload,
+                    }
+                )
+                ids.append(row["id"])
+            return {"traces": traces, "ids": ids, "space_id": rows[0]["space_id"]}
+
+    @staticmethod
+    def clear_pending_traces(project: str, trace_ids: list[str]) -> None:
+        SQLiteStorage._clear_pending(project, "traces", trace_ids)
 
     @staticmethod
     def _clear_pending(project: str, table: str, ids: list[int]) -> None:

--- a/trackio/sqlite_storage.py
+++ b/trackio/sqlite_storage.py
@@ -44,6 +44,7 @@ from trackio.utils import (
     get_color_palette,
     on_spaces,
     project_media_dir,
+    project_trace_sessions_dir,
     serialize_values,
     warn_dataset_persistence_deprecated,
 )
@@ -1616,6 +1617,7 @@ class SQLiteStorage:
                     )
                 SQLiteStorage._insert_trace_rows(cursor, trace_rows)
                 conn.commit()
+        SQLiteStorage.write_trace_sessions(project, trace_rows)
 
     @staticmethod
     def bulk_log(
@@ -1763,6 +1765,7 @@ class SQLiteStorage:
                         )
 
                 conn.commit()
+        SQLiteStorage.write_trace_sessions(project, trace_rows)
 
     @staticmethod
     def bulk_log_system(
@@ -2643,6 +2646,35 @@ class SQLiteStorage:
                 for row in trace_rows
             ],
         )
+
+    @staticmethod
+    def write_trace_sessions(project: str, trace_rows: list[dict[str, Any]]) -> int:
+        """Write each trace as an STS session file so the Hub can render it.
+
+        These files are a rendering artifact, never the source of truth: the
+        `traces` table stays authoritative and is what every Trackio reader
+        queries. A failure here must not take a `log()` call down with it.
+        """
+        if not trace_rows:
+            return 0
+        from trackio import agent_sessions as sessions  # noqa: PLC4015
+
+        sessions_dir = project_trace_sessions_dir(project)
+        written = 0
+        for row in trace_rows:
+            try:
+                run_dir = sessions_dir / sessions.safe_id(row.get("run_name") or "run")
+                path = run_dir / sessions.trace_session_filename(row.get("id"))
+                sessions.write_session(
+                    path, sessions.trace_to_records(row, project=project)
+                )
+                written += 1
+            except Exception as e:
+                _emit_nonfatal_warning(
+                    f"Could not write trace session file for trace "
+                    f"{row.get('id')!r}: {e}"
+                )
+        return written
 
     @staticmethod
     def _flatten_trace_search_text(trace: dict[str, Any]) -> str:

--- a/trackio/trace.py
+++ b/trackio/trace.py
@@ -9,21 +9,33 @@ class Trace:
     """
     Conversational or agent-style trace payload.
 
-    Traces store OpenAI-style messages plus optional metadata. Nested Trackio
-    media objects inside messages or metadata are persisted and serialized
-    alongside the trace.
+    Traces store OpenAI-style messages, optional metadata, and optional execution
+    spans. Spans are dictionaries that describe model generations, tool calls, or
+    other operations. Nested Trackio media objects inside messages, metadata, or
+    spans are persisted and serialized alongside the trace.
     """
 
     TYPE = "trackio.trace"
 
-    def __init__(self, messages: list[dict[str, Any]], metadata: dict | None = None):
+    def __init__(
+        self,
+        messages: list[dict[str, Any]],
+        metadata: dict | None = None,
+        spans: list[dict[str, Any]] | None = None,
+    ):
         if not isinstance(messages, list) or not all(
             isinstance(message, dict) for message in messages
         ):
             raise TypeError("`messages` must be a list of dictionaries.")
+        if spans is not None and (
+            not isinstance(spans, list)
+            or not all(isinstance(span, dict) for span in spans)
+        ):
+            raise TypeError("`spans` must be a list of dictionaries.")
 
         self.messages = [dict(message) for message in messages]
         self.metadata = dict(metadata) if metadata is not None else {}
+        self.spans = [dict(span) for span in spans] if spans is not None else []
 
     def _serialize_nested_value(
         self, value: Any, project: str, run: str, step: int
@@ -47,4 +59,5 @@ class Trace:
             "_type": self.TYPE,
             "messages": self._serialize_nested_value(self.messages, project, run, step),
             "metadata": self._serialize_nested_value(self.metadata, project, run, step),
+            "spans": self._serialize_nested_value(self.spans, project, run, step),
         }

--- a/trackio/trace.py
+++ b/trackio/trace.py
@@ -7,12 +7,30 @@ from trackio.media import TrackioMedia
 
 class Trace:
     """
-    Conversational or agent-style trace payload.
+    Initializes a Trace object.
 
-    Traces store OpenAI-style messages, optional metadata, and optional execution
-    spans. Spans are dictionaries that describe model generations, tool calls, or
-    other operations. Nested Trackio media objects inside messages, metadata, or
-    spans are persisted and serialized alongside the trace.
+    Traces capture a conversational or agent-style request: OpenAI-style messages,
+    optional metadata, and optional execution spans. Spans are dictionaries that
+    describe model generations, tool calls, or other operations. Nested Trackio
+    media objects inside messages, metadata, or spans are persisted and serialized
+    alongside the trace.
+
+    Args:
+        messages (`list[dict[str, Any]]`):
+            OpenAI-style messages, e.g. `{"role": "user", "content": "..."}`.
+            Assistant messages may include `tool_calls`, and tool results may
+            include `tool_call_id`; when no `spans` are provided, the dashboard
+            pairs those into tool operations.
+        metadata (`dict`, *optional*):
+            Trace-level metadata, e.g. `session_id` or `environment`. The keys
+            `status`, `duration_ms`, `latency_ms`, and `cost_usd` are used by the
+            dashboard as trace-level fallbacks when spans do not supply them.
+        spans (`list[dict[str, Any]]`, *optional*):
+            Execution spans describing what produced the response. Each span is a
+            dictionary keyed by `id`, `name`, and `kind` (`"span"`, `"generation"`,
+            or `"tool"`), plus optional `parent_id`, `start_time`, `end_time`,
+            `duration_ms`, `status`, `error`, `input`, `output`, `model`, `usage`,
+            `cost_usd`, and `metadata`.
     """
 
     TYPE = "trackio.trace"

--- a/trackio/utils.py
+++ b/trackio/utils.py
@@ -226,6 +226,28 @@ def project_artifacts_dir(project: str) -> Path:
     return ARTIFACTS_DIR / canonical_project_name(project)
 
 
+def trace_sessions_root() -> Path:
+    """Where per-trace STS session files are written.
+
+    On a Space the bucket is mounted at the parent of `TRACKIO_DIR` (`/data`
+    with `TRACKIO_DIR=/data/trackio`), so writing a sibling `traces/` directory
+    puts the files in the bucket without adding them to the `trackio/` prefix
+    that `download_bucket_to_trackio_dir` pulls down. Trace sessions are a
+    rendering artifact for the Hub's viewer, not something a CLI user needs to
+    sync alongside the database.
+    """
+    override = os.environ.get("TRACKIO_TRACE_SESSIONS_DIR")
+    if override:
+        return Path(override)
+    if on_spaces() and TRACKIO_DIR.name == "trackio":
+        return TRACKIO_DIR.parent / "traces"
+    return TRACKIO_DIR / "traces"
+
+
+def project_trace_sessions_dir(project: str) -> Path:
+    return trace_sessions_root() / canonical_project_name(project)
+
+
 NETWORK_FILESYSTEM_TYPES = {
     "nfs",
     "nfs4",


### PR DESCRIPTION
## Short description

Adds the minimal agent-trace observability needed to inspect what happened inside a Trackio trace:

- stores a backwards-compatible `spans` payload across SQLite, Parquet/static exports, run renames, and run moves
- adds a hierarchical execution inspector with per-operation status, latency, cost, token usage, model, input/output, errors, and metadata
- derives tool operations from existing OpenAI-style messages when explicit spans are absent
- documents the span contract and aggregation semantics, with a realistic nested trace example and regression tests



https://github.com/user-attachments/assets/5b1d8316-7ae6-49b4-8903-093eca5023ee


Deployed here: https://abidlabs-pwc-chat-traces.hf.space/traces