### PR TITLE
fix: make 3D object cards behave like image cards and fix Reset camera

### DIFF
--- a/.changeset/fancy-waves-double.md
+++ b/.changeset/fancy-waves-double.md
@@ -1,0 +1,5 @@
+---
+"trackio": minor
+---
+
+feat:fix: make 3D object cards behave like image cards and fix Reset camera

--- a/tests/ui/test_media_page.py
+++ b/tests/ui/test_media_page.py
@@ -97,7 +97,9 @@ def test_media_page_shows_every_media_type(media_run):
 
         expect(page.locator(".gallery img").first).to_be_visible()
         expect(page.get_by_text("3D Objects (2)")).to_be_visible()
-        expect(page.locator(".object-card")).to_have_count(3)
+        expect(page.locator(".object-card")).to_have_count(2)
+        expect(page.locator(".object-frame.compact")).to_have_count(1)
+        expect(page.get_by_role("button", name="Open", exact=True)).to_have_count(0)
         expect(page.locator("canvas[aria-label='Interactive 3D scene']")).to_have_count(
             0
         )
@@ -121,9 +123,9 @@ def test_object3d_viewer_opens_renders_and_disposes(media_run, caption):
         page.get_by_role("button", name="Media & Tables", exact=True).click()
 
         card = page.locator(".object-card").filter(has_text=caption)
-        card.click()
-        assert card.evaluate("element => element.classList.contains('selected')")
-        card.press("Enter")
+        frame = card.locator(".object-frame")
+        assert frame.evaluate("el => getComputedStyle(el).cursor") == "zoom-in"
+        frame.click()
 
         expect(
             page.get_by_role("dialog", name=f"3D viewer for {caption}")
@@ -138,4 +140,39 @@ def test_object3d_viewer_opens_renders_and_disposes(media_run, caption):
         expect(canvas).to_have_count(0)
 
         assert errors == []
+        browser.close()
+
+
+def test_reset_camera_restores_the_initial_view(media_run):
+    with sync_playwright() as playwright:
+        browser = playwright.chromium.launch()
+        page = browser.new_page(viewport={"width": 1280, "height": 900})
+        page.set_default_timeout(15_000)
+        page.goto(media_run)
+        page.get_by_role("button", name="Media & Tables", exact=True).click()
+
+        page.locator(".object-card").filter(has_text="Direct cloud").locator(
+            ".object-frame"
+        ).click()
+        canvas = page.locator("canvas[aria-label='Interactive 3D scene']")
+        expect(canvas).to_have_count(1)
+        expect(page.locator(".status")).to_have_count(0)
+        page.wait_for_timeout(1500)
+        initial = canvas.screenshot()
+
+        box = canvas.bounding_box()
+        page.mouse.move(box["x"] + box["width"] / 2, box["y"] + box["height"] / 2)
+        page.mouse.down()
+        page.mouse.move(
+            box["x"] + box["width"] / 2 + 180, box["y"] + box["height"] / 2 + 90
+        )
+        page.mouse.up()
+        page.wait_for_timeout(1500)
+        orbited = canvas.screenshot()
+        assert orbited != initial, "dragging the canvas should orbit the camera"
+
+        page.get_by_role("button", name="Reset camera", exact=True).click()
+        page.wait_for_timeout(1500)
+        assert canvas.screenshot() == initial, "Reset camera should restore the view"
+
         browser.close()

--- a/trackio/frontend/src/components/Object3DCard.svelte
+++ b/trackio/frontend/src/components/Object3DCard.svelte
@@ -2,17 +2,9 @@
   let {
     item,
     compact = false,
-    selected = false,
     color = "#9ca3af",
-    onselect = () => {},
     onopen = () => {},
   } = $props();
-
-  function activate(event) {
-    if (event.key !== "Enter" && event.key !== " ") return;
-    event.preventDefault();
-    onopen(item);
-  }
 
   function pointSummary() {
     const original = item.original_point_count;
@@ -24,92 +16,102 @@
   }
 </script>
 
-<div
-  class:compact
-  class:selected
-  class="object-card"
-  role="button"
-  tabindex="0"
-  aria-label={`Open 3D object ${item.caption || item.key || ""}`}
-  onclick={() => onselect(item)}
-  ondblclick={() => onopen(item)}
-  onkeydown={activate}
->
-  <div class="object-preview" aria-hidden="true">
-    <svg viewBox="0 0 64 64" fill="none">
-      <path d="M32 7 53 19.5v25L32 57 11 44.5v-25L32 7Z" stroke="currentColor" stroke-width="2"/>
-      <path d="m11 19.5 21 13 21-13M32 32.5V57" stroke="currentColor" stroke-width="2"/>
-      {#if item.kind === "point_cloud" || item.kind === "gaussian_splat"}
-        <circle cx="23" cy="21" r="2.5" fill="currentColor"/>
-        <circle cx="38" cy="18" r="1.8" fill="currentColor"/>
-        <circle cx="43" cy="33" r="2.2" fill="currentColor"/>
-        <circle cx="26" cy="41" r="1.7" fill="currentColor"/>
-      {/if}
-    </svg>
-    <span>{item.format?.toUpperCase() || "3D"}</span>
-  </div>
-  <div class="object-info">
-    <div class="object-title">{item.caption || item.key || "3D object"}</div>
-    {#if item.caption && item.key}<div class="object-key">{item.key}</div>{/if}
-    <div class="object-kind">{item.kind?.replaceAll("_", " ") || "model"}</div>
-    {#if pointSummary()}<div class="object-points">{pointSummary()}</div>{/if}
+{#snippet preview()}
+  <svg viewBox="0 0 64 64" fill="none" aria-hidden="true">
+    <path d="M32 7 53 19.5v25L32 57 11 44.5v-25L32 7Z" stroke="currentColor" stroke-width="2"/>
+    <path d="m11 19.5 21 13 21-13M32 32.5V57" stroke="currentColor" stroke-width="2"/>
+    {#if item.kind === "point_cloud" || item.kind === "gaussian_splat"}
+      <circle cx="23" cy="21" r="2.5" fill="currentColor"/>
+      <circle cx="38" cy="18" r="1.8" fill="currentColor"/>
+      <circle cx="43" cy="33" r="2.2" fill="currentColor"/>
+      <circle cx="26" cy="41" r="1.7" fill="currentColor"/>
+    {/if}
+  </svg>
+  <span class="format-badge">{item.format?.toUpperCase() || "3D"}</span>
+{/snippet}
+
+{#if compact}
+  <button
+    class="object-frame compact"
+    type="button"
+    onclick={() => onopen(item)}
+    aria-label={`Open 3D object ${item.caption || item.key || ""}`}
+    title={item.caption || item.key || "3D object"}
+  >
+    {@render preview()}
+  </button>
+{:else}
+  <div class="object-card">
+    <div class="object-label">{item.key || "3D object"}</div>
+    <button
+      class="object-frame"
+      type="button"
+      onclick={() => onopen(item)}
+      aria-label={`Open 3D object ${item.caption || item.key || ""}`}
+    >
+      {@render preview()}
+    </button>
+    {#if item.caption}
+      <div class="object-caption">{item.caption}</div>
+    {/if}
+    <div class="object-kind">
+      {item.kind?.replaceAll("_", " ") || "model"}{pointSummary()
+        ? ` · ${pointSummary()}`
+        : ""}
+    </div>
     {#if item._run !== undefined}
       <div class="object-meta">
         <span class="run-dot" style:background={color}></span>
-        <span>{item._run} · step {item.step}</span>
+        <span class="meta-text">{item._run}, Step: {item.step}</span>
       </div>
     {/if}
   </div>
-  <button
-    class="open-button"
-    type="button"
-    onclick={(event) => {
-      event.stopPropagation();
-      onopen(item);
-    }}
-  >Open</button>
-</div>
+{/if}
 
 <style>
   .object-card {
-    display: grid;
-    grid-template-columns: 86px minmax(0, 1fr) auto;
-    min-height: 96px;
-    align-items: center;
-    gap: 10px;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
     padding: 8px;
     border: 1px solid var(--border-color-primary, #e5e7eb);
     border-radius: var(--radius-lg, 8px);
     background: var(--background-fill-secondary, #f9fafb);
+    overflow: hidden;
+  }
+  .object-label {
+    font-size: var(--text-sm, 12px);
+    font-weight: 500;
     color: var(--body-text-color, #1f2937);
-    cursor: pointer;
-    outline: none;
+    word-break: break-word;
   }
-  .object-card:hover,
-  .object-card:focus-visible,
-  .object-card.selected {
-    border-color: var(--primary-500, #f97316);
-    box-shadow: 0 0 0 2px color-mix(in srgb, var(--primary-500, #f97316) 18%, transparent);
-  }
-  .object-card.compact {
-    grid-template-columns: 58px minmax(100px, 1fr);
-    min-width: 220px;
-    min-height: 66px;
-    padding: 5px;
-  }
-  .object-preview {
+  .object-frame {
     position: relative;
     display: grid;
-    min-height: 78px;
+    width: 100%;
+    aspect-ratio: 4 / 3;
     place-items: center;
+    overflow: hidden;
+    border: 0;
     border-radius: var(--radius-sm, 4px);
     background: linear-gradient(145deg, #111827, #293241);
     color: #ff9f43;
+    cursor: zoom-in;
+    font: inherit;
+    padding: 0;
   }
-  .compact .object-preview { min-height: 56px; }
-  .object-preview svg { width: 54px; height: 54px; opacity: 0.9; }
-  .compact .object-preview svg { width: 40px; height: 40px; }
-  .object-preview span {
+  .object-frame.compact {
+    width: 120px;
+    height: 80px;
+    aspect-ratio: auto;
+  }
+  .object-frame svg {
+    width: 46%;
+    max-width: 64px;
+    height: auto;
+    opacity: 0.9;
+  }
+  .format-badge {
     position: absolute;
     right: 5px;
     bottom: 4px;
@@ -118,35 +120,33 @@
     font-weight: 700;
     letter-spacing: 0.08em;
   }
-  .object-info { min-width: 0; }
-  .object-title {
-    overflow: hidden;
+  .object-caption,
+  .object-kind {
     font-size: var(--text-sm, 12px);
-    font-weight: 600;
+    color: var(--body-text-color-subdued, #9ca3af);
+  }
+  .object-kind {
+    font-size: var(--text-xs, 11px);
+    text-transform: capitalize;
+  }
+  .object-meta {
+    display: flex;
+    align-items: center;
+    gap: 3px;
+    font-size: var(--text-xs, 11px);
+    color: var(--body-text-color-subdued, #9ca3af);
+    font-variant-numeric: tabular-nums;
+  }
+  .run-dot {
+    width: 8px;
+    height: 8px;
+    flex-shrink: 0;
+    border-radius: 50%;
+    margin: 0 2px;
+  }
+  .meta-text {
+    overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
   }
-  .object-key,
-  .object-kind,
-  .object-points,
-  .object-meta {
-    margin-top: 2px;
-    color: var(--body-text-color-subdued, #6b7280);
-    font-size: var(--text-xs, 11px);
-  }
-  .object-kind { text-transform: capitalize; }
-  .object-meta { display: flex; align-items: center; gap: 5px; }
-  .run-dot { width: 7px; height: 7px; flex: 0 0 auto; border-radius: 50%; }
-  .open-button {
-    align-self: end;
-    border: 1px solid var(--border-color-primary, #d1d5db);
-    border-radius: var(--radius-sm, 4px);
-    background: var(--background-fill-primary, white);
-    color: inherit;
-    cursor: pointer;
-    font: inherit;
-    font-size: 11px;
-    padding: 4px 8px;
-  }
-  .compact .open-button { display: none; }
 </style>

--- a/trackio/frontend/src/lib/object3dViewer.js
+++ b/trackio/frontend/src/lib/object3dViewer.js
@@ -1,4 +1,6 @@
 const MAX_POINT_COUNT = 300000;
+const HOME_ALPHA = Math.PI / 4;
+const HOME_BETA = Math.PI / 3;
 
 function normalizedColors(attribute, vertexCount) {
   if (!attribute) return null;
@@ -78,9 +80,19 @@ function createEnvironment(scene, modules, dark) {
   return { grid, axes };
 }
 
-function frameCamera(camera, meshes) {
+function frameCamera(camera, meshes, restoreOrientation = false) {
   const visible = meshes.filter((mesh) => mesh?.getBoundingInfo && mesh.isEnabled());
   if (!visible.length) return;
+  if (restoreOrientation) {
+    camera.alpha = HOME_ALPHA;
+    camera.beta = HOME_BETA;
+    camera.targetScreenOffset.set(0, 0);
+    camera.inertialAlphaOffset = 0;
+    camera.inertialBetaOffset = 0;
+    camera.inertialRadiusOffset = 0;
+    camera.inertialPanningX = 0;
+    camera.inertialPanningY = 0;
+  }
   camera.zoomOn(visible, true);
   camera.lowerRadiusLimit = Math.max(camera.radius * 0.01, 0.001);
   camera.upperRadiusLimit = Math.max(camera.radius * 100, 100);
@@ -144,8 +156,8 @@ export async function createObject3DViewer(canvas, item, url, updateStatus, sign
     : new core.Color4(0.93, 0.945, 0.965, 1);
   const camera = new core.ArcRotateCamera(
     "camera",
-    Math.PI / 4,
-    Math.PI / 3,
+    HOME_ALPHA,
+    HOME_BETA,
     6,
     core.Vector3.Zero(),
     scene,
@@ -206,7 +218,7 @@ export async function createObject3DViewer(canvas, item, url, updateStatus, sign
 
   return {
     resetCamera() {
-      frameCamera(camera, loadedMeshes);
+      frameCamera(camera, loadedMeshes, true);
     },
     setGridVisible(visible) {
       environment.grid.setEnabled(visible);

--- a/trackio/frontend/src/pages/Media.svelte
+++ b/trackio/frontend/src/pages/Media.svelte
@@ -41,7 +41,6 @@
   let selectedImageIndex = $state(null);
   let loading = $state(false);
   let selectedObject3D = $state(null);
-  let highlightedObjectPath = $state(null);
 
   function createVisibleCounts() {
     return {
@@ -265,10 +264,6 @@
     };
   }
 
-  function selectObject3D(object3d) {
-    highlightedObjectPath = object3d.file_path;
-  }
-
   function openObject3D(object3d, parent = null) {
     selectedObject3D = normalizeObject3D(object3d, parent);
   }
@@ -359,7 +354,7 @@
     {#snippet meta(item)}
       <div class="meta">
         <span class="run-dot" style:background={runColor(item)}></span>
-        <span class="meta-text">Run: {item._run}, Step: {item.step}</span>
+        <span class="meta-text">{item._run}, Step: {item.step}</span>
       </div>
     {/snippet}
     {#if mediaItems.images.length > 0}
@@ -444,13 +439,11 @@
           </svg>
           <span class="section-title">3D Objects ({mediaItems.object3ds.length})</span>
         </summary>
-        <div class="object-gallery">
+        <div class="gallery">
           {#each visibleMediaItems.object3ds as object3d}
             <Object3DCard
               item={object3d}
               color={runColor(object3d)}
-              selected={highlightedObjectPath === object3d.file_path}
-              onselect={() => selectObject3D(object3d)}
               onopen={() => openObject3D(object3d)}
             />
           {/each}
@@ -590,8 +583,6 @@
                             item={normalizeObject3D(cell, tbl)}
                             compact
                             color={runColor(tbl)}
-                            selected={highlightedObjectPath === cell.file_path}
-                            onselect={() => selectObject3D(cell)}
                             onopen={() => openObject3D(cell, tbl)}
                           />
                         {:else if isObject3DList(cell)}
@@ -601,8 +592,6 @@
                                 item={normalizeObject3D(object3d, tbl)}
                                 compact
                                 color={runColor(tbl)}
-                                selected={highlightedObjectPath === object3d.file_path}
-                                onselect={() => selectObject3D(object3d)}
                                 onopen={() => openObject3D(object3d, tbl)}
                               />
                             {/each}
@@ -717,7 +706,7 @@
         {/if}
         <div class="meta image-modal-meta">
           <span class="run-dot" style:background={runColor(selectedImage)}></span>
-          <span class="meta-text">Run: {selectedImage._run}, Step: {selectedImage.step}</span>
+          <span class="meta-text">{selectedImage._run}, Step: {selectedImage.step}</span>
           {#if selectedImageIndex !== null && selectedImageList.length > 1}
             <span class="image-modal-count">{selectedImageIndex + 1} / {selectedImageList.length}</span>
           {/if}
@@ -908,11 +897,6 @@
     display: grid;
     grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
     gap: 12px;
-  }
-  .object-gallery {
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
-    gap: 10px;
   }
   .table-object-list {
     display: flex;


### PR DESCRIPTION
## Short description

Two small follow-ups to #673, ahead of the release.

### 1. 3D object cards now look and behave like image cards

Previously 3D objects had their own interaction model — a horizontal card with an explicit **Open** button and an orange "selected" border. This aligns them with images/video/audio:

- **Removed the Open button.** The preview tile is now the control itself: `cursor: zoom-in` on hover and a single click opens the viewer, exactly like clicking an image.
- **Removed the selected/highlight state**, which had no behaviour attached to it.
- **Vertical layout**, so the run name and step sit underneath the preview like video and audio.
- Uses the standard `.gallery` grid instead of a wider bespoke one.
- In table cells, renders a compact 120×80 tile sized to match `.table-image-frame`.

Accessibility improves as a side effect: the card was a `role="button"` `div` with a nested `<button>` inside it, and is now a single real `<button>`, so Enter/Space work natively rather than through a hand-rolled keydown handler.

Also drops the `Run: ` prefix from the shared media meta line — it now reads `every-media-type, Step: 5`. This affects images, video, audio, html, tables and the image modal, since the coloured run dot already conveys it.

### 2. "Reset camera" was a no-op after orbiting

Babylon's `zoomOn()` → `focusOn()` only restores `radius` and `_target`; it never touches `alpha`/`beta`. Since the initial framing already set radius and target, clicking **Reset camera** after orbiting the model appeared to do nothing at all — the rotation stayed exactly where you dragged it.

Reset now also restores the home orientation, clears any pan offset (`targetScreenOffset`) and cancels in-flight inertia.

## Type of Change

- [x] Bug fix
- [ ] New feature (non-breaking)
- [ ] New feature (breaking change)
- [ ] Documentation update
- [x] Test improvements

## Testing and linting

`tests/ui/test_media_page.py` updated for the new interaction model (asserts the zoom-in cursor, that clicking the frame opens the viewer, and that no Open button exists), plus a new `test_reset_camera_restores_the_initial_view` that screenshots the canvas, drags to orbit, clicks Reset camera and asserts the view returns to the original pixels. **Verified that this test fails on `main`** and passes with the fix.

24 tests pass locally (`tests/ui/test_media_page.py` + `tests/unit/test_object3d.py`), along with the 131 frontend vitest tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)