### PR TITLE
Fix dotted metric names in line plots

### DIFF
--- a/.changeset/early-chairs-tan.md
+++ b/.changeset/early-chairs-tan.md
@@ -1,0 +1,5 @@
+---
+"trackio": minor
+---
+
+feat:Fix dotted metric names in line plots

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,18 +76,135 @@ Tests are split into unit tests (testing individual modules) and e2e tests (test
 - **Adding import formats**: Extend `imports.py` with new import functions
 - **CLI modifications**: Update `cli.py` and entry points in `pyproject.toml`
 
-## Issue Resolution Workflow
+## GitHub Issue Fix Workflow
 
-When given a GitHub issue to solve, follow this workflow:
+When asked to fix a GitHub issue and prepare a PR, use the following end-to-end
+workflow. The goal is to give reviewers observable before/after evidence, not only a
+patch and a passing unit test.
 
-1. **Create a new branch** named after the issue (e.g., `fix-issue-123` or descriptive name)
-2. **Implement the solution** following the existing code patterns and conventions
-3. **Run tests** to ensure nothing is broken: `pytest`
-4. **Run linting/formatting**: `ruff check --fix --select I && ruff format`
+### 1. Isolate the work
 
-### Git Commands for Issue Workflow
+1. Read the issue and comments with `gh issue view <number> --repo gradio-app/trackio --comments`.
+2. Fetch `origin/main` and create a dedicated worktree under
+   `../trackio-worktrees/issue-<number>` from the fetched commit.
+3. Use a branch such as `issue-<number>-<short-description>`. Avoid assuming the
+   `fix/...` namespace is available; this repository may have a branch literally named
+   `fix`.
+4. Keep reproduction programs, generated data, Space staging files, screenshots, and
+   issue metadata untracked. Never commit them with the fix.
+
+### 2. Reproduce before editing source
+
+1. Build the smallest realistic reproduction using the exact API, input, or metric name
+   from the report. Name it `demo_issue_<number>.py` when appropriate.
+2. Isolate local demo data by setting `TRACKIO_DIR` to a directory inside the worktree.
+   Include a known-good control metric or behavior when that makes the failure clearer.
+3. For frontend work, use the frontend's own lockfile and commands:
+
+   ```bash
+   cd trackio/frontend
+   npm ci
+   npm run build
+   ```
+
+   The root pnpm install does not install `trackio/frontend` development dependencies.
+4. Run the demo against the package in the worktree. `uv sync --extra dev` followed by
+   `uv run python demo_issue_<number>.py` is a convenient isolated setup.
+5. Confirm the reported failure before changing source. Inspect both sides of the data
+   path when useful: verify the API/storage contains the expected values, then verify
+   the browser or renderer loses or misrepresents them.
+6. Prefer browser verification for UI bugs. If browser automation is unavailable, use
+   the closest deterministic renderer/dataflow check, keep the live demo available for
+   manual inspection, and state the limitation explicitly.
+7. If the issue does not reproduce on current `origin/main`, stop without editing code
+   or opening a PR. Report the demo, command, observed result, and uncertainty.
+
+### 3. Fix the root cause and add regression coverage
+
+1. Keep the patch scoped to the confirmed failure and follow existing Trackio patterns.
+2. Add a regression test that exercises the actual boundary that failed. For frontend
+   renderer bugs, test the renderer/accessor semantics rather than only a string helper.
+3. Cover adjacent syntax or edge cases only when the same root cause handles them; do
+   not broaden the PR into unrelated cleanup.
+
+### 4. Verify locally
+
+Rerun the reproduction and the narrowest relevant tests, then run the complete checks
+for the changed area.
+
+For frontend changes:
+
 ```bash
-git checkout -b fix-issue-NUMBER
+cd trackio/frontend
+npm test
+npm run lint
+npm run build
 ```
 
-Always ensure tests pass and code is formatted before pushing.
+For Python changes, run the relevant pytest files and Ruff checks described above. Use
+`git diff --check` before committing. Record exact commands and any environment-related
+limitation.
+
+### 5. Prepare a focused draft PR
+
+1. Confirm temporary demo and data files are still untracked with `git status --short`.
+2. Stage and commit only the required source and test files.
+3. Do **not** create a `.changeset` manually. The Trackio GitHub workflow creates one
+   from the PR title and commits it to the branch.
+4. Push the issue branch and open a draft PR against `gradio-app/trackio`.
+5. Keep the PR body short and include:
+   - `Fixes #<number>`
+   - the root cause and fix
+   - verification commands
+   - the minimal demo in a fenced code block
+   - a note that the demo file was not committed
+6. Leave the verified local demo server running and report its URL.
+
+### 6. Drive CI to green
+
+1. Watch required checks with `gh pr checks <pr> --repo gradio-app/trackio --watch`.
+2. Treat test, lint, build, documentation, wheel, and Trackio Spaces E2E failures as
+   defects in the change until evidence shows otherwise.
+3. Before fixing a suspected unrelated failure, compare recent `main` runs or reproduce
+   it on a clean checkout. Rerun a likely flake once. Do not add unrelated fixes to the
+   issue PR.
+4. The changeset bot pushes to the PR branch. Fetch and fast-forward/rebase before any
+   later push to avoid a non-fast-forward rejection.
+5. The preview-wheel upload and its PR-comment step are separate. If the comment step
+   fails, inspect the `PR wheel preview deploy` logs; the wheel may already be uploaded
+   and its exact URL will appear in the workflow inputs.
+
+### 7. Create before/after Spaces for reviewable UI bugs
+
+When the behavior is visible in a Trackio dashboard and the demo is safe to make public,
+deploy a comparison pair such as:
+
+- `<namespace>/trackio-<issue>-before`
+- `<namespace>/trackio-<issue>-after`
+
+Use these rules:
+
+1. Upload byte-identical, ordinary `app.py` files to both Spaces. The app should show the
+   real behavior directly; do not build an in-page PASS/FAIL test harness.
+2. The only functional difference should be `requirements.txt`:
+   - before: `trackio` (latest released package)
+   - after: the exact preview-wheel URL produced by the PR workflow
+3. A minimal Trackio Space can log its demonstration data at startup and finish with
+   `trackio.show(project=...)`. Use the Gradio Space SDK, matching Trackio's own deploy
+   template.
+4. Give each Space a short README that explains what to inspect, says whether it is the
+   released or PR version, and links to the other Space.
+5. Wait for both runtimes to reach `RUNNING`. Read back `app.py` and requirements from
+   the Hub, verify the app hashes match, verify both APIs serve the same demo data, and
+   confirm the visual difference in a browser whenever one is available.
+6. Never upload credentials, private user data, or the local Trackio cache. If a public
+   demonstration is inappropriate or impossible, explain why and skip the Spaces.
+7. Add or update one PR comment containing both links and a compact before/after table.
+   Keep a stable HTML marker such as `<!-- trackio-before-after-spaces -->` so reruns can
+   update the comment instead of duplicating it.
+
+### 8. Final handoff
+
+Report the worktree, branch, untracked demo path, local demo URL, draft PR, required CI
+status, both Space URLs, what reviewers should observe, and any remaining caveat. Ask
+the reviewer to open both Spaces and confirm the visible difference.

--- a/trackio/frontend/src/components/LinePlot.svelte
+++ b/trackio/frontend/src/components/LinePlot.svelte
@@ -4,6 +4,7 @@
   import * as vega from "vega";
   import { buildColorSpecKey } from "../lib/dataProcessing.js";
   import { visibleLegendEntries } from "../lib/legend.js";
+  import { escapeVegaField } from "../lib/vega.js";
 
   let {
     data = [],
@@ -147,21 +148,28 @@
     const { originalData, smoothedData, hasSmoothed } = splitData();
     lastHasSmoothed = hasSmoothed;
     const xDomain = computeXDomain(originalData);
+    const xVegaField = escapeVegaField(x);
+    const yVegaField = escapeVegaField(y);
+    const colorVegaField = escapeVegaField(colorField);
+    const colorDisplayVegaField = escapeVegaField(
+      colorDisplayField || colorField,
+    );
+    const dashVegaField = escapeVegaField(dashField);
 
     const xEnc = {
-      field: x,
+      field: xVegaField,
       type: "quantitative",
       scale: { zero: false, ...(xDomain ? { domain: xDomain } : {}) },
     };
     const yEnc = {
-      field: y,
+      field: yVegaField,
       type: "quantitative",
       ...(yExtent ? { scale: { domain: yExtent } } : {}),
     };
     const colorEnc = hasColor
       ? {
           color: {
-            field: colorField,
+            field: colorVegaField,
             type: "nominal",
             scale: { domain: colorDomain, range: colorRange },
             legend: null,
@@ -171,7 +179,7 @@
     const dashEnc = hasDash
       ? {
           strokeDash: {
-            field: dashField,
+            field: dashVegaField,
             type: "nominal",
             scale: {
               domain: dashLegendEntries.map((entry) => entry.name),
@@ -195,21 +203,21 @@
     const tooltipEnc = [];
     if (hasColor) {
       tooltipEnc.push({
-        field: colorDisplayField || colorField,
+        field: colorDisplayVegaField,
         type: "nominal",
         title: resolvedColorLabel,
       });
     }
     if (hasDash) {
       tooltipEnc.push({
-        field: dashField,
+        field: dashVegaField,
         type: "nominal",
         title: resolvedDashLabel,
       });
     }
     tooltipEnc.push(
-      { field: x, type: "quantitative", title: x },
-      { field: y, type: "quantitative", title: yTitle },
+      { field: xVegaField, type: "quantitative", title: x },
+      { field: yVegaField, type: "quantitative", title: yTitle },
     );
 
     const hoverParams = [{

--- a/trackio/frontend/src/lib/vega.js
+++ b/trackio/frontend/src/lib/vega.js
@@ -1,3 +1,3 @@
 export function escapeVegaField(field) {
-  return field.replace(/[.\\[\]]/g, "\\$&");
+  return field.replace(/[.\\[\]'"]/g, "\\$&");
 }

--- a/trackio/frontend/src/lib/vega.js
+++ b/trackio/frontend/src/lib/vega.js
@@ -1,0 +1,3 @@
+export function escapeVegaField(field) {
+  return field.replace(/[.\\[\]]/g, "\\$&");
+}

--- a/trackio/frontend/src/lib/vega.test.js
+++ b/trackio/frontend/src/lib/vega.test.js
@@ -12,6 +12,8 @@ describe("escapeVegaField", () => {
     "trainer.compute_loss",
     "metrics[0]",
     "literal\\backslash",
+    'say "hi"',
+    "it's",
     "profiling/Time taken: GRPOTrainer.compute_loss",
   ])("makes the literal field %s accessible to Vega", (field) => {
     const row = { [field]: 0.25 };

--- a/trackio/frontend/src/lib/vega.test.js
+++ b/trackio/frontend/src/lib/vega.test.js
@@ -1,0 +1,21 @@
+import { field as vegaField } from "vega";
+import { describe, expect, test } from "vitest";
+
+import { escapeVegaField } from "./vega.js";
+
+describe("escapeVegaField", () => {
+  test("leaves simple field names unchanged", () => {
+    expect(escapeVegaField("train_loss")).toBe("train_loss");
+  });
+
+  test.each([
+    "trainer.compute_loss",
+    "metrics[0]",
+    "literal\\backslash",
+    "profiling/Time taken: GRPOTrainer.compute_loss",
+  ])("makes the literal field %s accessible to Vega", (field) => {
+    const row = { [field]: 0.25 };
+
+    expect(vegaField(escapeVegaField(field))(row)).toBe(0.25);
+  });
+});


### PR DESCRIPTION
Fixes #677.

## Summary

- Escape Vega field-path metacharacters in dynamic line-plot encodings.
- Preserve the original labels while using escaped field references for axes, series, and tooltips.
- Add regression coverage for dots, brackets, and backslashes.

## Verification

- `cd trackio/frontend && npm test`
- `cd trackio/frontend && npm run lint`
- `cd trackio/frontend && npm run build`
- `cd trackio/frontend && node repro_issue_677_vega.mjs`

## Minimal reproduction

```python
import math
import trackio

metric = "profiling/Time taken: GRPOTrainer.compute_loss"
trackio.init(project="issue-677-dotted-metric", name="trl-grpo-profile")
for step in range(12):
    trackio.log({metric: 0.25 + 0.08 * math.sin(step / 2)}, step=step)
trackio.finish()
trackio.show(project="issue-677-dotted-metric")
```

The reproduction files are intentionally untracked and were not committed.