### PR TITLE
fix: decode UTF-8 blobs in query output instead of hex-encoding

### DIFF
--- a/.changeset/query-utf8-blobs.md
+++ b/.changeset/query-utf8-blobs.md
@@ -1,0 +1,5 @@
+---
+"trackio": patch
+---
+
+fix: decode UTF-8 blobs in `trackio query` output instead of hex-encoding them, so JSON columns like `config` and `metrics` are readable

--- a/tests/unit/test_sqlite_storage.py
+++ b/tests/unit/test_sqlite_storage.py
@@ -616,9 +616,26 @@ def test_query_project_row_limit(temp_dir):
 
 def test_query_project_normalizes_bytes(temp_dir):
     SQLiteStorage.log(project="qproj", run="r1", metrics={"a": 1})
-    result = SQLiteStorage.query_project("qproj", "SELECT randomblob(4) AS b")
-    assert isinstance(result["rows"][0]["b"], str)
-    assert len(result["rows"][0]["b"]) == 8
+    result = SQLiteStorage.query_project("qproj", "SELECT x'80FF8081' AS b")
+    assert result["rows"][0]["b"] == "80ff8081"
+
+
+def test_query_project_decodes_utf8_blobs(temp_dir):
+    """JSON columns are stored as UTF-8 blobs and must come back readable."""
+    SQLiteStorage.bulk_log(
+        project="qproj",
+        run="r1",
+        metrics_list=[{"a": 1}],
+        config={"lr": 0.01, "_Group": "sweep-1"},
+    )
+    result = SQLiteStorage.query_project(
+        "qproj", "SELECT config FROM configs WHERE run_name = 'r1'"
+    )
+    config = result["rows"][0]["config"]
+    assert isinstance(config, str)
+    parsed = orjson.loads(config)
+    assert parsed["lr"] == 0.01
+    assert parsed["_Group"] == "sweep-1"
 
 
 def test_query_project_missing_project(temp_dir):

--- a/trackio/sqlite_storage.py
+++ b/trackio/sqlite_storage.py
@@ -3068,7 +3068,11 @@ class SQLiteStorage:
     @staticmethod
     def _normalize_query_value(value: Any) -> Any:
         if isinstance(value, (bytes, bytearray, memoryview)):
-            return bytes(value).hex()
+            raw = bytes(value)
+            try:
+                return raw.decode("utf-8")
+            except UnicodeDecodeError:
+                return raw.hex()
         return value
 
     @staticmethod


### PR DESCRIPTION
JSON columns (`config`, `metrics`, ...) are stored as orjson-encoded UTF-8 BLOBs, but `_normalize_query_value` hex-encodes every bytes value, so the documented query interface returns unreadable output in both table and `--json` modes:

```
$ trackio query project --project my-project --sql "SELECT config FROM configs LIMIT 1"
7b226c72223a302e30312c...
```

This is especially confusing for agents using the query path that `storage_schema.md` and the trackio skill document as a first-class access method.

**Change:** try UTF-8 decode first; fall back to hex only for genuinely binary data.

**Tests:**
- new `test_query_project_decodes_utf8_blobs` — a stored config round-trips through `query_project` as parseable JSON text
- `test_query_project_normalizes_bytes` now uses a fixed invalid-UTF-8 blob (`x'80FF8081'`) — the previous `randomblob(4)` could occasionally produce valid UTF-8 and flake under this change

All 32 tests in `tests/unit/test_sqlite_storage.py` pass locally. Found while validating the SQL recipes for the sweep docs PR.