### PR TITLE
Reduce dashboard canvas GPU memory and render churn

### DIFF
--- a/.changeset/all-donkeys-drum.md
+++ b/.changeset/all-donkeys-drum.md
@@ -1,0 +1,5 @@
+---
+"trackio": minor
+---
+
+feat:Reduce dashboard canvas GPU memory and render churn

--- a/.changeset/all-donkeys-drum.md
+++ b/.changeset/all-donkeys-drum.md
@@ -1,5 +1,5 @@
 ---
-"trackio": minor
+"trackio": patch
 ---
 
 feat:Reduce dashboard canvas GPU memory and render churn

--- a/.changeset/calm-charts-release.md
+++ b/.changeset/calm-charts-release.md
@@ -1,0 +1,5 @@
+---
+"trackio": patch
+---
+
+Reduce dashboard GPU memory and render churn by finalizing stale Vega views, rendering charts only near the viewport, and preventing overlapping metric refreshes.

--- a/tests/ui/test_ui_display.py
+++ b/tests/ui/test_ui_display.py
@@ -201,3 +201,39 @@ def test_multiple_runs_display_multiple_plots(temp_dir):
     finally:
         trackio.delete_project("test_multi", force=True)
         app.close()
+
+
+def test_metric_charts_release_canvases_outside_viewport(temp_dir):
+    trackio.init(project="test_chart_visibility", name="run")
+    for step in range(2):
+        trackio.log(metrics={f"metric_{i}": i + step for i in range(20)})
+    trackio.finish()
+
+    app, _, _, full_url = trackio.show(
+        project="test_chart_visibility", block_thread=False, open_browser=False
+    )
+
+    try:
+        with sync_playwright() as p:
+            browser = p.chromium.launch()
+            page = browser.new_page(viewport={"width": 1280, "height": 720})
+            page.set_default_timeout(10000)
+            page.goto(full_url)
+
+            plots = page.locator(".metrics-page .plot")
+            expect(plots).to_have_count(20)
+            expect(plots.first.locator("canvas")).to_have_count(1)
+
+            initial_canvas_count = page.locator(".vega-embed canvas").count()
+            assert 0 < initial_canvas_count < 20
+
+            page.locator(".metrics-page").evaluate(
+                "element => { element.scrollTop = element.scrollHeight; }"
+            )
+            expect(plots.last.locator("canvas")).to_have_count(1)
+            expect(plots.first.locator("canvas")).to_have_count(0)
+
+            browser.close()
+    finally:
+        trackio.delete_project("test_chart_visibility", force=True)
+        app.close()

--- a/tests/ui/test_ui_display.py
+++ b/tests/ui/test_ui_display.py
@@ -206,7 +206,7 @@ def test_multiple_runs_display_multiple_plots(temp_dir):
 def test_metric_charts_release_canvases_outside_viewport(temp_dir):
     trackio.init(project="test_chart_visibility", name="run")
     for step in range(2):
-        trackio.log(metrics={f"metric_{i}": i + step for i in range(20)})
+        trackio.log(metrics={f"metric_{i}": i + step for i in range(48)})
     trackio.finish()
 
     app, _, _, full_url = trackio.show(
@@ -221,15 +221,33 @@ def test_metric_charts_release_canvases_outside_viewport(temp_dir):
             page.goto(full_url)
 
             plots = page.locator(".metrics-page .plot")
-            expect(plots).to_have_count(20)
+            expect(plots).to_have_count(48)
             expect(plots.first.locator("canvas")).to_have_count(1)
+            page.wait_for_function(
+                "() => document.querySelectorAll('.vega-embed canvas').length < 48"
+            )
 
             initial_canvas_count = page.locator(".vega-embed canvas").count()
-            assert 0 < initial_canvas_count < 20
+            initial_first_height = plots.first.evaluate(
+                "element => element.getBoundingClientRect().height"
+            )
+            assert 0 < initial_canvas_count < 48
 
             page.locator(".metrics-page").evaluate(
                 "element => { element.scrollTop = element.scrollHeight; }"
             )
+            expect(plots.last.locator("canvas")).to_have_count(1)
+            expect(plots.first.locator("canvas")).to_have_count(0)
+            released_first_height = plots.first.evaluate(
+                "element => element.getBoundingClientRect().height"
+            )
+            scroll_position = page.locator(".metrics-page").evaluate(
+                "element => ({ top: element.scrollTop, max: element.scrollHeight - element.clientHeight })"
+            )
+            assert abs(released_first_height - initial_first_height) < 1
+            assert abs(scroll_position["top"] - scroll_position["max"]) < 10
+
+            page.set_viewport_size({"width": 720, "height": 900})
             expect(plots.last.locator("canvas")).to_have_count(1)
             expect(plots.first.locator("canvas")).to_have_count(0)
 

--- a/tests/ui/test_ui_display.py
+++ b/tests/ui/test_ui_display.py
@@ -223,9 +223,7 @@ def test_metric_charts_release_canvases_outside_viewport(temp_dir):
             plots = page.locator(".metrics-page .plot")
             expect(plots).to_have_count(48)
             expect(plots.first.locator("canvas")).to_have_count(1)
-            page.wait_for_function(
-                "() => document.querySelectorAll('.vega-embed canvas').length < 48"
-            )
+            expect(plots.last.locator("canvas")).to_have_count(0)
 
             initial_canvas_count = page.locator(".vega-embed canvas").count()
             initial_first_height = plots.first.evaluate(
@@ -248,6 +246,9 @@ def test_metric_charts_release_canvases_outside_viewport(temp_dir):
             assert abs(scroll_position["top"] - scroll_position["max"]) < 10
 
             page.set_viewport_size({"width": 720, "height": 900})
+            page.locator(".metrics-page").evaluate(
+                "element => { element.scrollTop = element.scrollHeight; }"
+            )
             expect(plots.last.locator("canvas")).to_have_count(1)
             expect(plots.first.locator("canvas")).to_have_count(0)
 

--- a/trackio/frontend/src/components/BarPlot.svelte
+++ b/trackio/frontend/src/components/BarPlot.svelte
@@ -2,6 +2,10 @@
   import { onMount, tick } from "svelte";
   import embed from "vega-embed";
   import { buildColorSpecKey } from "../lib/dataProcessing.js";
+  import {
+    createVegaViewManager,
+    observeNearViewport,
+  } from "../lib/chartLifecycle.js";
 
   let {
     data = [],
@@ -19,8 +23,9 @@
   let container = $state(null);
   let plotContainer = $state(null);
   let fullscreenHost = $state(null);
-  let view = $state(null);
   let fullscreen = $state(false);
+  let nearViewport = $state(false);
+  const viewManager = createVegaViewManager();
 
   let legendEntries = $derived.by(() => {
     if (!colorField || !data || data.length === 0) return [];
@@ -144,6 +149,7 @@
   }
 
   function syncViewSize() {
+    const view = viewManager.current;
     if (!view || !container) return;
     view.width(container.clientWidth);
     if (fullscreen) view.height(container.clientHeight);
@@ -152,24 +158,33 @@
 
   async function render() {
     await tick();
-    if (!container || !data || data.length === 0 || !y) return;
+    if (!nearViewport || !container || !data || data.length === 0 || !y) {
+      viewManager.clear();
+      return;
+    }
 
+    const target = container;
     const barData = getBarData();
     if (barData.length === 0) return;
 
     const spec = buildSpec(barData);
 
     try {
-      if (view) {
-        view.finalize();
-        view = null;
+      const result = await viewManager.replace(
+        () =>
+          embed(target, spec, {
+            actions: false,
+            renderer: "canvas",
+          }),
+        target,
+      );
+      if (!result || target !== container) {
+        if (result) viewManager.clear();
+        return;
       }
-      const result = await embed(container, spec, {
-        actions: false,
-        renderer: "canvas",
+      requestAnimationFrame(() => {
+        if (viewManager.current === result.view) syncViewSize();
       });
-      view = result.view;
-      requestAnimationFrame(syncViewSize);
     } catch (e) {
       console.error("Vega render error:", e);
     }
@@ -200,6 +215,7 @@
   }
 
   async function downloadImage() {
+    const view = viewManager.current;
     if (!view) return;
     try {
       const url = await view.toImageURL("png", 4);
@@ -305,7 +321,15 @@
     title;
     fullscreen;
     container;
+    nearViewport;
     render();
+  });
+
+  $effect(() => {
+    if (!container) return;
+    return observeNearViewport(container, (visible) => {
+      nearViewport = visible;
+    });
   });
 
   $effect(() => {
@@ -327,7 +351,7 @@
       document.removeEventListener("webkitfullscreenchange", onFullscreenChange);
       document.removeEventListener("mozfullscreenchange", onFullscreenChange);
       document.removeEventListener("MSFullscreenChange", onFullscreenChange);
-      if (view) view.finalize();
+      viewManager.destroy();
       document.body.style.overflow = "";
     };
   });
@@ -605,6 +629,7 @@
   }
   .plot {
     width: 100%;
+    min-height: 250px;
   }
   .plot :global(.vega-embed) {
     width: 100% !important;

--- a/trackio/frontend/src/components/BarPlot.svelte
+++ b/trackio/frontend/src/components/BarPlot.svelte
@@ -629,7 +629,7 @@
   }
   .plot {
     width: 100%;
-    min-height: 250px;
+    min-height: 300px;
   }
   .plot :global(.vega-embed) {
     width: 100% !important;

--- a/trackio/frontend/src/components/HistogramPlot.svelte
+++ b/trackio/frontend/src/components/HistogramPlot.svelte
@@ -1,6 +1,10 @@
 <script>
   import { onMount, tick } from "svelte";
   import embed from "vega-embed";
+  import {
+    createVegaViewManager,
+    observeNearViewport,
+  } from "../lib/chartLifecycle.js";
 
   let {
     items = [],
@@ -11,8 +15,9 @@
 
   let container = $state(null);
   let fullscreenHost = $state(null);
-  let view = $state(null);
   let fullscreen = $state(false);
+  let nearViewport = $state(false);
+  const viewManager = createVegaViewManager();
 
   let legendEntries = $derived.by(() => {
     const seen = new Set();
@@ -139,25 +144,32 @@
 
   async function render() {
     await tick();
-    if (!container || !items || items.length === 0) return;
+    if (!nearViewport || !container || !items || items.length === 0) {
+      viewManager.clear();
+      return;
+    }
 
+    const target = container;
     const barData = getBarData();
     if (barData.length === 0) return;
 
     const spec = buildSpec(barData);
 
     try {
-      if (view) {
-        view.finalize();
-        view = null;
+      const result = await viewManager.replace(
+        () =>
+          embed(target, spec, {
+            actions: false,
+            renderer: "canvas",
+          }),
+        target,
+      );
+      if (!result || target !== container) {
+        if (result) viewManager.clear();
+        return;
       }
-      const result = await embed(container, spec, {
-        actions: false,
-        renderer: "canvas",
-      });
-      view = result.view;
       requestAnimationFrame(() => {
-        result.view.resize();
+        if (viewManager.current === result.view) result.view.resize();
       });
     } catch (e) {
       console.error("Vega render error:", e);
@@ -188,6 +200,7 @@
   }
 
   async function downloadImage() {
+    const view = viewManager.current;
     if (!view) return;
     try {
       const url = await view.toImageURL("png", 4);
@@ -239,7 +252,7 @@
       await requestFullscreenEl(fullscreenHost);
       await tick();
       relocateTooltipElement(fullscreenHost);
-      view?.resize();
+      viewManager.current?.resize();
     } catch {
       document.body.style.overflow = "";
       fullscreen = false;
@@ -276,7 +289,7 @@
       relocateTooltipElement(document.body);
     }
     if (active && fullscreen) {
-      tick().then(() => view?.resize());
+      tick().then(() => viewManager.current?.resize());
     }
   }
 
@@ -292,14 +305,22 @@
     title;
     fullscreen;
     container;
+    nearViewport;
     render();
+  });
+
+  $effect(() => {
+    if (!container) return;
+    return observeNearViewport(container, (visible) => {
+      nearViewport = visible;
+    });
   });
 
   $effect(() => {
     if (!container) return;
     const ro = new ResizeObserver(() => {
       queueMicrotask(() => {
-        view?.resize();
+        viewManager.current?.resize();
       });
     });
     ro.observe(container);
@@ -316,7 +337,7 @@
       document.removeEventListener("webkitfullscreenchange", onFullscreenChange);
       document.removeEventListener("mozfullscreenchange", onFullscreenChange);
       document.removeEventListener("MSFullscreenChange", onFullscreenChange);
-      if (view) view.finalize();
+      viewManager.destroy();
       document.body.style.overflow = "";
     };
   });
@@ -550,6 +571,7 @@
   }
   .plot {
     width: 100%;
+    min-height: 250px;
   }
   .plot :global(.vega-embed) {
     width: 100% !important;

--- a/trackio/frontend/src/components/HistogramPlot.svelte
+++ b/trackio/frontend/src/components/HistogramPlot.svelte
@@ -571,7 +571,7 @@
   }
   .plot {
     width: 100%;
-    min-height: 250px;
+    min-height: 300px;
   }
   .plot :global(.vega-embed) {
     width: 100% !important;

--- a/trackio/frontend/src/components/LinePlot.svelte
+++ b/trackio/frontend/src/components/LinePlot.svelte
@@ -4,6 +4,10 @@
   import * as vega from "vega";
   import { buildColorSpecKey } from "../lib/dataProcessing.js";
   import { visibleLegendEntries } from "../lib/legend.js";
+  import {
+    createVegaViewManager,
+    observeNearViewport,
+  } from "../lib/chartLifecycle.js";
 
   let {
     data = [],
@@ -30,8 +34,9 @@
   let container = $state(null);
   let plotContainer = $state(null);
   let fullscreenHost = $state(null);
-  let view = $state(null);
   let fullscreen = $state(false);
+  let nearViewport = $state(false);
+  const viewManager = createVegaViewManager();
 
   let lastStructuralKey = null;
   let lastHasSmoothed = false;
@@ -317,6 +322,7 @@
   }
 
   function tryIncrementalUpdate() {
+    const view = viewManager.current;
     if (!view) return false;
 
     const { originalData, smoothedData, hasSmoothed } = splitData();
@@ -340,6 +346,7 @@
   }
 
   function syncViewSize() {
+    const view = viewManager.current;
     if (!view || !container) return;
     view.width(container.clientWidth);
     if (fullscreen) view.height(container.clientHeight);
@@ -350,20 +357,27 @@
     await tick();
     if (!container || !data || data.length === 0 || !y) return;
 
+    const target = container;
     const spec = buildSpec();
+    const structuralKey = getStructuralKey();
 
     try {
-      if (view) {
-        view.finalize();
-        view = null;
+      const result = await viewManager.replace(
+        () =>
+          embed(target, spec, {
+            actions: false,
+            renderer: "canvas",
+          }),
+        target,
+      );
+      if (!result || target !== container) {
+        if (result) viewManager.clear();
+        return;
       }
-      const result = await embed(container, spec, {
-        actions: false,
-        renderer: "canvas",
+      lastStructuralKey = structuralKey;
+      requestAnimationFrame(() => {
+        if (viewManager.current === result.view) syncViewSize();
       });
-      view = result.view;
-      lastStructuralKey = getStructuralKey();
-      requestAnimationFrame(syncViewSize);
 
       if (onSelect) {
         let lastSelectTime = 0;
@@ -386,10 +400,14 @@
   }
 
   async function render() {
-    if (!container || !data || data.length === 0 || !y) return;
+    if (!nearViewport || !container || !data || data.length === 0 || !y) {
+      viewManager.clear();
+      lastStructuralKey = null;
+      return;
+    }
 
     const structuralKey = getStructuralKey();
-    if (view && structuralKey === lastStructuralKey) {
+    if (viewManager.current && structuralKey === lastStructuralKey) {
       if (tryIncrementalUpdate()) return;
     }
 
@@ -425,6 +443,7 @@
   }
 
   async function downloadImage() {
+    const view = viewManager.current;
     if (!view) return;
     try {
       const url = await view.toImageURL("png", 4);
@@ -534,7 +553,15 @@
     title;
     fullscreen;
     container;
+    nearViewport;
     render();
+  });
+
+  $effect(() => {
+    if (!container) return;
+    return observeNearViewport(container, (visible) => {
+      nearViewport = visible;
+    });
   });
 
   $effect(() => {
@@ -556,7 +583,7 @@
       document.removeEventListener("webkitfullscreenchange", onFullscreenChange);
       document.removeEventListener("mozfullscreenchange", onFullscreenChange);
       document.removeEventListener("MSFullscreenChange", onFullscreenChange);
-      if (view) view.finalize();
+      viewManager.destroy();
       document.body.style.overflow = "";
     };
   });
@@ -942,6 +969,7 @@
   }
   .plot {
     width: 100%;
+    min-height: 250px;
   }
   .plot :global(.vega-embed) {
     width: 100% !important;

--- a/trackio/frontend/src/components/LinePlot.svelte
+++ b/trackio/frontend/src/components/LinePlot.svelte
@@ -981,7 +981,7 @@
   }
   .plot {
     width: 100%;
-    min-height: 250px;
+    min-height: 300px;
   }
   .plot :global(.vega-embed) {
     width: 100% !important;

--- a/trackio/frontend/src/components/LinePlot.svelte
+++ b/trackio/frontend/src/components/LinePlot.svelte
@@ -363,7 +363,11 @@
 
   async function fullRender() {
     await tick();
-    if (!container || !data || data.length === 0 || !y) return;
+    if (!nearViewport || !container || !data || data.length === 0 || !y) {
+      viewManager.clear();
+      lastStructuralKey = null;
+      return;
+    }
 
     const target = container;
     const spec = buildSpec();

--- a/trackio/frontend/src/lib/api.js
+++ b/trackio/frontend/src/lib/api.js
@@ -39,7 +39,7 @@ function getOauthSessionHeader() {
   return sid ? { "x-trackio-oauth-session": sid } : {};
 }
 
-export async function callApi(apiName, params = {}) {
+export async function callApi(apiName, params = {}, requestOptions = {}) {
   const cleanApiName = apiName.startsWith("/") ? apiName.slice(1) : apiName;
   const url = `${BASE}/api/${cleanApiName}`;
   const resp = await fetch(url, {
@@ -47,6 +47,7 @@ export async function callApi(apiName, params = {}) {
     credentials: "include",
     headers: { "Content-Type": "application/json", ...getOauthSessionHeader() },
     body: JSON.stringify(params),
+    signal: requestOptions.signal,
   });
   if (resp.status === 429) {
     registerRateLimitHit();
@@ -94,7 +95,12 @@ export async function getLogs(project, run, options = {}) {
   return await callApi("/get_logs", params);
 }
 
-export async function getLogsBatch(project, runs, options = {}) {
+export async function getLogsBatch(
+  project,
+  runs,
+  options = {},
+  requestOptions = {},
+) {
   if (await isStaticMode()) {
     const out = [];
     for (const run of runs) {
@@ -108,7 +114,7 @@ export async function getLogsBatch(project, runs, options = {}) {
     runs: runs.map((run) => normalizeRun(run)),
     ...options,
   };
-  return await callApi("/get_logs_batch", payload);
+  return await callApi("/get_logs_batch", payload, requestOptions);
 }
 
 export async function getTraces(project, run, options = {}) {
@@ -146,13 +152,13 @@ export async function getSystemMetricsForRun(project, run) {
   return await callApi("/get_system_metrics_for_run", params);
 }
 
-export async function getSystemLogs(project, run) {
+export async function getSystemLogs(project, run, requestOptions = {}) {
   const params = { project, ...normalizeRun(run) };
   if (await isStaticMode()) return staticApi.getSystemLogs(project, run);
-  return await callApi("/get_system_logs", params);
+  return await callApi("/get_system_logs", params, requestOptions);
 }
 
-export async function getSystemLogsBatch(project, runs) {
+export async function getSystemLogsBatch(project, runs, requestOptions = {}) {
   if (await isStaticMode()) {
     const out = [];
     for (const run of runs) {
@@ -161,10 +167,14 @@ export async function getSystemLogsBatch(project, runs) {
     }
     return out;
   }
-  return await callApi("/get_system_logs_batch", {
-    project,
-    runs: runs.map((run) => normalizeRun(run)),
-  });
+  return await callApi(
+    "/get_system_logs_batch",
+    {
+      project,
+      runs: runs.map((run) => normalizeRun(run)),
+    },
+    requestOptions,
+  );
 }
 
 export async function getSnapshot(project, run, step) {

--- a/trackio/frontend/src/lib/api.js
+++ b/trackio/frontend/src/lib/api.js
@@ -104,7 +104,7 @@ export async function getLogsBatch(
   if (await isStaticMode()) {
     const out = [];
     for (const run of runs) {
-      const logs = await staticApi.getLogs(project, run, options);
+      const logs = await staticApi.getLogs(project, run, options, requestOptions);
       out.push({ ...normalizeRun(run), logs });
     }
     return out;
@@ -154,7 +154,8 @@ export async function getSystemMetricsForRun(project, run) {
 
 export async function getSystemLogs(project, run, requestOptions = {}) {
   const params = { project, ...normalizeRun(run) };
-  if (await isStaticMode()) return staticApi.getSystemLogs(project, run);
+  if (await isStaticMode())
+    return staticApi.getSystemLogs(project, run, requestOptions);
   return await callApi("/get_system_logs", params, requestOptions);
 }
 
@@ -162,7 +163,7 @@ export async function getSystemLogsBatch(project, runs, requestOptions = {}) {
   if (await isStaticMode()) {
     const out = [];
     for (const run of runs) {
-      const logs = await staticApi.getSystemLogs(project, run);
+      const logs = await staticApi.getSystemLogs(project, run, requestOptions);
       out.push({ ...normalizeRun(run), logs });
     }
     return out;

--- a/trackio/frontend/src/lib/chartLifecycle.js
+++ b/trackio/frontend/src/lib/chartLifecycle.js
@@ -1,0 +1,96 @@
+function finalizeView(view) {
+  if (!view) return;
+  try {
+    view.finalize();
+  } catch (error) {
+    console.warn("Failed to finalize Vega view:", error);
+  }
+}
+
+function clearElement(element) {
+  if (!element) return;
+  element.replaceChildren();
+}
+
+/**
+ * Owns the Vega view for a chart and makes asynchronous replacements race-safe.
+ *
+ * Vega embeds are asynchronous. Without a generation check, a slow render can
+ * finish after a newer render (or after component teardown) and leave a canvas
+ * and its event handlers alive with no reference through which to finalize it.
+ */
+export function createVegaViewManager() {
+  let current = null;
+  let currentElement = null;
+  let generation = 0;
+  let destroyed = false;
+
+  return {
+    get current() {
+      return current;
+    },
+
+    async replace(create, element = null) {
+      if (destroyed) return null;
+
+      const renderGeneration = ++generation;
+      finalizeView(current);
+      if (currentElement && currentElement !== element) {
+        clearElement(currentElement);
+      }
+      current = null;
+      currentElement = null;
+
+      const result = await create();
+      const next = result?.view;
+      if (!next) {
+        throw new Error("Vega embed did not return a view");
+      }
+
+      if (destroyed || renderGeneration !== generation) {
+        finalizeView(next);
+        if (element && element !== currentElement) clearElement(element);
+        return null;
+      }
+
+      current = next;
+      currentElement = element;
+      return result;
+    },
+
+    clear() {
+      generation += 1;
+      finalizeView(current);
+      clearElement(currentElement);
+      current = null;
+      currentElement = null;
+    },
+
+    destroy() {
+      destroyed = true;
+      generation += 1;
+      finalizeView(current);
+      clearElement(currentElement);
+      current = null;
+      currentElement = null;
+    },
+  };
+}
+
+/**
+ * Observe a chart with a generous margin so it is ready before scrolling into
+ * view, while charts far outside the viewport can release their canvas.
+ */
+export function observeNearViewport(element, onChange) {
+  if (typeof IntersectionObserver === "undefined") {
+    onChange(true);
+    return () => {};
+  }
+
+  const observer = new IntersectionObserver(
+    ([entry]) => onChange(entry?.isIntersecting ?? false),
+    { rootMargin: "600px 0px" },
+  );
+  observer.observe(element);
+  return () => observer.disconnect();
+}

--- a/trackio/frontend/src/lib/chartLifecycle.js
+++ b/trackio/frontend/src/lib/chartLifecycle.js
@@ -49,11 +49,16 @@ export function createVegaViewManager() {
     current = null;
     currentElement = null;
 
-    const result = await request.create();
-    const next = result?.view;
-    if (!next) {
-      throw new Error("Vega embed did not return a view");
+    let result;
+    try {
+      result = await request.create();
+      if (!result?.view) throw new Error("Vega embed did not return a view");
+    } catch (error) {
+      clearElement(request.element);
+      releaseElementHeight(request.element);
+      throw error;
     }
+    const next = result.view;
 
     if (destroyed || request.generation !== generation) {
       finalizeView(next);

--- a/trackio/frontend/src/lib/chartLifecycle.js
+++ b/trackio/frontend/src/lib/chartLifecycle.js
@@ -137,7 +137,8 @@ export function observeNearViewport(element, onChange) {
   }
 
   const observer = new IntersectionObserver(
-    ([entry]) => onChange(entry?.isIntersecting ?? false),
+    (entries) =>
+      onChange(entries[entries.length - 1]?.isIntersecting ?? false),
     { rootMargin: "600px 0px" },
   );
   observer.observe(element);

--- a/trackio/frontend/src/lib/chartLifecycle.js
+++ b/trackio/frontend/src/lib/chartLifecycle.js
@@ -7,8 +7,21 @@ function finalizeView(view) {
   }
 }
 
-function clearElement(element) {
+function holdElementHeight(element) {
+  if (!element?.style || typeof element.getBoundingClientRect !== "function") {
+    return;
+  }
+  const height = element.getBoundingClientRect().height;
+  if (height > 0) element.style.height = `${height}px`;
+}
+
+function releaseElementHeight(element) {
+  element?.style?.removeProperty("height");
+}
+
+function clearElement(element, holdHeight = false) {
   if (!element) return;
+  if (holdHeight) holdElementHeight(element);
   element.replaceChildren();
 }
 
@@ -17,44 +30,90 @@ export function createVegaViewManager() {
   let currentElement = null;
   let generation = 0;
   let destroyed = false;
+  let rendering = false;
+  let queued = null;
+
+  function cancelQueued() {
+    if (!queued) return;
+    queued.resolve(null);
+    queued = null;
+  }
+
+  async function execute(request) {
+    if (destroyed || request.generation !== generation) return null;
+
+    finalizeView(current);
+    if (currentElement && currentElement !== request.element) {
+      clearElement(currentElement);
+    }
+    current = null;
+    currentElement = null;
+
+    const result = await request.create();
+    const next = result?.view;
+    if (!next) {
+      throw new Error("Vega embed did not return a view");
+    }
+
+    if (destroyed || request.generation !== generation) {
+      finalizeView(next);
+      clearElement(request.element, true);
+      return null;
+    }
+
+    current = next;
+    currentElement = request.element;
+    releaseElementHeight(request.element);
+    return result;
+  }
+
+  function start(request) {
+    rendering = true;
+    void (async () => {
+      try {
+        request.resolve(await execute(request));
+      } catch (error) {
+        request.reject(error);
+      } finally {
+        rendering = false;
+        const next = queued;
+        queued = null;
+        if (next) start(next);
+      }
+    })();
+  }
 
   return {
     get current() {
       return current;
     },
 
-    async replace(create, element = null) {
-      if (destroyed) return null;
+    replace(create, element = null) {
+      if (destroyed) return Promise.resolve(null);
 
-      const renderGeneration = ++generation;
-      finalizeView(current);
-      if (currentElement && currentElement !== element) {
-        clearElement(currentElement);
-      }
-      current = null;
-      currentElement = null;
-
-      const result = await create();
-      const next = result?.view;
-      if (!next) {
-        throw new Error("Vega embed did not return a view");
-      }
-
-      if (destroyed || renderGeneration !== generation) {
-        finalizeView(next);
-        if (element && element !== currentElement) clearElement(element);
-        return null;
-      }
-
-      current = next;
-      currentElement = element;
-      return result;
+      const requestGeneration = ++generation;
+      return new Promise((resolve, reject) => {
+        const request = {
+          create,
+          element,
+          generation: requestGeneration,
+          resolve,
+          reject,
+        };
+        if (rendering) {
+          cancelQueued();
+          queued = request;
+        } else {
+          start(request);
+        }
+      });
     },
 
     clear() {
       generation += 1;
+      cancelQueued();
       finalizeView(current);
-      clearElement(currentElement);
+      clearElement(currentElement, true);
       current = null;
       currentElement = null;
     },
@@ -62,6 +121,7 @@ export function createVegaViewManager() {
     destroy() {
       destroyed = true;
       generation += 1;
+      cancelQueued();
       finalizeView(current);
       clearElement(currentElement);
       current = null;

--- a/trackio/frontend/src/lib/chartLifecycle.test.js
+++ b/trackio/frontend/src/lib/chartLifecycle.test.js
@@ -1,0 +1,145 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import {
+  createVegaViewManager,
+  observeNearViewport,
+} from "./chartLifecycle.js";
+
+function deferred() {
+  let resolve;
+  const promise = new Promise((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+function fakeResult() {
+  return { view: { finalize: vi.fn() } };
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("createVegaViewManager", () => {
+  test("finalizes the previous view when replacing it", async () => {
+    const manager = createVegaViewManager();
+    const first = fakeResult();
+    const second = fakeResult();
+
+    await manager.replace(async () => first);
+    await manager.replace(async () => second);
+
+    expect(first.view.finalize).toHaveBeenCalledOnce();
+    expect(second.view.finalize).not.toHaveBeenCalled();
+    expect(manager.current).toBe(second.view);
+  });
+
+  test("finalizes a stale render that finishes after a newer render", async () => {
+    const manager = createVegaViewManager();
+    const slow = deferred();
+    const stale = fakeResult();
+    const latest = fakeResult();
+
+    const slowReplace = manager.replace(() => slow.promise);
+    await manager.replace(async () => latest);
+    slow.resolve(stale);
+
+    expect(await slowReplace).toBeNull();
+    expect(stale.view.finalize).toHaveBeenCalledOnce();
+    expect(latest.view.finalize).not.toHaveBeenCalled();
+    expect(manager.current).toBe(latest.view);
+  });
+
+  test("finalizes an in-flight render after the manager is cleared", async () => {
+    const manager = createVegaViewManager();
+    const pending = deferred();
+    const stale = fakeResult();
+
+    const replacement = manager.replace(() => pending.promise);
+    manager.clear();
+    pending.resolve(stale);
+
+    expect(await replacement).toBeNull();
+    expect(stale.view.finalize).toHaveBeenCalledOnce();
+    expect(manager.current).toBeNull();
+  });
+
+  test("removes the canvas from the active chart when clearing it", async () => {
+    const manager = createVegaViewManager();
+    const result = fakeResult();
+    const element = { replaceChildren: vi.fn() };
+
+    await manager.replace(async () => result, element);
+    manager.clear();
+
+    expect(result.view.finalize).toHaveBeenCalledOnce();
+    expect(element.replaceChildren).toHaveBeenCalledOnce();
+  });
+
+  test("does not clear a newer render that shares a stale render's element", async () => {
+    const manager = createVegaViewManager();
+    const slow = deferred();
+    const stale = fakeResult();
+    const latest = fakeResult();
+    const element = { replaceChildren: vi.fn() };
+
+    const slowReplace = manager.replace(() => slow.promise, element);
+    await manager.replace(async () => latest, element);
+    slow.resolve(stale);
+    await slowReplace;
+
+    expect(stale.view.finalize).toHaveBeenCalledOnce();
+    expect(element.replaceChildren).not.toHaveBeenCalled();
+    expect(manager.current).toBe(latest.view);
+  });
+
+  test("does not start new renders after teardown", async () => {
+    const manager = createVegaViewManager();
+    const result = fakeResult();
+    const create = vi.fn(async () => result);
+
+    await manager.replace(create);
+    manager.destroy();
+
+    expect(result.view.finalize).toHaveBeenCalledOnce();
+    expect(await manager.replace(create)).toBeNull();
+    expect(create).toHaveBeenCalledOnce();
+  });
+});
+
+describe("observeNearViewport", () => {
+  test("reports intersections and disconnects the observer", () => {
+    let callback;
+    const observe = vi.fn();
+    const disconnect = vi.fn();
+    const IntersectionObserverMock = vi.fn((next) => {
+      callback = next;
+      return { observe, disconnect };
+    });
+    vi.stubGlobal("IntersectionObserver", IntersectionObserverMock);
+    const onChange = vi.fn();
+    const element = {};
+
+    const cleanup = observeNearViewport(element, onChange);
+    callback([{ isIntersecting: true }]);
+    callback([{ isIntersecting: false }]);
+    cleanup();
+
+    expect(IntersectionObserverMock).toHaveBeenCalledWith(expect.any(Function), {
+      rootMargin: "600px 0px",
+    });
+    expect(observe).toHaveBeenCalledWith(element);
+    expect(onChange).toHaveBeenNthCalledWith(1, true);
+    expect(onChange).toHaveBeenNthCalledWith(2, false);
+    expect(disconnect).toHaveBeenCalledOnce();
+  });
+
+  test("renders eagerly when IntersectionObserver is unavailable", () => {
+    vi.stubGlobal("IntersectionObserver", undefined);
+    const onChange = vi.fn();
+
+    observeNearViewport({}, onChange)();
+
+    expect(onChange).toHaveBeenCalledWith(true);
+  });
+});

--- a/trackio/frontend/src/lib/chartLifecycle.test.js
+++ b/trackio/frontend/src/lib/chartLifecycle.test.js
@@ -158,7 +158,7 @@ describe("observeNearViewport", () => {
     const element = {};
 
     const cleanup = observeNearViewport(element, onChange);
-    callback([{ isIntersecting: true }]);
+    callback([{ isIntersecting: false }, { isIntersecting: true }]);
     callback([{ isIntersecting: false }]);
     cleanup();
 

--- a/trackio/frontend/src/lib/chartLifecycle.test.js
+++ b/trackio/frontend/src/lib/chartLifecycle.test.js
@@ -34,17 +34,22 @@ describe("createVegaViewManager", () => {
     expect(manager.current).toBe(second.view);
   });
 
-  test("finalizes a stale render that finishes after a newer render", async () => {
+  test("waits for an active render before starting its replacement", async () => {
     const manager = createVegaViewManager();
     const slow = deferred();
     const stale = fakeResult();
     const latest = fakeResult();
+    const createLatest = vi.fn(async () => latest);
 
     const slowReplace = manager.replace(() => slow.promise);
-    await manager.replace(async () => latest);
+    const latestReplace = manager.replace(createLatest);
+
+    expect(createLatest).not.toHaveBeenCalled();
     slow.resolve(stale);
 
     expect(await slowReplace).toBeNull();
+    expect(await latestReplace).toBe(latest);
+    expect(createLatest).toHaveBeenCalledOnce();
     expect(stale.view.finalize).toHaveBeenCalledOnce();
     expect(latest.view.finalize).not.toHaveBeenCalled();
     expect(manager.current).toBe(latest.view);
@@ -76,21 +81,53 @@ describe("createVegaViewManager", () => {
     expect(element.replaceChildren).toHaveBeenCalledOnce();
   });
 
-  test("does not clear a newer render that shares a stale render's element", async () => {
+  test("keeps only the newest queued replacement", async () => {
     const manager = createVegaViewManager();
     const slow = deferred();
     const stale = fakeResult();
+    const middle = fakeResult();
     const latest = fakeResult();
-    const element = { replaceChildren: vi.fn() };
+    const createMiddle = vi.fn(async () => middle);
+    const createLatest = vi.fn(async () => latest);
 
-    const slowReplace = manager.replace(() => slow.promise, element);
-    await manager.replace(async () => latest, element);
+    const slowReplace = manager.replace(() => slow.promise);
+    const middleReplace = manager.replace(createMiddle);
+    const latestReplace = manager.replace(createLatest);
+
+    expect(await middleReplace).toBeNull();
+    expect(createMiddle).not.toHaveBeenCalled();
     slow.resolve(stale);
-    await slowReplace;
 
+    expect(await slowReplace).toBeNull();
+    expect(await latestReplace).toBe(latest);
     expect(stale.view.finalize).toHaveBeenCalledOnce();
-    expect(element.replaceChildren).not.toHaveBeenCalled();
+    expect(middle.view.finalize).not.toHaveBeenCalled();
+    expect(createLatest).toHaveBeenCalledOnce();
     expect(manager.current).toBe(latest.view);
+  });
+
+  test("preserves chart height while its canvas is cleared", async () => {
+    const manager = createVegaViewManager();
+    const result = fakeResult();
+    const removeProperty = vi.fn(function () {
+      this.height = "";
+    });
+    const element = {
+      getBoundingClientRect: () => ({ height: 312 }),
+      replaceChildren: vi.fn(),
+      style: { height: "", removeProperty },
+    };
+
+    await manager.replace(async () => result, element);
+    manager.clear();
+
+    expect(element.style.height).toBe("312px");
+
+    const replacement = fakeResult();
+    await manager.replace(async () => replacement, element);
+
+    expect(element.style.height).toBe("");
+    expect(removeProperty).toHaveBeenCalledTimes(2);
   });
 
   test("does not start new renders after teardown", async () => {

--- a/trackio/frontend/src/lib/chartLifecycle.test.js
+++ b/trackio/frontend/src/lib/chartLifecycle.test.js
@@ -81,6 +81,23 @@ describe("createVegaViewManager", () => {
     expect(element.replaceChildren).toHaveBeenCalledOnce();
   });
 
+  test("removes a finalized canvas when its replacement fails", async () => {
+    const manager = createVegaViewManager();
+    const result = fakeResult();
+    const element = { replaceChildren: vi.fn() };
+
+    await manager.replace(async () => result, element);
+
+    await expect(
+      manager.replace(async () => {
+        throw new Error("embed failed");
+      }, element),
+    ).rejects.toThrow("embed failed");
+    expect(result.view.finalize).toHaveBeenCalledOnce();
+    expect(element.replaceChildren).toHaveBeenCalledOnce();
+    expect(manager.current).toBeNull();
+  });
+
   test("keeps only the newest queued replacement", async () => {
     const manager = createVegaViewManager();
     const slow = deferred();

--- a/trackio/frontend/src/lib/hostPolling.js
+++ b/trackio/frontend/src/lib/hostPolling.js
@@ -27,3 +27,29 @@ export function getMetricsPollIntervalMs() {
 export function isTabHidden() {
   return typeof document !== "undefined" && document.hidden;
 }
+
+export function createPollingTask(timeoutMs = 30000) {
+  let controller = null;
+
+  return {
+    async run(task) {
+      if (controller) return false;
+
+      const runController = new AbortController();
+      controller = runController;
+      const timeout = setTimeout(() => runController.abort(), timeoutMs);
+      try {
+        await task(runController.signal);
+        return true;
+      } finally {
+        clearTimeout(timeout);
+        if (controller === runController) controller = null;
+      }
+    },
+
+    cancel() {
+      controller?.abort();
+      controller = null;
+    },
+  };
+}

--- a/trackio/frontend/src/lib/hostPolling.js
+++ b/trackio/frontend/src/lib/hostPolling.js
@@ -32,17 +32,19 @@ export function createPollingTask(timeoutMs = 30000) {
   let controller = null;
 
   return {
-    async run(task) {
+    async run(task, runTimeoutMs = timeoutMs) {
       if (controller) return false;
 
       const runController = new AbortController();
       controller = runController;
-      const timeout = setTimeout(() => runController.abort(), timeoutMs);
+      const timeout = runTimeoutMs
+        ? setTimeout(() => runController.abort(), runTimeoutMs)
+        : null;
       try {
         await task(runController.signal);
         return true;
       } finally {
-        clearTimeout(timeout);
+        if (timeout) clearTimeout(timeout);
         if (controller === runController) controller = null;
       }
     },

--- a/trackio/frontend/src/lib/hostPolling.test.js
+++ b/trackio/frontend/src/lib/hostPolling.test.js
@@ -1,0 +1,60 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { createPollingTask } from "./hostPolling.js";
+
+function deferred() {
+  let resolve;
+  const promise = new Promise((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+function waitForAbort(signal) {
+  return new Promise((resolve, reject) => {
+    signal.addEventListener("abort", () => reject(signal.reason));
+  });
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("createPollingTask", () => {
+  test("does not overlap polling tasks", async () => {
+    const pollingTask = createPollingTask();
+    const pending = deferred();
+    const task = vi.fn(() => pending.promise);
+
+    const first = pollingTask.run(task);
+
+    expect(await pollingTask.run(task)).toBe(false);
+    expect(task).toHaveBeenCalledOnce();
+
+    pending.resolve();
+
+    expect(await first).toBe(true);
+    expect(await pollingTask.run(async () => {})).toBe(true);
+  });
+
+  test("aborts a polling task after its timeout", async () => {
+    vi.useFakeTimers();
+    const pollingTask = createPollingTask(1000);
+    const run = pollingTask.run(waitForAbort);
+    const aborted = expect(run).rejects.toMatchObject({ name: "AbortError" });
+
+    await vi.advanceTimersByTimeAsync(1000);
+
+    await aborted;
+    expect(await pollingTask.run(async () => {})).toBe(true);
+  });
+
+  test("cancels an active polling task", async () => {
+    const pollingTask = createPollingTask();
+    const run = pollingTask.run(waitForAbort);
+    const aborted = expect(run).rejects.toMatchObject({ name: "AbortError" });
+
+    pollingTask.cancel();
+
+    await aborted;
+  });
+});

--- a/trackio/frontend/src/lib/hostPolling.test.js
+++ b/trackio/frontend/src/lib/hostPolling.test.js
@@ -48,6 +48,18 @@ describe("createPollingTask", () => {
     expect(await pollingTask.run(async () => {})).toBe(true);
   });
 
+  test("allows the timeout to be disabled for a run", async () => {
+    vi.useFakeTimers();
+    const pollingTask = createPollingTask(1000);
+    const pending = deferred();
+    const run = pollingTask.run(() => pending.promise, null);
+
+    await vi.advanceTimersByTimeAsync(1000);
+    pending.resolve();
+
+    await expect(run).resolves.toBe(true);
+  });
+
   test("cancels an active polling task", async () => {
     const pollingTask = createPollingTask();
     const run = pollingTask.run(waitForAbort);

--- a/trackio/frontend/src/lib/parquetReader.js
+++ b/trackio/frontend/src/lib/parquetReader.js
@@ -11,10 +11,10 @@ function coerceBigInts(row) {
   return out;
 }
 
-export async function readParquet(url, headers = {}) {
+export async function readParquet(url, headers = {}, signal) {
   if (cache.has(url)) return cache.get(url);
 
-  const resp = await fetch(url, { headers });
+  const resp = await fetch(url, { headers, signal });
   if (!resp.ok) {
     if (resp.status === 404) {
       cache.set(url, []);

--- a/trackio/frontend/src/lib/staticApi.js
+++ b/trackio/frontend/src/lib/staticApi.js
@@ -39,15 +39,19 @@ export function getReadOnlySource() {
   };
 }
 
-async function getMetricsData() {
+async function getMetricsData(signal) {
   if (metricsData) return metricsData;
-  metricsData = await readParquet(resolveUrl("metrics.parquet"));
+  metricsData = await readParquet(resolveUrl("metrics.parquet"), {}, signal);
   return metricsData;
 }
 
-async function getSystemData() {
+async function getSystemData(signal) {
   if (systemData) return systemData;
-  systemData = await readParquet(resolveUrl("aux/system_metrics.parquet"));
+  systemData = await readParquet(
+    resolveUrl("aux/system_metrics.parquet"),
+    {},
+    signal,
+  );
   return systemData;
 }
 
@@ -197,8 +201,9 @@ function parseHistogramValue(value) {
   return null;
 }
 
-export async function getLogs(_project, run, options = {}) {
-  const raw = await getMetricsData();
+export async function getLogs(_project, run, options = {}, requestOptions = {}) {
+  requestOptions.signal?.throwIfAborted();
+  const raw = await getMetricsData(requestOptions.signal);
   const { rows } = parseRows(raw);
   const runRows = rows.filter((r) => matchesRun(r, run));
   const scalarOnly = options.scalar_only === true;
@@ -453,8 +458,9 @@ export async function getSystemMetricsForRun(_project, run) {
   return [...present];
 }
 
-export async function getSystemLogs(_project, run) {
-  const raw = await getSystemData();
+export async function getSystemLogs(_project, run, requestOptions = {}) {
+  requestOptions.signal?.throwIfAborted();
+  const raw = await getSystemData(requestOptions.signal);
   const { rows } = parseRows(raw);
   const runRows = rows.filter((r) => matchesRun(r, run));
 

--- a/trackio/frontend/src/pages/Metrics.svelte
+++ b/trackio/frontend/src/pages/Metrics.svelte
@@ -56,6 +56,7 @@
 
   let rawDataCache = new Map();
   let refreshTimer = null;
+  let refreshInFlight = false;
   const MAX_BATCH_RUNS = 64;
 
   let colorMap = $derived(buildColorMap(allRuns));
@@ -258,7 +259,9 @@
     if (!project || selectedRuns.length === 0) return;
     if (isTabHidden()) return;
     if (isRateLimitCooldownActive()) return;
+    if (refreshInFlight) return;
 
+    refreshInFlight = true;
     try {
       const batch = await fetchLogsForRuns(selectedRuns);
       let changed = false;
@@ -276,6 +279,8 @@
       }
     } catch (e) {
       console.error("Failed to refresh metric logs:", e);
+    } finally {
+      refreshInFlight = false;
     }
   }
 

--- a/trackio/frontend/src/pages/Metrics.svelte
+++ b/trackio/frontend/src/pages/Metrics.svelte
@@ -9,6 +9,7 @@
   import RunComparer from "../components/RunComparer.svelte";
   import { getLogsBatch } from "../lib/api.js";
   import {
+    createPollingTask,
     getMetricsPollIntervalMs,
     isRateLimitCooldownActive,
     isTabHidden,
@@ -61,7 +62,7 @@
 
   let rawDataCache = new Map();
   let refreshTimer = null;
-  let refreshInFlight = false;
+  const refreshTask = createPollingTask();
   const MAX_BATCH_RUNS = 64;
 
   let colorMap = $derived(buildColorMap(allRuns));
@@ -213,11 +214,16 @@
     singlePointMetrics = sp;
   }
 
-  async function fetchLogsForRuns(runs) {
+  async function fetchLogsForRuns(runs, requestOptions = {}) {
     const results = [];
     for (let i = 0; i < runs.length; i += MAX_BATCH_RUNS) {
       const chunk = runs.slice(i, i + MAX_BATCH_RUNS);
-      const batch = await getLogsBatch(project, chunk, { scalar_only: true });
+      const batch = await getLogsBatch(
+        project,
+        chunk,
+        { scalar_only: true },
+        requestOptions,
+      );
       results.push(...batch);
     }
     return results;
@@ -266,28 +272,27 @@
     if (!project || selectedRuns.length === 0) return;
     if (isTabHidden()) return;
     if (isRateLimitCooldownActive()) return;
-    if (refreshInFlight) return;
-
-    refreshInFlight = true;
     try {
-      const batch = await fetchLogsForRuns(selectedRuns);
-      let changed = false;
-      for (const entry of batch) {
-        const runKey = entry.run_id ?? entry.run;
-        const logs = entry.logs;
-        const prev = rawDataCache.get(runKey);
-        if (!prev || logsHaveNewData(prev, logs)) {
-          rawDataCache.set(runKey, logs);
-          changed = true;
+      await refreshTask.run(async (signal) => {
+        const batch = await fetchLogsForRuns(selectedRuns, { signal });
+        let changed = false;
+        for (const entry of batch) {
+          const runKey = entry.run_id ?? entry.run;
+          const logs = entry.logs;
+          const prev = rawDataCache.get(runKey);
+          if (!prev || logsHaveNewData(prev, logs)) {
+            rawDataCache.set(runKey, logs);
+            changed = true;
+          }
         }
-      }
-      if (changed) {
-        processFromCache();
-      }
+        if (changed) {
+          processFromCache();
+        }
+      });
     } catch (e) {
-      console.error("Failed to refresh metric logs:", e);
-    } finally {
-      refreshInFlight = false;
+      if (e?.name !== "AbortError") {
+        console.error("Failed to refresh metric logs:", e);
+      }
     }
   }
 
@@ -295,6 +300,7 @@
     project;
     selectedRuns;
     appBootstrapReady;
+    refreshTask.cancel();
     rawDataCache = project ? rawDataCache : new Map();
     fetchNewRuns();
   });
@@ -325,6 +331,7 @@
     );
     return () => {
       if (refreshTimer) clearInterval(refreshTimer);
+      refreshTask.cancel();
     };
   });
 

--- a/trackio/frontend/src/pages/Metrics.svelte
+++ b/trackio/frontend/src/pages/Metrics.svelte
@@ -214,12 +214,16 @@
     singlePointMetrics = sp;
   }
 
-  async function fetchLogsForRuns(runs, requestOptions = {}) {
+  async function fetchLogsForRuns(
+    runs,
+    requestOptions = {},
+    projectName = project,
+  ) {
     const results = [];
     for (let i = 0; i < runs.length; i += MAX_BATCH_RUNS) {
       const chunk = runs.slice(i, i + MAX_BATCH_RUNS);
       const batch = await getLogsBatch(
-        project,
+        projectName,
         chunk,
         { scalar_only: true },
         requestOptions,
@@ -229,7 +233,7 @@
     return results;
   }
 
-  async function fetchNewRuns() {
+  async function fetchNewRuns(signal) {
     if (!appBootstrapReady) {
       hasLoaded = false;
       return;
@@ -243,20 +247,28 @@
       return;
     }
 
-    const needFetch = selectedRuns.filter((run) => {
+    const requestedProject = project;
+    const requestedRuns = selectedRuns;
+    const needFetch = requestedRuns.filter((run) => {
       const runKey = run.id ?? run.name;
       return !rawDataCache.has(runKey);
     });
     let fetched = false;
     if (needFetch.length > 0) {
       try {
-        const batch = await fetchLogsForRuns(needFetch);
+        const batch = await fetchLogsForRuns(
+          needFetch,
+          { signal },
+          requestedProject,
+        );
+        if (signal.aborted || requestedProject !== project) return;
         for (const entry of batch) {
           const runKey = entry.run_id ?? entry.run;
           rawDataCache.set(runKey, entry.logs);
           fetched = true;
         }
       } catch (e) {
+        if (e?.name === "AbortError") return;
         console.error("Failed to load metric logs:", e);
       }
     }
@@ -274,7 +286,14 @@
     if (isRateLimitCooldownActive()) return;
     try {
       await refreshTask.run(async (signal) => {
-        const batch = await fetchLogsForRuns(selectedRuns, { signal });
+        const requestedProject = project;
+        const requestedRuns = selectedRuns;
+        const batch = await fetchLogsForRuns(
+          requestedRuns,
+          { signal },
+          requestedProject,
+        );
+        if (signal.aborted || requestedProject !== project) return;
         let changed = false;
         for (const entry of batch) {
           const runKey = entry.run_id ?? entry.run;
@@ -288,6 +307,7 @@
         if (changed) {
           processFromCache();
         }
+        hasLoaded = true;
       });
     } catch (e) {
       if (e?.name !== "AbortError") {
@@ -302,7 +322,7 @@
     appBootstrapReady;
     refreshTask.cancel();
     rawDataCache = project ? rawDataCache : new Map();
-    fetchNewRuns();
+    void refreshTask.run(fetchNewRuns);
   });
 
   $effect(() => {

--- a/trackio/frontend/src/pages/Metrics.svelte
+++ b/trackio/frontend/src/pages/Metrics.svelte
@@ -322,7 +322,7 @@
     appBootstrapReady;
     refreshTask.cancel();
     rawDataCache = project ? rawDataCache : new Map();
-    void refreshTask.run(fetchNewRuns);
+    void refreshTask.run(fetchNewRuns, null);
   });
 
   $effect(() => {

--- a/trackio/frontend/src/pages/SystemMetrics.svelte
+++ b/trackio/frontend/src/pages/SystemMetrics.svelte
@@ -40,6 +40,7 @@
 
   let rawDataCache = new Map();
   let refreshTimer = null;
+  let refreshInFlight = false;
 
   let runColorMap = $derived(buildColorMap(allRuns.length ? allRuns : selectedRuns));
 
@@ -265,7 +266,9 @@
     if (!project || selectedRuns.length === 0) return;
     if (isTabHidden()) return;
     if (isRateLimitCooldownActive()) return;
+    if (refreshInFlight) return;
 
+    refreshInFlight = true;
     try {
       const batch = await fetchSystemLogsForRuns(selectedRuns);
       let changed = false;
@@ -283,6 +286,8 @@
       }
     } catch (e) {
       console.error("Failed to refresh system metric logs:", e);
+    } finally {
+      refreshInFlight = false;
     }
   }
 

--- a/trackio/frontend/src/pages/SystemMetrics.svelte
+++ b/trackio/frontend/src/pages/SystemMetrics.svelte
@@ -189,10 +189,14 @@
     return /\b(404|405|501)\b/.test(msg);
   }
 
-  async function fetchSystemLogsForRuns(runs, requestOptions = {}) {
+  async function fetchSystemLogsForRuns(
+    runs,
+    requestOptions = {},
+    projectName = project,
+  ) {
     if (batchEndpointAvailable && runs.length <= MAX_BATCH_RUNS) {
       try {
-        return await getSystemLogsBatch(project, runs, requestOptions);
+        return await getSystemLogsBatch(projectName, runs, requestOptions);
       } catch (e) {
         if (!isMissingEndpointError(e)) throw e;
         batchEndpointAvailable = false;
@@ -202,14 +206,18 @@
       const results = [];
       for (let i = 0; i < runs.length; i += MAX_BATCH_RUNS) {
         const chunk = runs.slice(i, i + MAX_BATCH_RUNS);
-        const batch = await getSystemLogsBatch(project, chunk, requestOptions);
+        const batch = await getSystemLogsBatch(
+          projectName,
+          chunk,
+          requestOptions,
+        );
         results.push(...batch);
       }
       return results;
     }
     const results = [];
     for (const run of runs) {
-      const logs = await getSystemLogs(project, run, requestOptions);
+      const logs = await getSystemLogs(projectName, run, requestOptions);
       results.push({
         run: run?.name ?? null,
         run_id: run?.id ?? null,
@@ -219,7 +227,7 @@
     return results;
   }
 
-  async function fetchNewRuns() {
+  async function fetchNewRuns(signal) {
     if (!appBootstrapReady) {
       hasLoaded = false;
       return;
@@ -232,14 +240,21 @@
       return;
     }
 
-    const needFetch = selectedRuns.filter((run) => {
+    const requestedProject = project;
+    const requestedRuns = selectedRuns;
+    const needFetch = requestedRuns.filter((run) => {
       const runKey = run.id ?? run.name;
       return !rawDataCache.has(runKey);
     });
     let fetched = false;
     if (needFetch.length > 0) {
       try {
-        const batch = await fetchSystemLogsForRuns(needFetch);
+        const batch = await fetchSystemLogsForRuns(
+          needFetch,
+          { signal },
+          requestedProject,
+        );
+        if (signal.aborted || requestedProject !== project) return;
         for (const entry of batch) {
           const runKey = entry.run_id ?? entry.run;
           rawDataCache.set(runKey, entry.logs);
@@ -247,6 +262,7 @@
         }
         loadError = null;
       } catch (e) {
+        if (e?.name === "AbortError") return;
         console.error("Failed to load system metric logs:", e);
         if (!hasLoaded) {
           loadError = e && e.message ? e.message : "Failed to load system metrics";
@@ -269,7 +285,14 @@
     if (isRateLimitCooldownActive()) return;
     try {
       await refreshTask.run(async (signal) => {
-        const batch = await fetchSystemLogsForRuns(selectedRuns, { signal });
+        const requestedProject = project;
+        const requestedRuns = selectedRuns;
+        const batch = await fetchSystemLogsForRuns(
+          requestedRuns,
+          { signal },
+          requestedProject,
+        );
+        if (signal.aborted || requestedProject !== project) return;
         let changed = false;
         for (const entry of batch) {
           const runKey = entry.run_id ?? entry.run;
@@ -283,6 +306,8 @@
         if (changed) {
           processFromCache();
         }
+        loadError = null;
+        hasLoaded = true;
       });
     } catch (e) {
       if (e?.name !== "AbortError") {
@@ -297,7 +322,7 @@
     appBootstrapReady;
     refreshTask.cancel();
     rawDataCache = project ? rawDataCache : new Map();
-    fetchNewRuns();
+    void refreshTask.run(fetchNewRuns);
   });
 
   $effect(() => {

--- a/trackio/frontend/src/pages/SystemMetrics.svelte
+++ b/trackio/frontend/src/pages/SystemMetrics.svelte
@@ -322,7 +322,7 @@
     appBootstrapReady;
     refreshTask.cancel();
     rawDataCache = project ? rawDataCache : new Map();
-    void refreshTask.run(fetchNewRuns);
+    void refreshTask.run(fetchNewRuns, null);
   });
 
   $effect(() => {

--- a/trackio/frontend/src/pages/SystemMetrics.svelte
+++ b/trackio/frontend/src/pages/SystemMetrics.svelte
@@ -5,6 +5,7 @@
   import LoadingTrackio from "../components/LoadingTrackio.svelte";
   import { getSystemLogs, getSystemLogsBatch } from "../lib/api.js";
   import {
+    createPollingTask,
     getMetricsPollIntervalMs,
     isRateLimitCooldownActive,
     isTabHidden,
@@ -40,7 +41,7 @@
 
   let rawDataCache = new Map();
   let refreshTimer = null;
-  let refreshInFlight = false;
+  const refreshTask = createPollingTask();
 
   let runColorMap = $derived(buildColorMap(allRuns.length ? allRuns : selectedRuns));
 
@@ -188,10 +189,10 @@
     return /\b(404|405|501)\b/.test(msg);
   }
 
-  async function fetchSystemLogsForRuns(runs) {
+  async function fetchSystemLogsForRuns(runs, requestOptions = {}) {
     if (batchEndpointAvailable && runs.length <= MAX_BATCH_RUNS) {
       try {
-        return await getSystemLogsBatch(project, runs);
+        return await getSystemLogsBatch(project, runs, requestOptions);
       } catch (e) {
         if (!isMissingEndpointError(e)) throw e;
         batchEndpointAvailable = false;
@@ -201,14 +202,14 @@
       const results = [];
       for (let i = 0; i < runs.length; i += MAX_BATCH_RUNS) {
         const chunk = runs.slice(i, i + MAX_BATCH_RUNS);
-        const batch = await getSystemLogsBatch(project, chunk);
+        const batch = await getSystemLogsBatch(project, chunk, requestOptions);
         results.push(...batch);
       }
       return results;
     }
     const results = [];
     for (const run of runs) {
-      const logs = await getSystemLogs(project, run);
+      const logs = await getSystemLogs(project, run, requestOptions);
       results.push({
         run: run?.name ?? null,
         run_id: run?.id ?? null,
@@ -266,28 +267,27 @@
     if (!project || selectedRuns.length === 0) return;
     if (isTabHidden()) return;
     if (isRateLimitCooldownActive()) return;
-    if (refreshInFlight) return;
-
-    refreshInFlight = true;
     try {
-      const batch = await fetchSystemLogsForRuns(selectedRuns);
-      let changed = false;
-      for (const entry of batch) {
-        const runKey = entry.run_id ?? entry.run;
-        const logs = entry.logs;
-        const prev = rawDataCache.get(runKey);
-        if (!prev || logsHaveNewData(prev, logs)) {
-          rawDataCache.set(runKey, logs);
-          changed = true;
+      await refreshTask.run(async (signal) => {
+        const batch = await fetchSystemLogsForRuns(selectedRuns, { signal });
+        let changed = false;
+        for (const entry of batch) {
+          const runKey = entry.run_id ?? entry.run;
+          const logs = entry.logs;
+          const prev = rawDataCache.get(runKey);
+          if (!prev || logsHaveNewData(prev, logs)) {
+            rawDataCache.set(runKey, logs);
+            changed = true;
+          }
         }
-      }
-      if (changed) {
-        processFromCache();
-      }
+        if (changed) {
+          processFromCache();
+        }
+      });
     } catch (e) {
-      console.error("Failed to refresh system metric logs:", e);
-    } finally {
-      refreshInFlight = false;
+      if (e?.name !== "AbortError") {
+        console.error("Failed to refresh system metric logs:", e);
+      }
     }
   }
 
@@ -295,6 +295,7 @@
     project;
     selectedRuns;
     appBootstrapReady;
+    refreshTask.cancel();
     rawDataCache = project ? rawDataCache : new Map();
     fetchNewRuns();
   });
@@ -344,6 +345,7 @@
     );
     return () => {
       if (refreshTimer) clearInterval(refreshTimer);
+      refreshTask.cancel();
     };
   });
 


### PR DESCRIPTION
Issue #683 reports browser-tab GPU memory reaching roughly 2 GB and severe UI slowdown. The dashboard previously kept a canvas-backed Vega view mounted for every metric chart, including charts far outside the viewport. Async embeds and interval refreshes could also overlap, allowing stale rendering work and redundant requests to accumulate.

Now instead, we display the plots when they are visible to the user. Here's what it looks like for reference:


https://github.com/user-attachments/assets/babf6fe4-290b-4b49-85fc-4f9921c97538



Closes: #683