### PR TITLE
Fix OAuth token authorization for Space logging

### DIFF
--- a/.changeset/soft-ears-find.md
+++ b/.changeset/soft-ears-find.md
@@ -1,0 +1,5 @@
+---
+"trackio": minor
+---
+
+feat:Fix OAuth token authorization for Space logging

--- a/.changeset/soft-ears-find.md
+++ b/.changeset/soft-ears-find.md
@@ -1,5 +1,5 @@
 ---
-"trackio": minor
+"trackio": patch
 ---
 
 feat:Fix OAuth token authorization for Space logging

--- a/tests/unit/test_token_auth.py
+++ b/tests/unit/test_token_auth.py
@@ -2,17 +2,7 @@
 
 from unittest.mock import Mock
 
-import huggingface_hub as hf
-import pytest
-
-from trackio.server import check_hf_token_has_write_access, check_write_access
-
-
-@pytest.fixture(autouse=True)
-def clear_token_access_cache():
-    check_hf_token_has_write_access.cache_clear()
-    yield
-    check_hf_token_has_write_access.cache_clear()
+from trackio.server import check_write_access as check_write_access_runs
 
 
 def test_check_write_access():
@@ -21,72 +11,15 @@ def test_check_write_access():
     mock_request = Mock()
     mock_request.headers = {"cookie": "trackio_write_token=test_token_123; other=value"}
     mock_request.query_params = {}
-    assert check_write_access(mock_request, test_token)
+    assert check_write_access_runs(mock_request, test_token)
 
     mock_request.headers = {"cookie": "trackio_write_token=wrong_token; other=value"}
-    assert not check_write_access(mock_request, test_token)
+    assert not check_write_access_runs(mock_request, test_token)
 
     mock_request.headers = {"cookie": ""}
     mock_request.query_params = {"write_token": "test_token_123"}
-    assert check_write_access(mock_request, test_token)
+    assert check_write_access_runs(mock_request, test_token)
 
     mock_request.headers = {"cookie": ""}
     mock_request.query_params = {}
-    assert not check_write_access(mock_request, test_token)
-
-
-def test_space_secret_token_skips_hub_permission_check(monkeypatch):
-    monkeypatch.setenv("SYSTEM", "spaces")
-    monkeypatch.setenv("HF_TOKEN", "space-token")
-    auth_check = Mock()
-    monkeypatch.setattr("trackio.server.HfApi.auth_check", auth_check)
-
-    check_hf_token_has_write_access("space-token")
-
-    auth_check.assert_not_called()
-
-
-def test_refreshed_oauth_token_uses_repository_write_check(monkeypatch):
-    monkeypatch.setenv("SYSTEM", "spaces")
-    monkeypatch.setenv("HF_TOKEN", "stale-space-token")
-    monkeypatch.setenv("SPACE_AUTHOR_NAME", "user")
-    monkeypatch.setenv("SPACE_REPO_NAME", "trackio")
-    auth_check = Mock()
-    monkeypatch.setattr("trackio.server.HfApi.auth_check", auth_check)
-
-    check_hf_token_has_write_access("refreshed-oauth-token")
-
-    auth_check.assert_called_once_with(
-        "user/trackio",
-        repo_type="space",
-        token="refreshed-oauth-token",
-        write=True,
-    )
-
-
-def test_token_without_repository_write_access_is_rejected(monkeypatch):
-    monkeypatch.setenv("SYSTEM", "spaces")
-    monkeypatch.setenv("HF_TOKEN", "space-token")
-    monkeypatch.setenv("SPACE_AUTHOR_NAME", "user")
-    monkeypatch.setenv("SPACE_REPO_NAME", "trackio")
-    auth_check = Mock(
-        side_effect=hf.errors.HfHubHTTPError("denied", response=Mock(status_code=403))
-    )
-    monkeypatch.setattr("trackio.server.HfApi.auth_check", auth_check)
-
-    with pytest.raises(PermissionError, match="provide write access"):
-        check_hf_token_has_write_access("read-only-token")
-
-
-def test_hub_permission_check_outage_is_not_reported_as_denied(monkeypatch):
-    monkeypatch.setenv("SYSTEM", "spaces")
-    monkeypatch.setenv("HF_TOKEN", "space-token")
-    monkeypatch.setenv("SPACE_AUTHOR_NAME", "user")
-    monkeypatch.setenv("SPACE_REPO_NAME", "trackio")
-    error = hf.errors.HfHubHTTPError("unavailable", response=Mock(status_code=503))
-    monkeypatch.setattr("trackio.server.HfApi.auth_check", Mock(side_effect=error))
-
-    with pytest.raises(hf.errors.HfHubHTTPError) as exc_info:
-        check_hf_token_has_write_access("oauth-token")
-
-    assert exc_info.value is error
+    assert not check_write_access_runs(mock_request, test_token)

--- a/tests/unit/test_token_auth.py
+++ b/tests/unit/test_token_auth.py
@@ -2,7 +2,17 @@
 
 from unittest.mock import Mock
 
-from trackio.server import check_write_access as check_write_access_runs
+import huggingface_hub as hf
+import pytest
+
+from trackio.server import check_hf_token_has_write_access, check_write_access
+
+
+@pytest.fixture(autouse=True)
+def clear_token_access_cache():
+    check_hf_token_has_write_access.cache_clear()
+    yield
+    check_hf_token_has_write_access.cache_clear()
 
 
 def test_check_write_access():
@@ -11,15 +21,72 @@ def test_check_write_access():
     mock_request = Mock()
     mock_request.headers = {"cookie": "trackio_write_token=test_token_123; other=value"}
     mock_request.query_params = {}
-    assert check_write_access_runs(mock_request, test_token)
+    assert check_write_access(mock_request, test_token)
 
     mock_request.headers = {"cookie": "trackio_write_token=wrong_token; other=value"}
-    assert not check_write_access_runs(mock_request, test_token)
+    assert not check_write_access(mock_request, test_token)
 
     mock_request.headers = {"cookie": ""}
     mock_request.query_params = {"write_token": "test_token_123"}
-    assert check_write_access_runs(mock_request, test_token)
+    assert check_write_access(mock_request, test_token)
 
     mock_request.headers = {"cookie": ""}
     mock_request.query_params = {}
-    assert not check_write_access_runs(mock_request, test_token)
+    assert not check_write_access(mock_request, test_token)
+
+
+def test_space_secret_token_skips_hub_permission_check(monkeypatch):
+    monkeypatch.setenv("SYSTEM", "spaces")
+    monkeypatch.setenv("HF_TOKEN", "space-token")
+    auth_check = Mock()
+    monkeypatch.setattr("trackio.server.HfApi.auth_check", auth_check)
+
+    check_hf_token_has_write_access("space-token")
+
+    auth_check.assert_not_called()
+
+
+def test_refreshed_oauth_token_uses_repository_write_check(monkeypatch):
+    monkeypatch.setenv("SYSTEM", "spaces")
+    monkeypatch.setenv("HF_TOKEN", "stale-space-token")
+    monkeypatch.setenv("SPACE_AUTHOR_NAME", "user")
+    monkeypatch.setenv("SPACE_REPO_NAME", "trackio")
+    auth_check = Mock()
+    monkeypatch.setattr("trackio.server.HfApi.auth_check", auth_check)
+
+    check_hf_token_has_write_access("refreshed-oauth-token")
+
+    auth_check.assert_called_once_with(
+        "user/trackio",
+        repo_type="space",
+        token="refreshed-oauth-token",
+        write=True,
+    )
+
+
+def test_token_without_repository_write_access_is_rejected(monkeypatch):
+    monkeypatch.setenv("SYSTEM", "spaces")
+    monkeypatch.setenv("HF_TOKEN", "space-token")
+    monkeypatch.setenv("SPACE_AUTHOR_NAME", "user")
+    monkeypatch.setenv("SPACE_REPO_NAME", "trackio")
+    auth_check = Mock(
+        side_effect=hf.errors.HfHubHTTPError("denied", response=Mock(status_code=403))
+    )
+    monkeypatch.setattr("trackio.server.HfApi.auth_check", auth_check)
+
+    with pytest.raises(PermissionError, match="provide write access"):
+        check_hf_token_has_write_access("read-only-token")
+
+
+def test_hub_permission_check_outage_is_not_reported_as_denied(monkeypatch):
+    monkeypatch.setenv("SYSTEM", "spaces")
+    monkeypatch.setenv("HF_TOKEN", "space-token")
+    monkeypatch.setenv("SPACE_AUTHOR_NAME", "user")
+    monkeypatch.setenv("SPACE_REPO_NAME", "trackio")
+    error = hf.errors.HfHubHTTPError("unavailable", response=Mock(status_code=503))
+    monkeypatch.setattr("trackio.server.HfApi.auth_check", Mock(side_effect=error))
+
+    with pytest.raises(hf.errors.HfHubHTTPError) as exc_info:
+        check_hf_token_has_write_access("oauth-token")
+
+    assert exc_info.value is error

--- a/trackio/server.py
+++ b/trackio/server.py
@@ -372,9 +372,7 @@ def check_hf_token_has_write_access(hf_token: str | None) -> None:
     Checks if the provided hf_token has write access to the space. If it does not
     have write access, a PermissionError is raised. Otherwise, the function returns None.
 
-    The function is cached in two separate caches to avoid unnecessary API calls to /whoami-v2 which is heavily rate-limited:
-    - A cache of the whoami response for the hf_token using .whoami(token=hf_token, cache=True).
-    - This entire function is cached using @lru_cache(maxsize=32).
+    The result is cached to avoid repeated Hub permission checks for the same token.
     """
     if on_spaces():
         if hf_token is None:
@@ -383,46 +381,23 @@ def check_hf_token_has_write_access(hf_token: str | None) -> None:
             )
         space_token = os.getenv("HF_TOKEN")
         if space_token and hf_token == space_token:
-            # If the HF_TOKEN is the same as the space token, we can assume that the user has write access.
-            # This avoids unnecessary API calls to /whoami-v2 which is heavily rate-limited.
             return
-        who = HfApi.whoami(token=hf_token, cache=True)
         owner_name = os.getenv("SPACE_AUTHOR_NAME")
         repo_name = os.getenv("SPACE_REPO_NAME")
-        orgs = [o["name"] for o in who["orgs"]]
-        if owner_name != who["name"] and owner_name not in orgs:
-            raise PermissionError(
-                "Expected the provided hf_token to be the user owner of the space, or be a member of the org owner of the space"
+        try:
+            HfApi.auth_check(
+                f"{owner_name}/{repo_name}",
+                repo_type="space",
+                token=hf_token,
+                write=True,
             )
-        access_token = who["auth"]["accessToken"]
-        if access_token["role"] == "fineGrained":
-            matched = False
-            for item in access_token["fineGrained"]["scoped"]:
-                if (
-                    item["entity"]["type"] == "space"
-                    and item["entity"]["name"] == f"{owner_name}/{repo_name}"
-                    and "repo.write" in item["permissions"]
-                ):
-                    matched = True
-                    break
-                if (
-                    (
-                        item["entity"]["type"] == "user"
-                        or item["entity"]["type"] == "org"
-                    )
-                    and item["entity"]["name"] == owner_name
-                    and "repo.write" in item["permissions"]
-                ):
-                    matched = True
-                    break
-            if not matched:
-                raise PermissionError(
-                    "Expected the provided hf_token with fine grained permissions to provide write access to the space"
-                )
-        elif access_token["role"] != "write":
+        except hf.errors.HfHubHTTPError as e:
+            status_code = e.response.status_code if e.response is not None else None
+            if status_code not in (401, 403, 404):
+                raise
             raise PermissionError(
-                "Expected the provided hf_token to provide write permissions"
-            )
+                "Expected the provided hf_token to provide write access to the space"
+            ) from e
 
 
 _oauth_write_cache: dict[str, tuple[bool, float]] = {}

--- a/trackio/server.py
+++ b/trackio/server.py
@@ -366,7 +366,7 @@ def oauth_logout(request: Request):
     return resp
 
 
-@lru_cache(maxsize=32)
+@lru_cache(maxsize=256)
 def check_hf_token_has_write_access(hf_token: str | None) -> None:
     """
     Checks if the provided hf_token has write access to the space. If it does not


### PR DESCRIPTION
## Summary

- use the Hub repository write-check endpoint instead of parsing `whoami()["auth"]["accessToken"]`
- support refreshed OAuth credentials while preserving the Space-secret fast path
- keep authorization failures distinct from transient Hub errors
- cache authorization results for up to 256 distinct tokens
- keep the existing `huggingface-hub>=1.10.0,<2` constraint because `HfApi.auth_check(..., write=True)` is available in 1.10.0

## Reproduction

Before this change, a valid OAuth-shaped `whoami` response without `auth.accessToken` crashes the Space write check:

```python
whoami = {"name": "user", "orgs": [], "auth": {}}
check_hf_token_has_write_access("refreshed-oauth-token")
# KeyError: 'accessToken'
```

The fix asks the Hub whether the token has write access to the exact Space, avoiding assumptions about token metadata.

## Verification

```text
pytest tests/unit/test_token_auth.py tests/unit/test_gradio_api_spaces.py tests/unit/test_artifact_server.py tests/unit/test_frontend_server.py -q
24 passed

ruff check --select I trackio/server.py tests/unit/test_token_auth.py
ruff format --check trackio/server.py tests/unit/test_token_auth.py
git diff --check
```

The reproduction was run inline; no demo file was committed.
